### PR TITLE
마인드맵 UI 개발

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "react-router": "^7.2.0",
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.9",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -2887,6 +2888,34 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
+      "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
@@ -6182,20 +6211,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
-      "integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6205,6 +6232,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
     "react-router": "^7.2.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.9",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/store/mindmapStore';
 import MindMapEdge from '@/components/reactFlow/edges';
 import SummaryNode from '@/components/reactFlow/nodes/ui/SummaryNode';
-import RootNode from '@/components/reactFlow/nodes/rootNode';
+import RootNode from '@/components/reactFlow/nodes/ui/RootNode';
 import AnswerInputNode from '@/components/reactFlow/nodes/ui/AnswerInputNode';
 import QuestionListNode from '@/components/reactFlow/nodes/ui/QuestionListNode';
 

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -15,10 +15,10 @@ import { useCallback, useRef } from 'react';
 import {
   useNodes,
   useEdges,
-  useNodesChange,
   useEdgesChange,
   useAddChildNode,
-} from '@/store/mindmapStore';
+  useNodesChange,
+} from '@/store/mindMapStore';
 import MindMapEdge from '@/components/reactFlow/edges';
 import SummaryNode from '@/components/reactFlow/nodes/ui/SummaryNode';
 import RootNode from '@/components/reactFlow/nodes/ui/RootNode';

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -1,13 +1,124 @@
-import { ReactFlow } from '@xyflow/react';
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  ConnectionLineType,
+  useReactFlow,
+  Controls,
+  OnConnectStart,
+  OnConnectEnd,
+  NodeOrigin,
+} from '@xyflow/react';
 
 import '@xyflow/react/dist/style.css';
-import { initialNodes } from '@/components/reactFlow/nodes';
-import { initialEdges } from '@/components/reactFlow/edges';
+import { useCallback, useRef } from 'react';
+
+import {
+  useNodes,
+  useEdges,
+  useNodesChange,
+  useEdgesChange,
+  useAddChildNode,
+} from '@/store/mindmapStore';
+import MindMapEdge from '@/components/reactFlow/edges';
+import SummaryNode from '@/components/reactFlow/nodes/ui/SummaryNode';
+import RootNode from '@/components/reactFlow/nodes/rootNode';
+import AnswerInputNode from '@/components/reactFlow/nodes/ui/AnswerInputNode';
+import QuestionListNode from '@/components/reactFlow/nodes/ui/QuestionListNode';
+
+const nodeTypes = {
+  root: RootNode,
+  summary: SummaryNode,
+  answer: AnswerInputNode,
+  question: QuestionListNode,
+};
+
+const edgeTypes = {
+  mindmapEdge: MindMapEdge,
+};
+
+const nodeOrigin: NodeOrigin = [0.5, 0.5];
+
+function FlowContent() {
+  const nodes = useNodes();
+  const edges = useEdges();
+  const onNodesChange = useNodesChange();
+  const onEdgesChange = useEdgesChange();
+  const addChildNode = useAddChildNode();
+
+  const { screenToFlowPosition } = useReactFlow();
+  const connectingNodeId = useRef<string | null>(null);
+
+  const getChildNodePosition = useCallback(
+    (event: MouseEvent) => {
+      const rect = (event.target as Element)
+        .closest('.react-flow')
+        ?.getBoundingClientRect();
+
+      if (!rect) return;
+
+      return screenToFlowPosition({
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      });
+    },
+    [screenToFlowPosition],
+  );
+
+  const onConnectStart: OnConnectStart = useCallback((_, { nodeId }) => {
+    connectingNodeId.current = nodeId;
+  }, []);
+
+  const onConnectEnd: OnConnectEnd = useCallback(
+    (event) => {
+      const targetIsPane = (event.target as Element).classList.contains(
+        'react-flow__pane',
+      );
+
+      if (!targetIsPane) {
+        return;
+      }
+
+      const childNodePosition = getChildNodePosition(event as MouseEvent);
+
+      if (childNodePosition && connectingNodeId.current) {
+        const parentNode = nodes.find(
+          (node) => node.id === connectingNodeId.current,
+        );
+        if (parentNode) {
+          addChildNode(parentNode, childNodePosition);
+        }
+      }
+    },
+    [nodes, getChildNodePosition, addChildNode],
+  );
+
+  return (
+    <div className="w-full h-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnectStart={onConnectStart}
+        onConnectEnd={onConnectEnd}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        nodeOrigin={nodeOrigin}
+        connectionLineType={ConnectionLineType.Straight}
+        fitView
+      >
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}
 
 function FlowWrapper() {
   return (
-    <div className="w-full h-full">
-      <ReactFlow nodes={initialNodes} edges={initialEdges} fitView></ReactFlow>
+    <div className="h-screen">
+      <ReactFlowProvider>
+        <FlowContent />
+      </ReactFlowProvider>
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/edges/index.ts
+++ b/frontend/src/components/reactFlow/edges/index.ts
@@ -1,1 +1,0 @@
-export const initialEdges = [{ id: 'e1-2', source: '1', target: '2' }];

--- a/frontend/src/components/reactFlow/edges/index.tsx
+++ b/frontend/src/components/reactFlow/edges/index.tsx
@@ -1,14 +1,21 @@
-import { BaseEdge, EdgeProps, getSimpleBezierPath } from '@xyflow/react';
+import {
+  BaseEdge,
+  getSimpleBezierPath,
+  type EdgeProps,
+  type Edge,
+} from '@xyflow/react';
+
+type MindMapEdgeType = Edge<Record<string, never>, 'mindmapEdge'>;
 
 function MindMapEdge({
+  id,
   sourceX,
   sourceY,
   targetX,
   targetY,
   sourcePosition,
   targetPosition,
-  ...props
-}: EdgeProps) {
+}: EdgeProps<MindMapEdgeType>) {
   const [edgePath] = getSimpleBezierPath({
     sourceX,
     sourceY: sourceY + 36,
@@ -18,7 +25,7 @@ function MindMapEdge({
     targetPosition,
   });
 
-  return <BaseEdge path={edgePath} {...props} />;
+  return <BaseEdge id={id} path={edgePath} />;
 }
 
 export default MindMapEdge;

--- a/frontend/src/components/reactFlow/edges/index.tsx
+++ b/frontend/src/components/reactFlow/edges/index.tsx
@@ -1,0 +1,24 @@
+import { BaseEdge, EdgeProps, getSimpleBezierPath } from '@xyflow/react';
+
+function MindMapEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  ...props
+}: EdgeProps) {
+  const [edgePath] = getSimpleBezierPath({
+    sourceX,
+    sourceY: sourceY + 18,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return <BaseEdge path={edgePath} {...props} />;
+}
+
+export default MindMapEdge;

--- a/frontend/src/components/reactFlow/edges/index.tsx
+++ b/frontend/src/components/reactFlow/edges/index.tsx
@@ -11,9 +11,9 @@ function MindMapEdge({
 }: EdgeProps) {
   const [edgePath] = getSimpleBezierPath({
     sourceX,
-    sourceY: sourceY + 18,
+    sourceY: sourceY + 36,
     targetX,
-    targetY,
+    targetY: targetY + 36,
     sourcePosition,
     targetPosition,
   });

--- a/frontend/src/components/reactFlow/nodes/index.ts
+++ b/frontend/src/components/reactFlow/nodes/index.ts
@@ -1,4 +1,0 @@
-export const initialNodes = [
-  { id: '1', position: { x: 0, y: 0 }, data: { label: '1' } },
-  { id: '2', position: { x: 0, y: 100 }, data: { label: '2' } },
-];

--- a/frontend/src/components/reactFlow/nodes/rootNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/rootNode.tsx
@@ -1,25 +1,52 @@
-import { MindMapNode as MindMapNodeType } from '@/types/mindMap';
 import { Handle, NodeProps, Position } from '@xyflow/react';
 import { ListCheck } from 'lucide-react';
+import DragIcon from '@/components/reactFlow/nodes/ui/DragIcon';
+import { MindMapNodeData } from '@/types/mindMap';
 
-export default function rootNode({ data }: NodeProps<MindMapNodeType>) {
+export default function RootNode({
+  data,
+  selected,
+}: NodeProps<MindMapNodeData>) {
   return (
-    <div className="w-[267px] h-[146px] border border-black flex flex-col justify-center items-center rounded-lg relative">
+    <div
+      className={`w-[267px] h-[146px] border border-black bg-white flex flex-col justify-center items-center rounded-lg relative group ${
+        selected ? 'selected' : ''
+      }`}
+    >
+      <div className="dragHandle absolute top-2 left-2 z-20 cursor-grab opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+        <DragIcon />
+      </div>
+
       <div className="z-10 absolute -top-[25px] left-1/2 transform -translate-x-1/2 w-[50px] h-[50px] bg-root-icon rounded-full border border-black flex items-center justify-center">
         <span className="text-lg">✅</span>
       </div>
 
       <ListCheck size={25} color="#D8D8D8" className="absolute top-4 right-4" />
-      {/* <ListRestart
-        size={25}
-        color="#FF696C"
-        className="absolute top-4 right-4"
-      /> */}
 
       <p className="text-[30px] font-semibold">{data.label}</p>
 
-      <Handle type="target" position={Position.Top} />
-      <Handle type="source" position={Position.Bottom} />
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="target"
+        style={{ opacity: 0, pointerEvents: 'none' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Top}
+        className="source"
+        style={{
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          background: 'transparent',
+          border: 'none',
+          borderRadius: 0,
+          transform: 'none',
+          zIndex: 10,
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/nodes/rootNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/rootNode.tsx
@@ -1,0 +1,25 @@
+import { MindMapNode as MindMapNodeType } from '@/types/mindMap';
+import { Handle, NodeProps, Position } from '@xyflow/react';
+import { ListCheck } from 'lucide-react';
+
+export default function rootNode({ data }: NodeProps<MindMapNodeType>) {
+  return (
+    <div className="w-[267px] h-[146px] border border-black flex flex-col justify-center items-center rounded-lg relative">
+      <div className="z-10 absolute -top-[25px] left-1/2 transform -translate-x-1/2 w-[50px] h-[50px] bg-root-icon rounded-full border border-black flex items-center justify-center">
+        <span className="text-lg">✅</span>
+      </div>
+
+      <ListCheck size={25} color="#D8D8D8" className="absolute top-4 right-4" />
+      {/* <ListRestart
+        size={25}
+        color="#FF696C"
+        className="absolute top-4 right-4"
+      /> */}
+
+      <p className="text-[30px] font-semibold">{data.label}</p>
+
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -1,16 +1,16 @@
 import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/Input';
-import useStore from '@/store/mindmapStore';
-import { MindMapNodeData } from '@/types/mindMap';
+import useStore from '@/store/mindMapStore';
+import { AnswerNodeType } from '@/types/mindMap';
 import { NodeProps } from '@xyflow/react';
 import { Loader2 } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ChangeEvent } from 'react';
 
 export default function AnswerInputNode({
   id,
   data,
-}: NodeProps<MindMapNodeData>) {
+}: NodeProps<AnswerNodeType>) {
   const initialAnswer = data.answer || '';
 
   const [answer, setAnswer] = useState(initialAnswer);
@@ -26,7 +26,7 @@ export default function AnswerInputNode({
     setIsInputFilled(answer.trim() !== '');
   }, [answer]);
 
-  const handleInputChange = (e) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
   };
 

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -1,8 +1,9 @@
+import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/Input';
 import useStore from '@/store/mindmapStore';
 import { MindMapNodeData } from '@/types/mindMap';
-import { Handle, NodeProps, Position } from '@xyflow/react';
+import { NodeProps } from '@xyflow/react';
 import { Loader2 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
@@ -61,7 +62,7 @@ export default function AnswerInputNode({
   };
 
   return (
-    <div className="px-8 py-[30px] border-4 border-[#b3cbfa] rounded-lg">
+    <div className="w-[538px] bg-white px-8 py-[30px] border-4 border-[#b3cbfa] rounded-lg">
       <p className="text-[20px] font-semibold mb-[26px]">{data.label}</p>
 
       <div className="mb-6">
@@ -91,8 +92,7 @@ export default function AnswerInputNode({
         </Button>
       </div>
 
-      <Handle type="target" position={Position.Top} />
-      <Handle type="source" position={Position.Top} />
+      <NodeHandles />
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -1,0 +1,75 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/Input';
+import { Loader2 } from 'lucide-react';
+import { useState, useEffect } from 'react';
+
+interface AnswerInputProps {
+  title: string;
+  initialAnswer?: string;
+  onSubmit: (answer: string) => void;
+  onCancel?: () => void;
+}
+
+export default function AnswerInputNode({
+  title,
+  initialAnswer = '',
+  onSubmit,
+}: AnswerInputProps) {
+  const [answer, setAnswer] = useState(initialAnswer);
+  const [isInputFilled, setIsInputFilled] = useState(
+    initialAnswer.trim() !== '',
+  );
+  const [isSubmitLoading, setIsSubmitLoading] = useState(false);
+
+  useEffect(() => {
+    setIsInputFilled(answer.trim() !== '');
+  }, [answer]);
+
+  const handleInputChange = (e) => {
+    setAnswer(e.target.value);
+  };
+
+  const handleSubmit = async () => {
+    if (isInputFilled) {
+      setIsSubmitLoading(true);
+      try {
+        await onSubmit(answer);
+      } finally {
+        setIsSubmitLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="px-8 py-[30px] border-4 border-[#b3cbfa] rounded-lg">
+      <p className="text-[20px] font-semibold mb-[26px]">{title}</p>
+
+      <div className="mb-6">
+        <Input
+          placeholder="답변을 적어주세요"
+          className="h-[48px]"
+          value={answer}
+          onChange={handleInputChange}
+        />
+      </div>
+
+      <div className="flex justify-end space-x-3">
+        <Button
+          variant={isInputFilled ? 'black' : 'disabled'}
+          onClick={handleSubmit}
+          className="w-[180px] h-12"
+          disabled={!isInputFilled || isSubmitLoading}
+        >
+          {isSubmitLoading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              생성 중...
+            </>
+          ) : (
+            '입력하기'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -1,25 +1,25 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/Input';
+import useStore from '@/store/mindmapStore';
+import { MindMapNodeData } from '@/types/mindMap';
+import { Handle, NodeProps, Position } from '@xyflow/react';
 import { Loader2 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
-interface AnswerInputProps {
-  title: string;
-  initialAnswer?: string;
-  onSubmit: (answer: string) => void;
-  onCancel?: () => void;
-}
-
 export default function AnswerInputNode({
-  title,
-  initialAnswer = '',
-  onSubmit,
-}: AnswerInputProps) {
+  id,
+  data,
+}: NodeProps<MindMapNodeData>) {
+  const initialAnswer = data.answer || '';
+
   const [answer, setAnswer] = useState(initialAnswer);
   const [isInputFilled, setIsInputFilled] = useState(
     initialAnswer.trim() !== '',
   );
   const [isSubmitLoading, setIsSubmitLoading] = useState(false);
+
+  const setNode = useStore((state) => state.setNode);
+  const nodes = useStore((state) => state.nodes);
 
   useEffect(() => {
     setIsInputFilled(answer.trim() !== '');
@@ -31,18 +31,38 @@ export default function AnswerInputNode({
 
   const handleSubmit = async () => {
     if (isInputFilled) {
-      setIsSubmitLoading(true);
-      try {
-        await onSubmit(answer);
-      } finally {
-        setIsSubmitLoading(false);
+      setIsSubmitLoading(false);
+
+      const currentNode = nodes.find((node) => node.id === id);
+
+      /* 
+      TODO: 추후에 GPT 한줄 요약으로 수정해야함. 지금은 로직의 흐름을 위해 답변을 summary로 처리
+      */
+      if (currentNode) {
+        setNode(id, {
+          ...currentNode,
+          type: 'summary',
+          data: {
+            ...currentNode.data,
+            summary: answer,
+          },
+        });
       }
+
+      /* TODO: 추후에 API 연동시 처리하기! */
+      // setIsSubmitLoading(true);
+
+      // try {
+      //   await onSubmit(answer);
+      // } finally {
+      //   setIsSubmitLoading(false);
+      // }
     }
   };
 
   return (
     <div className="px-8 py-[30px] border-4 border-[#b3cbfa] rounded-lg">
-      <p className="text-[20px] font-semibold mb-[26px]">{title}</p>
+      <p className="text-[20px] font-semibold mb-[26px]">{data.label}</p>
 
       <div className="mb-6">
         <Input
@@ -70,6 +90,9 @@ export default function AnswerInputNode({
           )}
         </Button>
       </div>
+
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Top} />
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/nodes/ui/DragIcon.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/DragIcon.tsx
@@ -1,0 +1,16 @@
+export default function DragIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 3H9V5H7V3ZM7 7H9V9H7V7ZM7 11H9V13H7V11ZM3 3H5V5H3V3ZM3 7H5V9H3V7ZM3 11H5V13H3V11ZM11 3H13V5H11V3ZM11 7H13V9H11V7ZM11 11H13V13H11V11Z"
+        fill="#999999"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/reactFlow/nodes/ui/NodeHandles.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/NodeHandles.tsx
@@ -1,0 +1,38 @@
+import { Handle, Position } from '@xyflow/react';
+
+const SimpleHandles = () => (
+  <>
+    <Handle type="target" position={Position.Top} className="opacity-0" />
+    <Handle type="source" position={Position.Top} className="opacity-0" />
+  </>
+);
+
+const FullNodeHandles = () => (
+  <>
+    <Handle type="target" position={Position.Top} className="opacity-0" />
+    <Handle
+      type="source"
+      position={Position.Top}
+      className="opacity-0"
+      style={{
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        background: 'transparent',
+        border: 'none',
+        borderRadius: 0,
+        transform: 'none',
+        zIndex: 10,
+      }}
+    />
+  </>
+);
+
+type NodeHandlesProps = {
+  type?: 'simple' | 'full';
+};
+
+export default function NodeHandles({ type = 'simple' }: NodeHandlesProps) {
+  return <>{type === 'simple' ? <SimpleHandles /> : <FullNodeHandles />}</>;
+}

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -1,6 +1,7 @@
+import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 import useStore from '@/store/mindmapStore';
 import { MindMapNodeData } from '@/types/mindMap';
-import { Handle, NodeProps, Position } from '@xyflow/react';
+import { NodeProps } from '@xyflow/react';
 import { X } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
@@ -133,8 +134,7 @@ export default function QuestionListNode({
           </li>
         </ul>
 
-        <Handle type="target" position={Position.Top} />
-        <Handle type="source" position={Position.Top} />
+        <NodeHandles />
       </div>
     </>
   );

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -1,6 +1,6 @@
 import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
-import useStore from '@/store/mindmapStore';
-import { MindMapNodeData } from '@/types/mindMap';
+import useStore from '@/store/mindMapStore';
+import { QuestionNodeType } from '@/types/mindMap';
 import { NodeProps } from '@xyflow/react';
 import { X } from 'lucide-react';
 import { useState, useEffect } from 'react';
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react';
 export default function QuestionListNode({
   id,
   data,
-}: NodeProps<MindMapNodeData>) {
+}: NodeProps<QuestionNodeType>) {
   const questions = data.recommendedQuestions;
   const [displayedQuestions, setDisplayedQuestions] = useState<
     Array<{
@@ -38,7 +38,7 @@ export default function QuestionListNode({
   };
 
   useEffect(() => {
-    if (questions.length > 0) {
+    if (questions && questions.length > 0) {
       const initial = questions.slice(0, 3).map((text, index) => ({
         id: index,
         text,

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -1,0 +1,115 @@
+import AnswerInputNode from '@/components/reactFlow/nodes/ui/AnswerInputNode';
+import { X } from 'lucide-react';
+import { useState, useEffect } from 'react';
+
+type QuestionListNodeProps = {
+  questions: string[];
+};
+
+export default function QuestionListNode({ questions }: QuestionListNodeProps) {
+  const [displayedQuestions, setDisplayedQuestions] = useState<
+    Array<{
+      id: number;
+      text: string;
+      animating: boolean;
+    }>
+  >([]);
+  const [questionQueue, setQuestionQueue] = useState<string[]>([]);
+  const [isDirectInputMode, setIsDirectInputMode] = useState(false);
+
+  useEffect(() => {
+    if (questions.length > 0) {
+      const initial = questions.slice(0, 3).map((text, index) => ({
+        id: index,
+        text,
+        animating: false,
+      }));
+      setDisplayedQuestions(initial);
+      setQuestionQueue(questions.slice(3));
+    }
+  }, [questions]);
+
+  const handleRemoveQuestion = (id: number) => {
+    setDisplayedQuestions((prev) =>
+      prev.map((q) => (q.id === id ? { ...q, animating: true } : q)),
+    );
+
+    setTimeout(() => {
+      setDisplayedQuestions((prev) => {
+        const updatedQuestions = [...prev];
+        const questionIndex = updatedQuestions.findIndex((q) => q.id === id);
+
+        if (questionIndex !== -1) {
+          const nextQuestion = questionQueue[0];
+
+          const newQueue = [
+            ...questionQueue.slice(1),
+            updatedQuestions[questionIndex].text,
+          ];
+          setQuestionQueue(newQueue);
+
+          updatedQuestions[questionIndex] = {
+            ...updatedQuestions[questionIndex],
+            text: nextQuestion,
+            animating: false,
+          };
+        }
+
+        return updatedQuestions;
+      });
+    }, 300);
+  };
+
+  const activateDirectInputMode = () => {
+    setIsDirectInputMode(true);
+  };
+
+  const handleSubmitDirectAnswer = async () => {
+    setIsDirectInputMode(false);
+  };
+
+  return (
+    <>
+      {isDirectInputMode ? (
+        <AnswerInputNode
+          title="질문을 직접 입력해주세요"
+          initialAnswer=""
+          onSubmit={handleSubmitDirectAnswer}
+        />
+      ) : (
+        <div className="px-8 py-[30px] border border-border-gray rounded-lg">
+          <h3 className="text-[20px] font-semibold mb-5">
+            다음 질문을 선택해주세요
+          </h3>
+          <ul className="flex flex-col gap-[10px]">
+            {displayedQuestions.map((question) => (
+              <li
+                key={question.id}
+                className={`p-4 border border-border-gray rounded-lg flex justify-between items-center transition-all duration-300 hover:bg-question-input-hover active:bg-question-input-active ${
+                  question.animating
+                    ? 'opacity-0 transform -translate-x-2'
+                    : 'opacity-100'
+                }`}
+              >
+                <span>{question.text}</span>
+                <button
+                  onClick={() => handleRemoveQuestion(question.id)}
+                  className="cursor-pointer"
+                  disabled={question.animating}
+                >
+                  <X size={24} color="#B9B9B7" />
+                </button>
+              </li>
+            ))}
+            <li
+              onClick={activateDirectInputMode}
+              className="p-4 border border-border-gray rounded-lg flex justify-between items-center"
+            >
+              <span>직접 입력하기</span>
+            </li>
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -98,7 +98,7 @@ export default function QuestionListNode({
 
   return (
     <>
-      <div className="px-8 py-[30px] border border-border-gray rounded-lg">
+      <div className="bg-white px-8 py-[30px] border border-border-gray rounded-lg">
         <h3 className="text-[20px] font-semibold mb-5">
           다음 질문을 선택해주세요
         </h3>

--- a/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
@@ -1,7 +1,8 @@
-import { Handle, NodeProps, Position } from '@xyflow/react';
+import { NodeProps } from '@xyflow/react';
 import { ListCheck } from 'lucide-react';
 import DragIcon from '@/components/reactFlow/nodes/ui/DragIcon';
 import { MindMapNodeData } from '@/types/mindMap';
+import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 
 export default function RootNode({
   data,
@@ -25,28 +26,7 @@ export default function RootNode({
 
       <p className="text-[30px] font-semibold">{data.label}</p>
 
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="target"
-        style={{ opacity: 0, pointerEvents: 'none' }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        className="source"
-        style={{
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          background: 'transparent',
-          border: 'none',
-          borderRadius: 0,
-          transform: 'none',
-          zIndex: 10,
-        }}
-      />
+      <NodeHandles type="full" />
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
@@ -1,13 +1,10 @@
 import { NodeProps } from '@xyflow/react';
 import { ListCheck } from 'lucide-react';
 import DragIcon from '@/components/reactFlow/nodes/ui/DragIcon';
-import { MindMapNodeData } from '@/types/mindMap';
+import { RootNodeType } from '@/types/mindMap';
 import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 
-export default function RootNode({
-  data,
-  selected,
-}: NodeProps<MindMapNodeData>) {
+export default function RootNode({ data, selected }: NodeProps<RootNodeType>) {
   return (
     <div
       className={`w-[267px] h-[146px] border border-black bg-white flex flex-col justify-center items-center rounded-lg relative group ${

--- a/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
@@ -1,0 +1,62 @@
+import useStore from '@/store/mindmapStore';
+import { MindMapNodeData } from '@/types/mindMap';
+import { Handle, NodeProps, Position } from '@xyflow/react';
+import { Pencil, X } from 'lucide-react';
+
+export default function SummaryNode({ id, data }: NodeProps<MindMapNodeData>) {
+  const setNode = useStore((state) => state.setNode);
+  const nodes = useStore((state) => state.nodes);
+
+  const handleEditClick = () => {
+    const currentNode = nodes.find((node) => node.id === id);
+
+    if (currentNode) {
+      setNode(id, {
+        ...currentNode,
+        type: 'answer',
+      });
+    }
+  };
+
+  return (
+    <div className="w-[538px] px-8 py-[30px] flex items-center border-1 border-[#b3cbfa] bg-white rounded-lg relative z-100 group">
+      <div className="flex-1">
+        <p className="text-[20px] font-semibold">{data.summary}</p>
+      </div>
+      {/* <div className="dragHandle z-20">
+        <DragIcon />
+      </div> */}
+      <div className="opacity-0 group-hover:opacity-100 flex items-center gap-8 transition-opacity duration-300 ease-in-out">
+        <Pencil
+          size={20}
+          color="#B9B9B7"
+          className="cursor-pointer hover:text-black transition-colors z-20"
+          onClick={handleEditClick}
+        />
+
+        <X
+          size={20}
+          color="#B9B9B7"
+          className="cursor-pointer hover:text-black transition-colors"
+        />
+      </div>
+      <Handle type="target" position={Position.Top} />
+      <Handle
+        type="source"
+        position={Position.Top}
+        className="source"
+        style={{
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          background: 'transparent',
+          border: 'none',
+          borderRadius: 0,
+          transform: 'none',
+          zIndex: 10,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
@@ -1,6 +1,7 @@
+import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 import useStore from '@/store/mindmapStore';
 import { MindMapNodeData } from '@/types/mindMap';
-import { Handle, NodeProps, Position } from '@xyflow/react';
+import { NodeProps } from '@xyflow/react';
 import { Pencil, X } from 'lucide-react';
 
 export default function SummaryNode({ id, data }: NodeProps<MindMapNodeData>) {
@@ -40,23 +41,7 @@ export default function SummaryNode({ id, data }: NodeProps<MindMapNodeData>) {
           className="cursor-pointer hover:text-black transition-colors"
         />
       </div>
-      <Handle type="target" position={Position.Top} />
-      <Handle
-        type="source"
-        position={Position.Top}
-        className="source"
-        style={{
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          background: 'transparent',
-          border: 'none',
-          borderRadius: 0,
-          transform: 'none',
-          zIndex: 10,
-        }}
-      />
+      <NodeHandles type="full" />
     </div>
   );
 }

--- a/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
@@ -1,10 +1,10 @@
 import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
-import useStore from '@/store/mindmapStore';
-import { MindMapNodeData } from '@/types/mindMap';
+import useStore from '@/store/mindMapStore';
+import { SummaryNodeType } from '@/types/mindMap';
 import { NodeProps } from '@xyflow/react';
 import { Pencil, X } from 'lucide-react';
 
-export default function SummaryNode({ id, data }: NodeProps<MindMapNodeData>) {
+export default function SummaryNode({ id, data }: NodeProps<SummaryNodeType>) {
   const setNode = useStore((state) => state.setNode);
   const nodes = useStore((state) => state.nodes);
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         black: 'bg-black text-white hover:bg-black/90',
         white: 'bg-white text-black border hover:bg-gray-100',
         primary: 'bg-button-primary text-white hover:bg-button-primary/90',
-        disabled: 'bg-button-disabled text-gray-500 hover:bg-button-disabled',
+        disabled: 'bg-button-disabled text-white hover:bg-button-disabled',
 
         /* shadcn/ui 기본 variants */
         destructive:

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -11,19 +11,18 @@ import {
 } from '@xyflow/react';
 import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
-import { shallow } from 'zustand/shallow';
-import { MindMapNodeData } from '@/types/mindMap';
+import { MindMapNode, MindMapNodeData } from '@/types/mindMap';
 
 export type RFState = {
-  nodes: Node<MindMapNodeData>[];
+  nodes: MindMapNode[];
   edges: Edge[];
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   addChildNode: (parentNode: Node, position: XYPosition) => void;
-  setNode: (nodeId: string, node: Node<MindMapNodeData>) => void;
+  setNode: (nodeId: string, node: MindMapNode) => void;
 };
 
-const initialNodes: Node<MindMapNodeData>[] = [
+const initialNodes: MindMapNode[] = [
   {
     id: '1',
     type: 'root',
@@ -65,7 +64,7 @@ const useStore = create<RFState>((set, get) => ({
 
   onNodesChange: (changes: NodeChange[]) => {
     set({
-      nodes: applyNodeChanges(changes, get().nodes),
+      nodes: applyNodeChanges(changes, get().nodes) as MindMapNode[],
     });
   },
 
@@ -76,11 +75,9 @@ const useStore = create<RFState>((set, get) => ({
   },
 
   addChildNode: (parentNode: Node, position: XYPosition) => {
-    console.log('Adding child node at position:', position);
+    const parentDepth = (parentNode.data as MindMapNodeData)?.depth || 0;
 
-    const parentDepth = parentNode.data?.depth || 0;
-
-    const newNode: Node<MindMapNodeData> = {
+    const newNode: MindMapNode = {
       id: nanoid(),
       type: 'question',
       data: {
@@ -97,8 +94,6 @@ const useStore = create<RFState>((set, get) => ({
       },
       position,
     };
-
-    console.log('Created new node:', newNode);
 
     const newEdge: Edge = {
       id: nanoid(),
@@ -124,8 +119,8 @@ const useStore = create<RFState>((set, get) => ({
   },
 }));
 
-export const useNodes = () => useStore((state) => state.nodes, shallow);
-export const useEdges = () => useStore((state) => state.edges, shallow);
+export const useNodes = () => useStore((state) => state.nodes);
+export const useEdges = () => useStore((state) => state.edges);
 export const useNodesChange = () => useStore((state) => state.onNodesChange);
 export const useEdgesChange = () => useStore((state) => state.onEdgesChange);
 export const useAddChildNode = () => useStore((state) => state.addChildNode);

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -1,0 +1,134 @@
+import {
+  Edge,
+  EdgeChange,
+  Node,
+  NodeChange,
+  OnNodesChange,
+  OnEdgesChange,
+  applyNodeChanges,
+  applyEdgeChanges,
+  XYPosition,
+} from '@xyflow/react';
+import { create } from 'zustand';
+import { nanoid } from 'nanoid/non-secure';
+import { shallow } from 'zustand/shallow';
+import { MindMapNodeData } from '@/types/mindMap';
+
+export type RFState = {
+  nodes: Node<MindMapNodeData>[];
+  edges: Edge[];
+  onNodesChange: OnNodesChange;
+  onEdgesChange: OnEdgesChange;
+  addChildNode: (parentNode: Node, position: XYPosition) => void;
+  setNode: (nodeId: string, node: Node<MindMapNodeData>) => void;
+};
+
+const initialNodes: Node<MindMapNodeData>[] = [
+  {
+    id: '1',
+    type: 'root',
+    data: { label: '프로젝트 계획', depth: 0 },
+    position: { x: 0, y: 0 },
+  },
+  {
+    id: '2',
+    type: 'summary',
+    data: { label: '디자인', depth: 1, summary: '요약말' },
+    position: { x: -300, y: 300 },
+  },
+  {
+    id: '3',
+    type: 'summary',
+    data: { label: '개발', depth: 1, summary: '요약말' },
+    position: { x: 500, y: 500 },
+  },
+];
+
+const initialEdges: Edge[] = [
+  {
+    id: 'e1-2',
+    source: '1',
+    target: '2',
+    type: 'mindmapEdge',
+  },
+  {
+    id: 'e1-3',
+    source: '1',
+    target: '3',
+    type: 'mindmapEdge',
+  },
+];
+
+const useStore = create<RFState>((set, get) => ({
+  nodes: initialNodes,
+  edges: initialEdges,
+
+  onNodesChange: (changes: NodeChange[]) => {
+    set({
+      nodes: applyNodeChanges(changes, get().nodes),
+    });
+  },
+
+  onEdgesChange: (changes: EdgeChange[]) => {
+    set({
+      edges: applyEdgeChanges(changes, get().edges),
+    });
+  },
+
+  addChildNode: (parentNode: Node, position: XYPosition) => {
+    console.log('Adding child node at position:', position);
+
+    const parentDepth = parentNode.data?.depth || 0;
+
+    const newNode: Node<MindMapNodeData> = {
+      id: nanoid(),
+      type: 'question',
+      data: {
+        label: '다음 질문을 선택해주세요',
+        depth: parentDepth + 1,
+        recommendedQuestions: [
+          '질문1',
+          '질문2',
+          '질문3',
+          '질문4',
+          '질문5',
+          '질문6',
+        ],
+      },
+      position,
+    };
+
+    console.log('Created new node:', newNode);
+
+    const newEdge: Edge = {
+      id: nanoid(),
+      source: parentNode.id,
+      target: newNode.id,
+      type: 'mindmapEdge',
+    };
+
+    console.log('Created new edge:', newEdge);
+
+    set((state) => ({
+      nodes: [...state.nodes, newNode],
+      edges: [...state.edges, newEdge],
+    }));
+  },
+
+  setNode: (nodeId, updatedNode) => {
+    set({
+      nodes: get().nodes.map((node) =>
+        node.id === nodeId ? updatedNode : node,
+      ),
+    });
+  },
+}));
+
+export const useNodes = () => useStore((state) => state.nodes, shallow);
+export const useEdges = () => useStore((state) => state.edges, shallow);
+export const useNodesChange = () => useStore((state) => state.onNodesChange);
+export const useEdgesChange = () => useStore((state) => state.onEdgesChange);
+export const useAddChildNode = () => useStore((state) => state.addChildNode);
+export const useSetNode = () => useStore((state) => state.setNode);
+
+export default useStore;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,7 +1,15 @@
 @import 'tailwindcss';
 
 @theme {
-  /* 버튼 색상 */
+  /* 공통 색상 */
+  --color-border-gray: #e3e3e3;
+
+  /* button 색상 */
   --color-button-primary: #ffe277;
   --color-button-disabled: #e7e7e7;
+
+  /* mindmap 관련 색상 */
+  --color-root-icon: #ffea9f;
+  --color-question-input-hover: rgba(0, 0, 0, 0.02);
+  --color-question-input-active: rgba(0, 0, 0, 0.05);
 }

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -12,7 +12,16 @@ export type MindMapNodeData = {
   recommendedQuestions?: string[];
 };
 
-export type MindMapNode = ReactFlowNode<MindMapNodeData>;
+export type RootNodeType = ReactFlowNode<MindMapNodeData, 'root'>;
+export type QuestionNodeType = ReactFlowNode<MindMapNodeData, 'question'>;
+export type AnswerNodeType = ReactFlowNode<MindMapNodeData, 'answer'>;
+export type SummaryNodeType = ReactFlowNode<MindMapNodeData, 'summary'>;
+
+export type MindMapNode =
+  | RootNodeType
+  | QuestionNodeType
+  | AnswerNodeType
+  | SummaryNodeType;
 
 export type MindMapEdge = ReactFlowEdge;
 

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -1,0 +1,29 @@
+import { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
+
+export type TodoType = 'TODO' | 'THINKING';
+
+export type MindMapNodeData = {
+  label: string;
+  answer?: string | null;
+  summary?: string | null;
+};
+
+export type MindMapNode = ReactFlowNode<MindMapNodeData> & {
+  depth: number;
+  recommendedQuestions?: string[];
+};
+
+export type MindMapEdge = ReactFlowEdge;
+
+export type MindMap = {
+  id: number;
+  order: number;
+  type: TodoType;
+  todoTime: string;
+  toDoDate: string;
+  title: string;
+  lastModifiedAt: string;
+  user_id: number;
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
+};

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -2,16 +2,17 @@ import { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
 
 export type TodoType = 'TODO' | 'THINKING';
 
+export type MindMapNodeType = 'root' | 'question' | 'answer' | 'summary';
+
 export type MindMapNodeData = {
   label: string;
   answer?: string | null;
   summary?: string | null;
-};
-
-export type MindMapNode = ReactFlowNode<MindMapNodeData> & {
   depth: number;
   recommendedQuestions?: string[];
 };
+
+export type MindMapNode = ReactFlowNode<MindMapNodeData>;
 
 export type MindMapEdge = ReactFlowEdge;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #11 

## 📝 작업 내용
React Flow 라이브러리를 활용하여 마인드맵 UI를 개발했습니다. 
백엔드와 사전 협의하여 짜놓은 마인드맵 구조로 테스트했으며, 질문을 확장해나가는 기능의 범위까지 개발했습니다.

로딩 상태 UI 처리 및, 실제 데이터 구조는 GPT API 연동 작업을 처리하는 Issue 및 PR에서 처리할 예정입니다.

### @/types 폴더 정의
타입 관련 폴더를 생성했습니다. 타입 선언과 관련된 부분은 아래 폴더 내에서 생성 후 작업하도록 합시다!

### React Flow 라이브러리 호환 마인드맵 타입 정의
마인드맵 기능 구현을 위한 타입 정의를 추가했습니다. 기존에 백엔드 팀원들과 이야기하며 맞춘 데이터 구조로 타입을 정의했습니다. 

React Flow에서 제공하는 [[Node](https://reactflow.dev/api-reference/types/node)](https://reactflow.dev/api-reference/types/node), [[Edge](https://reactflow.dev/api-reference/types/edge)](https://reactflow.dev/api-reference/types/edge) 타입을 확장하여 프로젝트 내에서 필요한 형태로 커스텀했습니다. 

- `MindMapNodeType`: 저희 프로젝트에서 노드가 4가지 종류의 형태로 존재하기 때문에, 각 타입을 명확하게 정의했습니다. 
    - 'root' | 'question' | 'answer' | 'summary'
- `MindMapNodeData` : 모든 노드 타입이 공유하는 데이터 구조 정의 
    - `ReactFlowNode`는 **Generic** 형태로 `NodeData`를 받기 때문에 이에 맞게 정의한 타입을 설정해줬습니다. 
    - 노드 데이터(label, answer, summary, depth, recommendedQuestions) 타입 지정
     - 저희가 커스텀으로 추가해야하는 데이터는 전부 `MindMapNodeData` 내에 정의해주면 됩니다. 
- `MindMapNode`: React Flow의 기본 Node 타입을 확장하여 마인드맵 노드 타입 정의
- `MindMapEdge`: React Flow의 Edge 타입을 활용한 마인드맵 연결선 타입 정의
- `MindMap`: `MindMapNode`, `MindMapEdge` 데이터를 기반으로한 마인드맵 데이터 타입 정의

참조 문서: [[React Flow 타입 시스템](https://reactflow.dev/docs/api/types/)](https://reactflow.dev/docs/api/types/)

### Zustand를 활용한 마인드맵 상태 관리 구현
마인드맵 기능의 상태 관리 시스템을 저희가 사전에 사용하기로 결정한 전역 상태 라이브러리 Zustand를 활용해 구현했습니다. 

마인드맵 관련 store는 @/store/mindMapStore.ts에 정의했습니다. 아직 로직이 완성본이 아니라서, 추후에 삭제 로직과 더불어 변경 감지 상태 관련 로직 추가 될 예정입니다. 해당 작업과 함께 store 명도 변경할 계획입니다. `useStore -> useMindMapStore`

현재 정의한 네 가지 형태의 노드(root, question, answer, summary) 컴포넌트가 변경되는 로직 역시 해당 store에 정의되어져 있습니다.
(컴포넌트의 변경이 필요할 때, node 데이터의 type을 바꿔줌) -> 리뷰하실 때 참조 부탁드립니다.

### 현재까지 일부 구현된 마인드맵 생성 플로우 영상
**드래그앤 드롭으로 질문 생성 -> 질문 선택 -> 답변 입력 -> 요약 노드 완성 (현재 자연어 처리는 테스트 데이터로 넣기도 애매해서, 일단 답변 내용을 요약 내용으로 업데이트하도록 임시 처리)**
![2025-03-182 53 31-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9622a29e-aeea-4595-a7e1-8563ca93383c)

**질문 목록 순환되는 로직이 적용된 노드 컴포넌트**
![2025-03-182 55 45-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/218aa1e2-be61-4481-ba0b-48d15b980926)

**질문 수정 & 직접 입력하기 눌렀을 때의 처리**
![2025-03-182 57 30-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/142a7b7c-bef1-4a48-9145-e93c74510b9d)



## 💬 리뷰 요구사항(선택)
- 마인드맵 데이터 구조와 데이터를 핸들링하는 로직은, 저희 프로젝트를 위해 모두가 꼭 알아야하는 구조라고 생각해서 @/types/mindMap.ts 파일과, @/store/mindMapStore.ts 은 보다 꼼꼼하게 봐주시면 좋을 것 같습니다!
- 현재 edge 디자인은 기본 제공해주는 디자인으로 사용하고 있는데, 해당 디자인만으로 괜찮은지 혹은 커스텀이 필요할지도 의견이 필요합니다! 현제 저도 어느 정도의 범위까지 커스텀이 가능할지는 모르겠는데, 우선 선의 굵기나 색상 같은 것은 변경하는데에 전혀 문제 없습니다! 
- DragIcon 부분은 우선 무시해주셔도 될 것 같습니다. (보현님 디자인 나오면 그 디자인에 맞춰서 아이콘으로 변경할 예정임). 임시로 넣어둔 것!
- React Flow를 두 분다 아직 제대로 모르시는 상황일듯해서, 괴리감이 느껴지는 함수나 컴포넌트나 로직이 있을수도 있는데, 아리까리하면 바로 코멘트 남겨주시면 제가 습득한 내용을 바탕으로 다 설명드릴게요. 뭐든!!
