### PR TITLE
Feat/45 mindmap

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -65,5 +66,15 @@ public class MindMapController {
     )  {
         List<MindMapResponse> mindMaps = mindMapService.getMindMaps(date, type);
         return ApiResponse.ok(mindMaps);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "마인드맵 루트 노드 수정")
+    public ApiResponse<String> updateMindMap(
+        @PathVariable Long id,
+        @Valid @RequestBody MindMapRequest mindMapRequest
+    ){
+        mindMapService.updateMindMap(id, mindMapRequest);
+        return ApiResponse.ok("마인드맵이 수정되었습니다. ID: " + id);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,4 +42,13 @@ public class MindMapController {
         return ApiResponse.ok(mindMapService.getMindMapById(id));
     }
 
+    @DeleteMapping("/{id}")
+    @Operation(summary = "마인드맵 전체 삭제")
+    public ApiResponse<String> deleteMindMap(
+        @Parameter(required = true, description = "마인드맵 ID", in = ParameterIn.PATH)
+        @PathVariable Long id
+    ) {
+        mindMapService.deleteMindMap(id);
+        return ApiResponse.ok("마인드맵이 성공적으로 삭제되었습니다.");
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -1,5 +1,6 @@
 package capstone.backend.domain.mindmap.controller;
 
+import capstone.backend.domain.mindmap.dto.request.UpdateMindMapOrderRequest;
 import capstone.backend.domain.mindmap.entity.MindMapType;
 import capstone.backend.global.api.dto.ApiResponse;
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -77,4 +79,14 @@ public class MindMapController {
         mindMapService.updateMindMap(id, mindMapRequest);
         return ApiResponse.ok("마인드맵이 수정되었습니다. ID: " + id);
     }
+
+    @PatchMapping("/order")
+    @Operation(summary = "마인드맵 순서 변경")
+    public ApiResponse<String> updateMindMapOrder(
+        @Valid @RequestBody UpdateMindMapOrderRequest updateMindMapOrderRequest
+    ){
+        mindMapService.updateMindMapOrder(updateMindMapOrderRequest);
+        return ApiResponse.ok(("마인드맵 순서가 변경되었습니다."));
+    }
+
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -1,5 +1,6 @@
 package capstone.backend.domain.mindmap.controller;
 
+import capstone.backend.domain.mindmap.entity.MindMapType;
 import capstone.backend.global.api.dto.ApiResponse;
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
 import capstone.backend.domain.mindmap.dto.response.MindMapResponse;
@@ -8,13 +9,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -50,5 +55,15 @@ public class MindMapController {
     ) {
         mindMapService.deleteMindMap(id);
         return ApiResponse.ok("마인드맵이 성공적으로 삭제되었습니다.");
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "날짜별, 타입별 마인드맵 전체 조회")
+    public ApiResponse<List<MindMapResponse>> getMindMaps(
+        @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        @RequestParam(value = "type") MindMapType type
+    )  {
+        List<MindMapResponse> mindMaps = mindMapService.getMindMaps(date, type);
+        return ApiResponse.ok(mindMaps);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -44,7 +44,7 @@ public class MindMapController {
     @GetMapping("/{id}")
     @Operation(summary = "특정 마인드맵 조회")
     public ApiResponse<MindMapResponse> getMindMap(
-            @Parameter(required = true, description = "마인드맵 ID", in = ParameterIn.PATH)
+            @Parameter(name="id", description = "조회 마인드맵 ID", required = true, in = ParameterIn.PATH)
             @PathVariable Long id
     ) {
         return ApiResponse.ok(mindMapService.getMindMapById(id));
@@ -53,7 +53,7 @@ public class MindMapController {
     @DeleteMapping("/{id}")
     @Operation(summary = "마인드맵 전체 삭제")
     public ApiResponse<String> deleteMindMap(
-        @Parameter(required = true, description = "마인드맵 ID", in = ParameterIn.PATH)
+        @Parameter(name = "id", description = "삭제 마인드맵 ID", required = true, in = ParameterIn.PATH)
         @PathVariable Long id
     ) {
         mindMapService.deleteMindMap(id);
@@ -63,7 +63,10 @@ public class MindMapController {
     @GetMapping("/search")
     @Operation(summary = "날짜별, 타입별 마인드맵 전체 조회")
     public ApiResponse<List<MindMapResponse>> getMindMaps(
+        @Parameter(name = "date", description = "조회할 날짜 (ex. 2025-03-23)", required = true, in = ParameterIn.QUERY)
         @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+
+        @Parameter(name = "type", description = "마인드맵 타입 (TODO 또는 THINKING)", required = true, in = ParameterIn.QUERY)
         @RequestParam(value = "type") MindMapType type
     )  {
         List<MindMapResponse> mindMaps = mindMapService.getMindMaps(date, type);
@@ -73,6 +76,7 @@ public class MindMapController {
     @PutMapping("/{id}")
     @Operation(summary = "마인드맵 루트 노드 수정")
     public ApiResponse<String> updateMindMap(
+        @Parameter(name = "id", description = "수정 마인드맵 ID", required = true, in = ParameterIn.PATH)
         @PathVariable Long id,
         @Valid @RequestBody MindMapRequest mindMapRequest
     ){

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/MindMapRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/MindMapRequest.java
@@ -12,6 +12,7 @@ public record MindMapRequest(
     @NotNull MindMapType type,
     @NotNull LocalDate toDoDate,
     @NotBlank String title,
+    String description,
     @NotNull Long memberId,
     List<Node> nodes
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/UpdateMindMapOrderRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/UpdateMindMapOrderRequest.java
@@ -1,0 +1,16 @@
+package capstone.backend.domain.mindmap.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record UpdateMindMapOrderRequest(
+    @NotNull LocalDate toDoDate,
+    @NotEmpty List<MindMapOrder> orderList
+) {
+    public record MindMapOrder(
+        @NotNull Long mindMapId,
+        @NotNull Integer orderIndex
+    ) {}
+}

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Builder
 public record MindMapResponse(
     Long id,
     int order_index,
@@ -14,13 +13,11 @@ public record MindMapResponse(
     LocalDate toDoDate,
     String title,
     String description,
-    int maxDepth,
     LocalDateTime lastModifiedAt,
     String type,
     List<NodeResponse> nodes,
     List<EdgeResponse> edges
 ) {
-    @Builder
     public record NodeResponse(
         String id,
         String parentId,
@@ -34,7 +31,6 @@ public record MindMapResponse(
         int y
     ) {}
 
-    @Builder
     public record EdgeResponse(
         String id,
         String source,
@@ -43,15 +39,17 @@ public record MindMapResponse(
 
     @Builder
     public static MindMapResponse fromEntity(MindMap mindMap) {
-        return MindMapResponse.builder()
-            .id(mindMap.getMindmapId())
-            .title(mindMap.getTitle())
-            .description(mindMap.getDescription())
-            .order_index(mindMap.getOrderIndex())
-            .memberId(mindMap.getMemberId())
-            .toDoDate(mindMap.getToDoDate())
-            .type(mindMap.getType().name())
-            .lastModifiedAt(mindMap.getLastModifiedAt())
-            .build();
+        return new MindMapResponse(
+            mindMap.getMindmapId(),
+            mindMap.getOrderIndex(),
+            mindMap.getMemberId(),
+            mindMap.getToDoDate(),
+            mindMap.getTitle(),
+            mindMap.getDescription(),
+            mindMap.getLastModifiedAt(),
+            mindMap.getType().name(),
+            null,
+            null
+        );
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
@@ -13,6 +13,7 @@ public record MindMapResponse(
     Long memberId,
     LocalDate toDoDate,
     String title,
+    String description,
     int maxDepth,
     LocalDateTime lastModifiedAt,
     String type,
@@ -45,6 +46,7 @@ public record MindMapResponse(
         return MindMapResponse.builder()
             .id(mindMap.getMindmapId())
             .title(mindMap.getTitle())
+            .description(mindMap.getDescription())
             .order_index(mindMap.getOrderIndex())
             .memberId(mindMap.getMemberId())
             .toDoDate(mindMap.getToDoDate())

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/MindMapResponse.java
@@ -1,5 +1,6 @@
 package capstone.backend.domain.mindmap.dto.response;
 
+import capstone.backend.domain.mindmap.entity.MindMap;
 import lombok.Builder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,4 +39,17 @@ public record MindMapResponse(
         String source,
         String target
     ) {}
+
+    @Builder
+    public static MindMapResponse fromEntity(MindMap mindMap) {
+        return MindMapResponse.builder()
+            .id(mindMap.getMindmapId())
+            .title(mindMap.getTitle())
+            .order_index(mindMap.getOrderIndex())
+            .memberId(mindMap.getMemberId())
+            .toDoDate(mindMap.getToDoDate())
+            .type(mindMap.getType().name())
+            .lastModifiedAt(mindMap.getLastModifiedAt())
+            .build();
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
@@ -35,6 +35,9 @@ public class MindMap {
     @Column(nullable = false, name="title")
     private String title;
 
+    @Column(name="description")
+    private String description;
+
     @Column(nullable = false, name="last_modified_at")
     private LocalDateTime lastModifiedAt;
 
@@ -56,6 +59,7 @@ public class MindMap {
             .memberId(mindMapRequest.memberId())
             .toDoDate(mindMapRequest.toDoDate())
             .title(mindMapRequest.title())
+            .description(mindMapRequest.description())
             .lastModifiedAt(LocalDateTime.now())
             .type(mindMapRequest.type())
             .nodes(mindMapRequest.nodes())
@@ -64,6 +68,7 @@ public class MindMap {
 
     public void update(MindMapRequest mindMapRequest) {
         this.title = mindMapRequest.title();
+        this.description = mindMapRequest.description();
         this.toDoDate = mindMapRequest.toDoDate();
         this.type = mindMapRequest.type();
         this.orderIndex = mindMapRequest.orderIndex();

--- a/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
@@ -61,4 +61,12 @@ public class MindMap {
             .nodes(mindMapRequest.nodes())
             .build();
     }
+
+    public void update(MindMapRequest mindMapRequest) {
+        this.title = mindMapRequest.title();
+        this.toDoDate = mindMapRequest.toDoDate();
+        this.type = mindMapRequest.type();
+        this.orderIndex = mindMapRequest.orderIndex();
+        this.lastModifiedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/exception/InvalidMindMapDateException.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/exception/InvalidMindMapDateException.java
@@ -1,0 +1,12 @@
+package capstone.backend.domain.mindmap.exception;
+
+import capstone.backend.global.api.exception.ApiException;
+import java.time.LocalDate;
+import org.springframework.http.HttpStatus;
+
+public class InvalidMindMapDateException extends ApiException {
+    public InvalidMindMapDateException(Long id, LocalDate date) {
+        super(HttpStatus.BAD_REQUEST, "마인드맵 날짜와 요청된 날짜가 다릅니다. ID: " + id + " 날짜: " + date);
+    }
+
+}

--- a/backend/src/main/java/capstone/backend/domain/mindmap/exception/MindMapNotFoundException.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/exception/MindMapNotFoundException.java
@@ -9,4 +9,7 @@ public class MindMapNotFoundException extends ApiException {
         super(HttpStatus.NOT_FOUND, "MindMap을 찾을 수 없습니다");
     }
 
+    public MindMapNotFoundException(Long id) {
+        super(HttpStatus.NOT_FOUND, "MindMap을 찾을 수 없습니다: ID: " + id);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
@@ -1,10 +1,16 @@
 package capstone.backend.domain.mindmap.repository;
 
 import capstone.backend.domain.mindmap.entity.MindMap;
+import capstone.backend.domain.mindmap.entity.MindMapType;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MindMapRepository extends JpaRepository<MindMap, Long> {
-
+    List<MindMap> findAllByToDoDateAndTypeOrderByOrderIndexAsc(
+        LocalDate date,
+        MindMapType type);
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
@@ -5,7 +5,6 @@ import capstone.backend.domain.mindmap.entity.MindMapType;
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -27,10 +27,7 @@ public class MindMapService {
 
     public MindMapResponse getMindMapById(Long id){
         return mindMapRepository.findById(id)
-            .map(mindMap -> MindMapResponse.builder()
-                .id(mindMap.getMindmapId())
-                .title(mindMap.getTitle())
-                .build())
+            .map(MindMapResponse::fromEntity)
             .orElseThrow(MindMapNotFoundException::new);
     }
 
@@ -44,17 +41,14 @@ public class MindMapService {
     }
 
     public List<MindMapResponse> getMindMaps(LocalDate date, MindMapType type) {
-        return mindMapRepository.findAllByToDoDateAndTypeOrderByOrderIndexAsc(date, type)
-            .stream()
-            .map(mindMap -> MindMapResponse.builder()
-                .id(mindMap.getMindmapId())
-                .title(mindMap.getTitle())
-                .order_index(mindMap.getOrderIndex())
-                .memberId(mindMap.getMemberId())
-                .toDoDate(mindMap.getToDoDate())
-                .type(mindMap.getType().name())
-                .lastModifiedAt(mindMap.getLastModifiedAt())
-                .build())
+        List<MindMap> mindMaps = mindMapRepository.findAllByToDoDateAndTypeOrderByOrderIndexAsc(date, type);
+
+        if (mindMaps.isEmpty()) {
+            throw new MindMapNotFoundException();
+        }
+
+        return mindMaps.stream()
+            .map(MindMapResponse::fromEntity)
             .toList();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -51,4 +51,12 @@ public class MindMapService {
             .map(MindMapResponse::fromEntity)
             .toList();
     }
+
+    @Transactional
+    public void updateMindMap(Long id, MindMapRequest mindMapRequest) {
+        MindMap mindMap = mindMapRepository.findById(id)
+            .orElseThrow(() -> new MindMapNotFoundException(id));
+
+        mindMap.update(mindMapRequest);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -2,7 +2,6 @@ package capstone.backend.domain.mindmap.service;
 
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
 import capstone.backend.domain.mindmap.dto.request.UpdateMindMapOrderRequest;
-import capstone.backend.domain.mindmap.dto.request.UpdateMindMapOrderRequest.MindMapOrder;
 import capstone.backend.domain.mindmap.dto.response.MindMapResponse;
 import capstone.backend.domain.mindmap.entity.MindMap;
 import capstone.backend.domain.mindmap.entity.MindMapType;

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -31,4 +31,12 @@ public class MindMapService {
             .orElseThrow(MindMapNotFoundException::new);
     }
 
+    @Transactional
+    public void deleteMindMap(Long id) {
+        if (!mindMapRepository.existsById(id)) {
+            throw new MindMapNotFoundException(id);
+        }
+
+        mindMapRepository.deleteById(id);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -3,8 +3,11 @@ package capstone.backend.domain.mindmap.service;
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
 import capstone.backend.domain.mindmap.dto.response.MindMapResponse;
 import capstone.backend.domain.mindmap.entity.MindMap;
+import capstone.backend.domain.mindmap.entity.MindMapType;
 import capstone.backend.domain.mindmap.exception.MindMapNotFoundException;
 import capstone.backend.domain.mindmap.repository.MindMapRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,5 +41,20 @@ public class MindMapService {
         }
 
         mindMapRepository.deleteById(id);
+    }
+
+    public List<MindMapResponse> getMindMaps(LocalDate date, MindMapType type) {
+        return mindMapRepository.findAllByToDoDateAndTypeOrderByOrderIndexAsc(date, type)
+            .stream()
+            .map(mindMap -> MindMapResponse.builder()
+                .id(mindMap.getMindmapId())
+                .title(mindMap.getTitle())
+                .order_index(mindMap.getOrderIndex())
+                .memberId(mindMap.getMemberId())
+                .toDoDate(mindMap.getToDoDate())
+                .type(mindMap.getType().name())
+                .lastModifiedAt(mindMap.getLastModifiedAt())
+                .build())
+            .toList();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #45 

## 📝 작업 내용

- 루트 노드 삭제

- 날짜 + 타입(TODO / THINKING)별 마인드맵 전체 조회 API 구현
  - DB쿼리 조회 시 specification 적용 or queryDSL 적용을 넣는게 좋을까요? 마인드맵 전체 조회하는게 이거 밖에 없어서 오버엔지니어링 같기도 해서 고민입니다.

- 루트 노드 수정 시 하위노드 삭제, 엣지 삭제
 
- MindMap에 설명(description) 필드 추가
  
- 마인드맵 순서(orderIndex) 일괄 수정 API 구현
  - `fetchMindMapsAsMap` : mindMapId 리스트로 IN 쿼리 실행
  - `validateMindMapExists` : 마인드맵이 존재하는지 확인
  - `validateToDoDateMatch:` 마인드맵의 날짜가 요청한 날짜와 다른 경우 → 유효하지 않은 수정 시도 → 예외 발생


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
