### PR TITLE
[FE] feat: 마인드맵 Pane 클릭 시, 노드 상태 복원 기능 구현

### DIFF
--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -56,7 +56,6 @@ export default function QuestionListNode({
   }, [questions]);
 
   const handleRemoveQuestion = (id: number) => {
-    console.log('handleRemove');
     setDisplayedQuestions((prev) =>
       prev.map((q) => (q.id === id ? { ...q, animating: true } : q)),
     );


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #59 

## 📝 작업 내용
질문 선택 노드 또는 질문 답변 작성 노드 상태에서 외부(배경) 클릭 시 이전 상태로 되돌리는 기능을 구현했습니다.

### 계층형 ActiveState 구조 도입
`mindMapStore`에 아래 구조에 해당하는 상태를 도입했습니다.
```
type ActiveState = {
  nodeId: string;
  previousNodes: MindMapNode[];
  previousEdges: MindMapEdge[];
  previousActiveState: ActiveState | null; // 이전 상태 추적을 위한 계층 추가
};
```
- 여러 단계의 상태 변경을 추적할 수 있는 계층형 구조 구현
- 연결 리스트 형태로 상태 이력을 저장하여 연속적인 상태 복원 가능

새 노드 생성 또는 노드 타입이 변경될 때 마다 이전 상태를 저장하는 로직을 적용했습니다. (`addChildNode`, `setNode`)

### 마인드맵 외부 클릭 감지
React Flow의 `onPaneClick` 메소드를 활용했습니다.
그런데, 드래그앤 드롭을 해서 놔도 `onPaneClick` 이벤트가 발생해서, `onConnectEnd`의 이벤트와 겹치지 않도록 `ignoreNextPaneClick` ref로 pane만 클릭을 감지하도록 처리했습니다. 

### 스크린샷 (선택)
![2025-04-085 21 01-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/59f4d7b8-790f-4930-8e9a-daa49f83cccc)