### PR TITLE
[BE] feat: 상단바에 들어갈 유저 데이터 조회 API 작성

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package capstone.backend.domain.member.controller;
+
+
+import capstone.backend.domain.member.dto.response.UserDataDTO;
+import capstone.backend.domain.member.service.MemberService;
+import capstone.backend.global.api.dto.ApiResponse;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "유저 정보 API")
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    @Operation(summary = "상단바 유저 정보", description = "email, username 데이터")
+    public ApiResponse<UserDataDTO> me(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        return ApiResponse.ok(memberService.findMember(user.getMemberId()));
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/member/dto/response/UserDataDTO.java
+++ b/backend/src/main/java/capstone/backend/domain/member/dto/response/UserDataDTO.java
@@ -1,0 +1,15 @@
+package capstone.backend.domain.member.dto.response;
+
+import capstone.backend.domain.member.scheme.Member;
+
+public record UserDataDTO(
+        String email,
+        String username
+) {
+    public UserDataDTO(Member member) {
+        this(
+                member.getEmail(),
+                member.getUsername()
+        );
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
@@ -1,0 +1,22 @@
+package capstone.backend.domain.member.service;
+
+import capstone.backend.domain.member.dto.response.UserDataDTO;
+import capstone.backend.domain.member.exception.MemberNotFoundException;
+import capstone.backend.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public UserDataDTO findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(UserDataDTO::new)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #104 

## 📝 작업 내용

1. 상단바에 들어갈 user data를 조회하는 과정이 없음
2. 임시 토큰 발급 후 해당 토큰으로 JWT 발급 받는 api 호출 과정에서 **user data를 조회한 후 zustand에 전역 상태로 저장하는 로직** 필요
<img width="661" alt="image" src="https://github.com/user-attachments/assets/70919328-e179-43bd-8204-06f4a4d39b39" />


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

