### PR TITLE
[FE] test: 뽀모도로 더미데이터로 실행 흐름 처리

### DIFF
--- a/frontend/src/components/ui/Modal/AddPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/AddPomodoro.tsx
@@ -6,6 +6,8 @@ import { MultiSlider } from '@/components/ui/MultiSlider.tsx';
 import { PomodoroCycle, Eisenhower } from '@/types/pomodoro';
 import { Input } from '@/components/ui/Input.tsx';
 import { DialogClose } from '@radix-ui/react-dialog';
+import { useCreatePomodoro } from '@/store/pomodoro';
+import { useNavigate } from 'react-router';
 
 type Props = {
   trigger: ReactNode;
@@ -19,6 +21,10 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
   const [minutes, setMinutes] = useState(0);
   const [totalTime, setTotalTime] = useState(0); // 전체 시간 (분)
   const [cycleValue, setCycleValue] = useState<PomodoroCycle[]>([]); // 슬라이더 값
+
+  const navigate = useNavigate();
+
+  const createPomodoro = useCreatePomodoro();
 
   // 세션 간격 추천
   const generateSliderValuesFromTime = (hours: number, minutes: number) => {
@@ -90,8 +96,23 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
     setPage(0);
   };
 
-  const createPomodoro = () => {
+  const handleCreatePomodoro = () => {
     // 생성 api 추가
+
+    const newPomodoroId = createPomodoro({
+      title,
+      plannedCycles: cycleValue,
+      totalPlannedTime: {
+        hour: hours,
+        minute: minutes,
+        second: 0,
+        nano: 0,
+      },
+      eisenhower: null,
+    });
+
+    navigate(`pomodoro/${newPomodoroId}`);
+
     resetStates();
   };
 
@@ -127,7 +148,10 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
                 뒤로가기
               </Button>
               <DialogClose asChild>
-                <Button className="px-8 w-full flex-1" onClick={createPomodoro}>
+                <Button
+                  className="px-8 w-full flex-1"
+                  onClick={handleCreatePomodoro}
+                >
                   다음
                 </Button>
               </DialogClose>

--- a/frontend/src/components/ui/Modal/DeletePomodoro.tsx
+++ b/frontend/src/components/ui/Modal/DeletePomodoro.tsx
@@ -5,6 +5,8 @@ import { MultiSlider } from '@/components/ui/MultiSlider.tsx';
 import { LinkedUnlinkedPomodoro } from '@/types/pomodoro';
 import { DialogClose } from '@radix-ui/react-dialog';
 import { ReactNode } from 'react';
+import { useDeletePomodoro } from '@/store/pomodoro';
+import { useNavigate } from 'react-router';
 
 export default function DeletePomodoro({
   trigger,
@@ -21,9 +23,14 @@ export default function DeletePomodoro({
     0,
   );
 
-  const deletePomodoro = () => {
+  const navigate = useNavigate();
+
+  const deletePomodoro = useDeletePomodoro();
+
+  const handleDeletePomodoro = () => {
     // 삭제 api 추가
-    console.log('deletePomodoro');
+    deletePomodoro(pomodoro.id);
+    navigate('/pomodoro');
   };
 
   return (
@@ -40,7 +47,10 @@ export default function DeletePomodoro({
               </Button>
             </DialogClose>
             <DialogClose asChild>
-              <Button className="px-8 w-full flex-1" onClick={deletePomodoro}>
+              <Button
+                className="px-8 w-full flex-1"
+                onClick={handleDeletePomodoro}
+              >
                 삭제하기
               </Button>
             </DialogClose>

--- a/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
@@ -2,116 +2,15 @@ import { LinkIcon, Unlink, Plus } from 'lucide-react';
 import { SubSidebarAccordion } from '@/components/ui/SubSidebarAccordion.tsx';
 import CommonSubSidebarWrapper from '../CommonSubSidebarWrapper';
 import { PomodoroItem } from '@/components/ui/pomodoro/PomodoroItem.tsx';
-import type { PomodoroList } from '@/types/pomodoro';
 import AddPomodoro from '@/components/ui/Modal/AddPomodoro.tsx';
 import { useNavigate, useParams } from 'react-router';
-
-// 예시 데이터
-const response: PomodoroList = {
-  linkedPomodoros: [
-    {
-      pomodoro: {
-        id: 1,
-        title: '개발하기',
-        createdAt: '2025-04-04T19:43:39.359437',
-        completedAt: '2025-04-04T19:46:58.644763',
-        totalPlannedTime: {
-          hour: 1,
-          minute: 55,
-          second: 0,
-          nano: 0,
-        },
-        totalExecutedTime: {
-          hour: 1,
-          minute: 30,
-          second: 0,
-          nano: 0,
-        },
-        totalWorkingTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalBreakTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        plannedCycles: [
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-        executedCycles: [
-          { workDuration: 30, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-      },
-      eisenhower: {
-        id: 1,
-        title: '개발 프로젝트',
-        memo: '깃헙에 푸시해야 함',
-        dueDate: '2025-04-10',
-        quadrant: 'Q1',
-        type: 'TODO',
-        order: 1,
-        isCompleted: false,
-        createdAt: '2025-04-04T19:40:00',
-      },
-    },
-  ],
-
-  unlinkedPomodoros: [
-    {
-      pomodoro: {
-        id: 2,
-        title: '자유',
-        createdAt: '2025-04-04T19:43:41.849539',
-        completedAt: '2025-04-05T09:00:00',
-        totalPlannedTime: {
-          hour: 1,
-          minute: 55,
-          second: 0,
-          nano: 0,
-        },
-        totalExecutedTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalWorkingTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalBreakTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        plannedCycles: [
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-        executedCycles: [],
-      },
-      eisenhower: null,
-    },
-  ],
-};
+import { usePomodoros } from '@/store/pomodoro';
 
 export default function PomodoroSubSidebar() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+
+  const pomodoros = usePomodoros();
 
   const pomodoroClick = (id: number) => {
     navigate(`/pomodoro/${id}`);
@@ -130,7 +29,7 @@ export default function PomodoroSubSidebar() {
           icon={<LinkIcon className="w-4 h-4" />}
           title="연결된 뽀모도로"
         >
-          {response.linkedPomodoros?.map((item) => (
+          {pomodoros.linkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
               item={item}
@@ -144,7 +43,7 @@ export default function PomodoroSubSidebar() {
           icon={<Unlink className="w-4 h-4" />}
           title="자유로운 뽀모도로"
         >
-          {response.unlinkedPomodoros?.map((item) => (
+          {pomodoros.unlinkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
               item={item}

--- a/frontend/src/mock/pomorodo.ts
+++ b/frontend/src/mock/pomorodo.ts
@@ -1,0 +1,103 @@
+import { PomodoroList } from '@/types/pomodoro';
+
+export const pomodoroMockData: PomodoroList = {
+  linkedPomodoros: [
+    {
+      pomodoro: {
+        id: 1,
+        title: '개발하기',
+        createdAt: '2025-04-04T19:43:39.359437',
+        completedAt: '2025-04-04T19:46:58.644763',
+        totalPlannedTime: {
+          hour: 1,
+          minute: 55,
+          second: 0,
+          nano: 0,
+        },
+        totalExecutedTime: {
+          hour: 1,
+          minute: 30,
+          second: 0,
+          nano: 0,
+        },
+        totalWorkingTime: {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          nano: 0,
+        },
+        totalBreakTime: {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          nano: 0,
+        },
+        plannedCycles: [
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 0 },
+        ],
+        executedCycles: [
+          { workDuration: 30, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 0 },
+        ],
+      },
+      eisenhower: {
+        id: 1,
+        title: '개발 프로젝트',
+        memo: '깃헙에 푸시해야 함',
+        dueDate: '2025-04-10',
+        quadrant: 'Q1',
+        type: 'TODO',
+        order: 1,
+        isCompleted: false,
+        createdAt: '2025-04-04T19:40:00',
+      },
+    },
+  ],
+
+  unlinkedPomodoros: [
+    {
+      pomodoro: {
+        id: 2,
+        title: '자유',
+        createdAt: '2025-04-04T19:43:41.849539',
+        completedAt: '2025-04-05T09:00:00',
+        totalPlannedTime: {
+          hour: 1,
+          minute: 55,
+          second: 0,
+          nano: 0,
+        },
+        totalExecutedTime: {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          nano: 0,
+        },
+        totalWorkingTime: {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          nano: 0,
+        },
+        totalBreakTime: {
+          hour: 0,
+          minute: 0,
+          second: 0,
+          nano: 0,
+        },
+        plannedCycles: [
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 5 },
+          { workDuration: 25, breakDuration: 0 },
+        ],
+        executedCycles: [],
+      },
+      eisenhower: null,
+    },
+  ],
+};

--- a/frontend/src/pages/pomodoro.tsx
+++ b/frontend/src/pages/pomodoro.tsx
@@ -1,133 +1,32 @@
-import { Search, Settings, Bell } from 'lucide-react';
 import { PomodoroTimer } from '@/components/ui/pomodoro/PomodoroTimer.tsx';
 import PomodoroResult from '@/components/ui/pomodoro/PomodoroResult.tsx';
-import { LinkedUnlinkedPomodoro, PomodoroList } from '@/types/pomodoro';
+import { LinkedUnlinkedPomodoro } from '@/types/pomodoro';
 import { useParams, useNavigate } from 'react-router';
 import { useEffect } from 'react';
-
-// 예시 데이터
-const response: PomodoroList = {
-  linkedPomodoros: [
-    {
-      pomodoro: {
-        id: 1,
-        title: '개발하기',
-        createdAt: '2025-04-04T19:43:39.359437',
-        completedAt: '2025-04-04T19:46:58.644763',
-        totalPlannedTime: {
-          hour: 1,
-          minute: 55,
-          second: 0,
-          nano: 0,
-        },
-        totalExecutedTime: {
-          hour: 1,
-          minute: 30,
-          second: 0,
-          nano: 0,
-        },
-        totalWorkingTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalBreakTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        plannedCycles: [
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-        executedCycles: [
-          { workDuration: 30, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-      },
-      eisenhower: {
-        id: 1,
-        title: '개발 프로젝트',
-        memo: '깃헙에 푸시해야 함',
-        dueDate: '2025-04-10',
-        quadrant: 'Q1',
-        type: 'TODO',
-        order: 1,
-        isCompleted: false,
-        createdAt: '2025-04-04T19:40:00',
-      },
-    },
-  ],
-
-  unlinkedPomodoros: [
-    {
-      pomodoro: {
-        id: 2,
-        title: '자유',
-        createdAt: '2025-04-04T19:43:41.849539',
-        completedAt: '2025-04-05T09:00:00',
-        totalPlannedTime: {
-          hour: 1,
-          minute: 55,
-          second: 0,
-          nano: 0,
-        },
-        totalExecutedTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalWorkingTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        totalBreakTime: {
-          hour: 0,
-          minute: 0,
-          second: 0,
-          nano: 0,
-        },
-        plannedCycles: [
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 5 },
-          { workDuration: 25, breakDuration: 0 },
-        ],
-        executedCycles: [],
-      },
-      eisenhower: null,
-    },
-  ],
-};
+import { usePomodoros } from '@/store/pomodoro';
 
 export default function Pomodoro() {
   const { id } = useParams();
   const navigate = useNavigate();
 
+  const pomodoros = usePomodoros();
+  const { linkedPomodoros, unlinkedPomodoros } = pomodoros;
+
   // 예시 데이터 선택. api 연결 후 수정
   const allPomodoros: LinkedUnlinkedPomodoro[] = [
-    ...(response.linkedPomodoros ?? []),
-    ...(response.unlinkedPomodoros ?? []),
+    ...(linkedPomodoros ?? []),
+    ...(unlinkedPomodoros ?? []),
   ];
   // id에 따른 예시 데이터
   const data = id
     ? (allPomodoros.find((item) => item.pomodoro.id === Number(id)) ?? null)
     : null;
 
-  // // 존재하지 않는 id로 접근했거나, id 없이 접근했을 경우 → 리다이렉트
   useEffect(() => {
     if (!data) {
       const pomodoroIdToShow =
-        response.linkedPomodoros?.[0]?.pomodoro.id ||
-        response.unlinkedPomodoros?.[0]?.pomodoro.id;
+        linkedPomodoros?.[0]?.pomodoro.id ||
+        unlinkedPomodoros?.[0]?.pomodoro.id;
       if (pomodoroIdToShow) {
         navigate(`/pomodoro/${pomodoroIdToShow}`);
         return;
@@ -135,61 +34,11 @@ export default function Pomodoro() {
       // 아무것도 없을 때 화면 필요
       console.log('표시할 뽀모도로가 없습니다.');
     }
-  }, [id, data, allPomodoros, navigate]);
-
-  useEffect(() => {
-    if (!id) {
-      const pomodoroIdToShow =
-        response.linkedPomodoros?.[0]?.pomodoro.id ||
-        response.unlinkedPomodoros?.[0]?.pomodoro.id;
-      if (pomodoroIdToShow) {
-        navigate(`/pomodoro/${pomodoroIdToShow}`);
-        return;
-      }
-      // 아무것도 없을 때 화면 필요
-      console.log('표시할 뽀모도로가 없습니다.');
-    }
-  }, [id, navigate]);
-
+  }, [id, data, linkedPomodoros, unlinkedPomodoros, navigate]);
   return (
     <div className="flex min-h-screen bg-white">
       <div className="flex-1">
-        {/*헤더 컴포넌트로 교체하기*/}
-        <header className="p-4 flex items-center justify-between border-b">
-          <div className="flex-1 max-w-md mx-auto">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-              <input
-                type="text"
-                placeholder="검색어를 입력하세요"
-                className="w-full bg-[#f2f2f2] rounded-full py-2 pl-10 pr-4 text-sm focus:outline-none"
-              />
-            </div>
-          </div>
-          <div className="flex items-center gap-4">
-            <button className="p-2">
-              <Settings className="w-5 h-5 text-gray-600" />
-            </button>
-            <button className="p-2">
-              <Bell className="w-5 h-5 text-gray-600" />
-            </button>
-            <div className="flex items-center gap-2">
-              <div className="text-right text-xs">
-                <div>Anima Agrawal</div>
-                <div className="text-gray-500">user@naver.com</div>
-              </div>
-              <div className="w-8 h-8 rounded-full bg-[#8d5cf6] flex items-center justify-center text-white">
-                <img
-                  src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/2025__EC_BA_A1_EC_8A_A4_ED_86_A4-lGSmjOdO4oCUnJig32lAVPeWcCJRl8.png"
-                  alt="Profile"
-                  className="w-8 h-8 rounded-full"
-                />
-              </div>
-            </div>
-          </div>
-        </header>
-
-        <main className="px-[40px] py-[50px] flex flex-col gap-[50px]">
+        <main className="flex flex-col gap-[50px]">
           <div className="flex-1 flex-col gap-[25px]">
             <h1 className="text-[40px] font-semibold">뽀모도로 실행</h1>
             <p className="text-[16px] font-normal">

--- a/frontend/src/store/pomodoro.ts
+++ b/frontend/src/store/pomodoro.ts
@@ -1,0 +1,15 @@
+import { pomodoroMockData } from '@/mock/pomorodo';
+import { PomodoroList } from '@/types/pomodoro';
+import { create } from 'zustand';
+
+export type PomodoroListState = {
+  pomodoros: PomodoroList;
+};
+
+const useStore = create<PomodoroListState>(() => ({
+  pomodoros: pomodoroMockData,
+}));
+
+export const usePomodoros = () => useStore((state) => state.pomodoros);
+
+export default useStore;

--- a/frontend/src/store/pomodoro.ts
+++ b/frontend/src/store/pomodoro.ts
@@ -19,6 +19,7 @@ export type PomodoroListState = {
     totalPlannedTime: TotalTime;
     eisenhower: Eisenhower | null;
   }) => void;
+  deletePomodoro: (id: number) => void;
 };
 
 const useStore = create<PomodoroListState>((set) => ({
@@ -81,10 +82,34 @@ const useStore = create<PomodoroListState>((set) => ({
 
     return newId;
   },
+
+  deletePomodoro: (id) => {
+    set((state) => {
+      const updatedPomodoros = { ...state.pomodoros };
+
+      if (updatedPomodoros.linkedPomodoros) {
+        updatedPomodoros.linkedPomodoros =
+          updatedPomodoros.linkedPomodoros.filter(
+            (item) => item.pomodoro.id !== id,
+          );
+      }
+
+      if (updatedPomodoros.unlinkedPomodoros) {
+        updatedPomodoros.unlinkedPomodoros =
+          updatedPomodoros.unlinkedPomodoros.filter(
+            (item) => item.pomodoro.id !== id,
+          );
+      }
+
+      return { pomodoros: updatedPomodoros };
+    });
+  },
 }));
 
 export const usePomodoros = () => useStore((state) => state.pomodoros);
 export const useCreatePomodoro = () =>
   useStore((state) => state.createPomodoro);
+export const useDeletePomodoro = () =>
+  useStore((state) => state.deletePomodoro);
 
 export default useStore;

--- a/frontend/src/store/pomodoro.ts
+++ b/frontend/src/store/pomodoro.ts
@@ -1,15 +1,90 @@
 import { pomodoroMockData } from '@/mock/pomorodo';
-import { PomodoroList } from '@/types/pomodoro';
+import {
+  PomodoroList,
+  Pomodoro,
+  LinkedUnlinkedPomodoro,
+  Eisenhower,
+  PomodoroCycle,
+  TotalTime,
+} from '@/types/pomodoro';
 import { create } from 'zustand';
+import { nanoid } from 'nanoid/non-secure';
 
 export type PomodoroListState = {
   pomodoros: PomodoroList;
+
+  createPomodoro: (newPomodoroData: {
+    title: string;
+    plannedCycles: PomodoroCycle[];
+    totalPlannedTime: TotalTime;
+    eisenhower: Eisenhower | null;
+  }) => void;
 };
 
-const useStore = create<PomodoroListState>(() => ({
+const useStore = create<PomodoroListState>((set) => ({
   pomodoros: pomodoroMockData,
+
+  createPomodoro: (newPomodoroData) => {
+    const newId = parseInt(nanoid(8), 36) % 10000;
+    const now = new Date().toISOString();
+
+    const newPomodoro: Pomodoro = {
+      id: newId,
+      title: newPomodoroData.title,
+      createdAt: now,
+      completedAt: '',
+      totalPlannedTime: newPomodoroData.totalPlannedTime,
+      totalExecutedTime: {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        nano: 0,
+      },
+      totalWorkingTime: {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        nano: 0,
+      },
+      totalBreakTime: {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        nano: 0,
+      },
+      plannedCycles: newPomodoroData.plannedCycles,
+      executedCycles: [],
+    };
+
+    const newPomodoroItem: LinkedUnlinkedPomodoro = {
+      pomodoro: newPomodoro,
+      eisenhower: newPomodoroData.eisenhower,
+    };
+
+    set((state) => {
+      const updatedPomodoros = { ...state.pomodoros };
+
+      if (newPomodoroData.eisenhower) {
+        updatedPomodoros.linkedPomodoros = [
+          ...(updatedPomodoros.linkedPomodoros || []),
+          newPomodoroItem,
+        ];
+      } else {
+        updatedPomodoros.unlinkedPomodoros = [
+          ...(updatedPomodoros.unlinkedPomodoros || []),
+          newPomodoroItem,
+        ];
+      }
+
+      return { pomodoros: updatedPomodoros };
+    });
+
+    return newId;
+  },
 }));
 
 export const usePomodoros = () => useStore((state) => state.pomodoros);
+export const useCreatePomodoro = () =>
+  useStore((state) => state.createPomodoro);
 
 export default useStore;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #108 

## 📝 작업 내용
### 뽀모도로 Store 구현 및 더미데이터 분리
더미데이터로 뽀모도로 데이터 조회 및 생성&삭제 기능을 구현하기 위해 뽀모도로 Store를 정의했습니다. (`@/store/pomodoro.ts`)
뽀모도로 데이터는 더미데이터 관련 폴더에 옮겼습니다! (`@/mock/pomodoro.ts`)

더미데이터에 정의한 변수로 처리되도록 파일의 일부분들이 수정되었습니다. (`response` -> `pomodoroMockData`)

### 뽀모도로 생성 기능 추가
뽀모도로 store 함수에, 뽀모도로 생성 기능을 추가하였습니다. -> `@/store/pomodoro.ts` 파일의 `createPomodoro` 함수

뽀모도로 페이지에서 별도로 생성되는 뽀모도로는 아이젠하워 관련 데이터가 들어있지 않으므로, 이를 적용하여서 입력된 데이터 값으로 새로운 아이젠하워를 생성하도록 처리했습니다. 
현재 ID값은 nanoid 라이브러리를 활용하고 있는데, string으로 생성돼서 일단 `parseInt(nanoid(8), 36) % 10000;` 이렇게 처리해놨습니다. 추후에 백엔드 연동 작업하면 어차피 nanoid는 활용되지 않으므로 임시 구현된 부분이라고 생각해주세요!

뽀모도로가 생성되면, 새로 생성된 뽀모도로 페이지로 이동하도록 처리했습니다. 

### 뽀모도로 삭제 기능 추가
뽀모도로 store 함수에, 뽀모도로 삭제 기능을 추가하였습니다. -> `@/store/pomodoro.ts` 파일의 `deletePomodoro` 함수

삭제되면 `/pomodoro` 로 redirect 합니다. 

## 💬 리뷰 요구사항(선택)
- 뽀모도로 조회&생성&삭제가 잘 되는지만 확인해주면 됩니다 😄 
- 아이젠하워가 완성되지 않은 시점에서, 처리할 수 있는 부분은 뽀모도로 페이지에서 별도로 생성되는 뽀모도로 처리와 삭제 부분이어서 이 부분 적용했습니다! 아이젠하워와 관련된 부분은 다운님 작업이 완료되면 모두 작업될 예정입니다.
- 아이젠하워 실행 완료 부분은, 시연 부분에서 처리될 부분은 아닐 것 같아서 더미데이터 처리는 배제했습니다. API 연동 작업 때 바로 작업합시다! 


