### PR TITLE
[FE] style: 헤더, 사이드바, 서브 사이드바 스타일 수정

### DIFF
--- a/frontend/src/components/ui/SubSidebarAccordion.tsx
+++ b/frontend/src/components/ui/SubSidebarAccordion.tsx
@@ -21,7 +21,7 @@ export function SubSidebarAccordion({
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value={value}>
-        <AccordionTrigger className="hover:no-underline cursor-pointer pt-2.5 pb-2.5">
+        <AccordionTrigger className="hover:no-underline cursor-pointer">
           <div className="flex items-center gap-2">
             {icon}
             <span className="text-[18px] font-semibold">{title}</span>

--- a/frontend/src/components/ui/header/Header.tsx
+++ b/frontend/src/components/ui/header/Header.tsx
@@ -2,7 +2,7 @@ import { Bell, Search, Settings } from 'lucide-react';
 
 export default function Header() {
   return (
-    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5] z-100">
+    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5] z-10">
       <div className="flex-1 max-w-md">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5" />

--- a/frontend/src/components/ui/header/Header.tsx
+++ b/frontend/src/components/ui/header/Header.tsx
@@ -2,18 +2,20 @@ import { Bell, Search, Settings } from 'lucide-react';
 
 export default function Header() {
   return (
-    <header className="px-10 py-5 h-[84px] flex items-center justify-between border-b">
+    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5]">
       <div className="flex-1 max-w-md">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5" />
           <input
             type="text"
             placeholder="검색어를 입력하세요"
-            className="w-full bg-[#f2f2f2] rounded-full py-[10px] pl-10 pr-4 text-sm focus:outline-none"
+            className="w-full bg-[#f2f2f2] rounded-full py-[7px] pl-10 pr-4 text-sm focus:outline-none"
           />
         </div>
       </div>
-      <div className="flex items-center gap-[30px]">
+      <div className="flex items-center gap-[20px]">
+        <div>
+        </div>
         <button className="cursor-pointer">
           <Settings className="w-5 h-5 text-gray-600" />
         </button>

--- a/frontend/src/components/ui/header/Header.tsx
+++ b/frontend/src/components/ui/header/Header.tsx
@@ -2,7 +2,7 @@ import { Bell, Search, Settings } from 'lucide-react';
 
 export default function Header() {
   return (
-    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5]">
+    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5] z-100">
       <div className="flex-1 max-w-md">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5" />

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -54,7 +54,7 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
   return (
     <div
       className={cn(
-        'flex flex-col gap-[5px] p-5 rounded-md  cursor-pointer border-b hover:bg-[rgba(123,104,238,0.1)] transition-colors group',
+        'flex flex-col gap-[5px] p-5 cursor-pointer border-b  transition-colors group',
           cardBg
       )}
       onClick={(e) => pomodoroClick(e)}

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -67,7 +67,7 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
               className={'close-button cursor-pointer hidden group-hover:block'}
               onClick={deletePomodoro}
             >
-              <X className="w-5 h-5 text-gray-700" />
+              <X className=" text-gray-700" size={18}/>
             </button>
           }
           linkedUnlinkedPomodoro={item}

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -48,17 +48,19 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
     navigate(`/pomodoro/${id}`);
   };
 
+  const cardBg = selected ? 'bg-[#ECE5FF] rounded-lg' : 'bg-white';
+
+
   return (
     <div
       className={cn(
-        'flex flex-col gap-2.5 p-5 rounded-md  cursor-pointer hover:bg-[rgba(123,104,238,0.1)] transition-colors group',
-        selected &&
-          'bg-[rgba(123,104,238,0.2)] hover:bg-[rgba(123,104,238,0.2)]',
+        'flex flex-col gap-[5px] p-5 rounded-md  cursor-pointer border-b hover:bg-[rgba(123,104,238,0.1)] transition-colors group',
+          cardBg
       )}
       onClick={(e) => pomodoroClick(e)}
     >
       <div className="flex justify-between pl-1">
-        <p className="font-semibold text-lg">{item.pomodoro.title}</p>
+        <p className="font-semibold text-[16px]">{item.pomodoro.title}</p>
         <DeletePomodoro
           trigger={
             <button
@@ -75,14 +77,14 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
       </div>
 
       {item.eisenhower && (
-        <div className="flex justify-end gap-2 w-full items-center">
-          <Link className="text-[#9F4BC9] w-4 h-4" />
-          <p className="text-[#9F4BC9] text-base">{item.eisenhower?.title}</p>
+        <div className="flex justify-end gap-1 w-full items-center">
+          <Link className="text-[#9F4BC9]" size={14} />
+          <p className="text-[#9F4BC9]  text-[14px]">{item.eisenhower?.title}</p>
         </div>
       )}
 
       <div className="px-1">
-        <p className="text-sm text-gray-500">
+        <p className="text-[14px] text-[#6E726E]">
           {formatToHourMin(item.pomodoro.totalExecutedTime)}
         </p>
       </div>

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function Sidebar() {
     <div className="flex h-screen">
       <div className="flex h-full relative">
         <aside className="w-[230px] bg-white border-r border-gray-[#E5E5E5] px-[15px] py-[10px] flex flex-col gap-[20px]">
-          <div className="flex items-center gap-2  h-[45px] pl-[10px] pt-[5px]">
+          <div className="flex items-center gap-2  h-[45px] pl-[12px] pt-[5px]">
             <div className="w-8 h-8 bg-black rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">★</span>
             </div>

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Network,
@@ -68,15 +67,15 @@ export default function Sidebar() {
   return (
     <div className="flex h-screen">
       <div className="flex h-full relative">
-        <aside className="w-[250px] bg-white border-r border-gray-300 px-[22px] py-[20px]">
-          <div className="flex items-center gap-2 mb-6">
+        <aside className="w-[230px] bg-white border-r border-gray-[#E5E5E5] px-[15px] py-[10px] flex flex-col gap-[20px]">
+          <div className="flex items-center gap-2  h-[45px] pl-[10px] pt-[5px]">
             <div className="w-8 h-8 bg-black rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">★</span>
             </div>
-            <span className="text-lg font-semibold">Flowin</span>
+            <span className="text-lg font-semibold">AHZ</span>
           </div>
 
-          <div className="overflow-hidden">
+          <div className="overflow-hidden flex flex-col gap-[5px]">
             {navItems.map((item) => (
               <button
                 key={item.id}
@@ -84,7 +83,7 @@ export default function Sidebar() {
                 className={cn(
                   'flex items-center w-full px-4 py-3 gap-2 text-left transition rounded-md cursor-pointer relative group',
                   activeId === item.id
-                    ? 'bg-[#8F5AFF] text-white font-semibold'
+                    ? 'bg-[#8F5AFF] text-white'
                     : 'text-black hover:bg-gray-50',
                 )}
               >
@@ -104,8 +103,8 @@ export default function Sidebar() {
         {activeItemHasPanel && (
           <div
             className={cn(
-              'h-full bg-white border-r border-gray-300 transition-all duration-300 ease-in-out overflow-hidden',
-              panelVisible ? 'w-[300px] opacity-100' : 'w-0 opacity-0',
+              'h-full bg-white transition-all duration-300 ease-in-out overflow-hidden border-none',
+              panelVisible ? 'w-[300px] opacity-100' : 'w-0 opacity-0 border-r border-gray-300',
             )}
           >
             {activeId && <SubSidebar activeId={activeId} />}

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -12,13 +12,7 @@ import { useSidebarStore } from '@/store/sidebarStore';
 import SubSidebar from '@/components/ui/sidebar/subSidebar/SubSidebar';
 
 const navItems = [
-  {
-    id: 'todayList',
-    icon: <LayoutDashboard size={24} />,
-    label: '오늘의 할 일',
-    route: '/today',
-    hasPanel: false,
-  },
+
   {
     id: 'matrix',
     icon: <Grid2x2 size={24} />,

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -16,7 +16,7 @@ export default function CommonSubSidebarWrapper({
   const { setPanelVisible } = useSidebarStore();
 
   return (
-    <div className="relative w-[300px] border-r  h-full overflow-y-auto  ">
+    <div className="relative w-[300px] border-r  h-full overflow-y-auto scrollbar-hide ">
       <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
         <h2 className="font-bold text-lg">{title}</h2>
         <div className="flex items-center gap-[5px]">
@@ -29,8 +29,10 @@ export default function CommonSubSidebarWrapper({
           </button>
         </div>
       </div>
+      <div className="bg-[linear-gradient(to_bottom,_white,_transparent)] fixed top-[55px] w-[300px] h-[15px] z-10"></div>
 
-      <div className="px-[15px] py-[10px] gap-2.5">{children}</div>
+
+      <div className="px-[15px] py-[10px] gap-2.5" >{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -16,21 +16,21 @@ export default function CommonSubSidebarWrapper({
   const { setPanelVisible } = useSidebarStore();
 
   return (
-    <div className="relative w-[300px] border-r bg-white h-full overflow-y-auto">
-      <div className="p-4 h-[84px] flex items-center justify-between mb-4 border-b border-gray-300">
+    <div className="relative w-[300px] border-r  h-full overflow-y-auto  ">
+      <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
         <h2 className="font-bold text-lg">{title}</h2>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-[5px]">
           {addButton && <div>{addButton}</div>}
           <button
             onClick={() => setPanelVisible(false)}
             className="cursor-pointer"
           >
-            <ChevronsLeft size={20} />
+            <ChevronsLeft size={24} />
           </button>
         </div>
       </div>
 
-      <div className="p-4">{children}</div>
+      <div className="px-[15px] py-[10px] gap-2.5">{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -18,7 +18,7 @@ export default function CommonSubSidebarWrapper({
   return (
     <div className="relative w-[300px] border-r  h-full overflow-y-auto scrollbar-hide ">
       <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
-        <h2 className="font-bold text-lg">{title}</h2>
+        <h2 className="font-semibold text-lg">{title}</h2>
         <div className="flex items-center gap-[5px]">
           {addButton && <div>{addButton}</div>}
           <button
@@ -32,7 +32,7 @@ export default function CommonSubSidebarWrapper({
       <div className="bg-[linear-gradient(to_bottom,_white,_transparent)] fixed top-[55px] w-[300px] h-[15px] z-10"></div>
 
 
-      <div className="px-[15px] py-[10px] gap-2.5" >{children}</div>
+      <div className="px-[15px] py-[20px]" >{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -25,7 +25,7 @@ export default function CommonSubSidebarWrapper({
             onClick={() => setPanelVisible(false)}
             className="cursor-pointer"
           >
-            <ChevronsLeft size={24} />
+            <ChevronsLeft size={22} />
           </button>
         </div>
       </div>

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
@@ -26,7 +26,7 @@ export default function MindmapAddButton() {
 
   return (
     <Modal
-      trigger={<Plus size={20} className="cursor-pointer" />}
+      trigger={<Plus size={22} className="cursor-pointer" />}
       title="마인드맵 생성하기"
       description={`해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
         질문을 통해 더 깊이 고민할 수 있도록 도와줄게요`}

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -5,8 +5,9 @@ import { cn } from '@/lib/utils';
 import { useDeleteMindMap } from '@/store/mindmapListStore';
 import { MindMap } from '@/types/mindMap';
 import { Link, X } from 'lucide-react';
+import { TypeBadge } from '@/components/eisenhower/filter/TypeBadge';
 
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import { MouseEvent } from 'react';
 
 type MindmapCardProps = {
@@ -52,23 +53,15 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
   return (
     <div
       className={cn(
-        'p-[20px] cursor-pointer transition border-b flex flex-col gap-[10px]',
+        'p-[20px] cursor-pointer transition border-b flex flex-col gap-[5px] relative group',
         cardBg,
       )}
       onClick={handleClick}
     >
       <div className="flex items-center justify-between">
-        <div
-          className={cn(
-            'inline-flex items-center gap-1 px-2 py-1 rounded-full font-medium',
-            statusColor,
-          )}
-        >
-          <div className="w-[5px] h-[5px] rounded-full bg-primary-100" />
-          <p className="text-[12px] truncate">{type}</p>
-        </div>
+        <TypeBadge type={type}/>
         <Modal
-          trigger={<X size={16} className="close-button text-gray-700" />}
+          trigger={<X size={16} className="close-button text-gray-700 hidden group-hover:block" />}
           title="이 마인드맵을 삭제할까요?"
           description="해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
             질문을 통해 더 깊이 고민할 수 있도록 도와줄게요"
@@ -94,16 +87,16 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
         </Modal>
       </div>
 
-      <div className="font-heading-4 font-bold text-[18px]">{title}</div>
+      <div className="font-heading-4 font-semibold text-[16px] pl-1">{title}</div>
 
       {linked && (
-        <div className="flex items-center justify-end gap-1 text-primary-100">
+        <div className="flex items-center justify-end gap-1 text-[#9F4BC9]">
           <Link size={14} />
           <p>linked todo</p>
         </div>
       )}
 
-      <p className="text-[14px] text-gray-700">
+      <p className="text-[14px] text-[#6E726E]">
         최종 수정: {formatDate(lastModifiedAt)}
       </p>
     </div>

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -61,7 +61,7 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
       <div className="flex items-center justify-between">
         <TypeBadge type={type}/>
         <Modal
-          trigger={<X size={16} className="close-button text-gray-700 hidden group-hover:block" />}
+          trigger={<X size={18} className="close-button text-gray-700 hidden group-hover:block" />}
           title="이 마인드맵을 삭제할까요?"
           description="해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
             질문을 통해 더 깊이 고민할 수 있도록 도와줄게요"

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapSubSidebar.tsx
@@ -17,37 +17,39 @@ export default function MindmapSubSidebar() {
 
   return (
     <CommonSubSidebarWrapper title="마인드맵" addButton={<MindmapAddButton />}>
-      <SubSidebarAccordion
-        value="linked"
-        icon={<Link className="w-4 h-4" />}
-        title="연결된 마인드맵"
-      >
-        <div className="space-y-4">
-          {connectedMindMaps.map((mindmap) => (
-            <MindmapCard
-              key={mindmap.id}
-              mindmap={mindmap}
-              selected={id === mindmap.id}
-            />
-          ))}
-        </div>
-      </SubSidebarAccordion>
+      <div className="flex flex-col gap-5">
+        <SubSidebarAccordion
+          value=" linked"
+          icon={<Link className=" w-4 h-4" />}
+          title=" 연결된 마인드맵"
+        >
+          <div className=" space-y-2">
+            {connectedMindMaps.map((mindmap) => (
+              <MindmapCard
+                key={mindmap.id}
+                mindmap={mindmap}
+                selected={id === mindmap.id}
+              />
+            ))}
+          </div>
+        </SubSidebarAccordion>
 
-      <SubSidebarAccordion
-        value="unlinked"
-        icon={<Unlink className="w-4 h-4" />}
-        title="자유로운 마인드맵"
-      >
-        <div className="space-y-4">
-          {freeMindMaps.map((mindmap) => (
-            <MindmapCard
-              key={mindmap.id}
-              mindmap={mindmap}
-              selected={id === mindmap.id}
-            />
-          ))}
-        </div>
-      </SubSidebarAccordion>
+        <SubSidebarAccordion
+          value=" unlinked"
+          icon={<Unlink className=" w-4 h-4" />}
+          title=" 자유로운 마인드맵"
+        >
+          <div className=" space-y-2">
+            {freeMindMaps.map((mindmap) => (
+              <MindmapCard
+                key={mindmap.id}
+                mindmap={mindmap}
+                selected={id === mindmap.id}
+              />
+            ))}
+          </div>
+        </SubSidebarAccordion>
+      </div>
     </CommonSubSidebarWrapper>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
@@ -15,7 +15,7 @@ export default function PomodoroSubSidebar() {
     <CommonSubSidebarWrapper
       title="뽀모도로"
       addButton={
-        <AddPomodoro trigger={<Plus size={24} className="cursor-pointer" />} />
+        <AddPomodoro trigger={<Plus size={22} className="cursor-pointer" />} />
       }
     >
       <div>

--- a/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
@@ -18,12 +18,13 @@ export default function PomodoroSubSidebar() {
         <AddPomodoro trigger={<Plus size={22} className="cursor-pointer" />} />
       }
     >
-      <div>
+      <div className="flex flex-col gap-5">
         <SubSidebarAccordion
           value="linked"
           icon={<LinkIcon className="w-4 h-4" />}
           title="연결된 뽀모도로"
         >
+          <div className=" space-y-2">
           {pomodoros.linkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
@@ -31,12 +32,14 @@ export default function PomodoroSubSidebar() {
               selected={item.pomodoro.id === Number(id)}
             />
           ))}
+      </div>
         </SubSidebarAccordion>
         <SubSidebarAccordion
           value="unlinked"
           icon={<Unlink className="w-4 h-4" />}
           title="자유로운 뽀모도로"
         >
+          <div className=" space-y-2">
           {pomodoros.unlinkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
@@ -44,6 +47,7 @@ export default function PomodoroSubSidebar() {
               selected={item.pomodoro.id === Number(id)}
             />
           ))}
+          </div>
         </SubSidebarAccordion>
       </div>
     </CommonSubSidebarWrapper>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -54,3 +54,7 @@
   --color-question-input-hover: rgba(0, 0, 0, 0.02);
   --color-question-input-active: rgba(0, 0, 0, 0.05);
 }
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#114 

## 📝 작업 내용

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/12be43ca-3a9e-438c-9830-845539722c39" />

사이드바 크기 수정, 서브사이드바, item 통일, 스크롤바 제거 및 블러 추가, 헤더 크기 수정 등
헤더, 사이드바, 서브사이드바, item에 대한 스타일을 수정했습니다.

## 💬 리뷰 요구사항(선택)

구조상으로 크게 달라진 것은 없습니다.
마인드맵 item에 badge 컴포넌트로 적용해두었습니다!
다른 페이지 수정 필요 사항은 정리해서 곧 공유해드리도록 하겠습니다 :)