### PR TITLE
[FE] style: 뽀모도로 관련 페이지, 모달 스타일링 수정

### DIFF
--- a/frontend/src/components/eisenhower/card/TaskCard.tsx
+++ b/frontend/src/components/eisenhower/card/TaskCard.tsx
@@ -7,12 +7,14 @@ import { TypeBadge } from '@/components/eisenhower/filter/TypeBadge';
 import { CategoryBadge } from '@/components/eisenhower/filter/CategoryBadge';
 import { getCategoryNameById } from '@/utils/category';
 import { format } from 'date-fns';
+import { cn } from '@/lib/utils.ts';
 
 interface TaskCardProps {
   task: Task;
   onClick?: () => void;
   layout?: 'matrix' | 'board';
   dragHandle?: 'full';
+  className?: string;
 }
 
 export function TaskCard({
@@ -20,6 +22,7 @@ export function TaskCard({
   onClick,
   layout = 'matrix',
   dragHandle,
+  className,
 }: TaskCardProps) {
   const { id, title, memo, dueDate, type, categoryId } = task;
   const { categories } = useCategoryStore();
@@ -41,14 +44,14 @@ export function TaskCard({
   };
 
   return (
-    <div className="py-1 group">
+    <div className='py-1 group w-full'>
       <div
         ref={setNodeRef}
         style={style}
         {...attributes}
         {...(dragHandle === 'full' ? listeners : {})}
         onClick={handleClick}
-        className={`bg-white rounded-md p-3 ${
+        className={cn(`bg-white rounded-md p-3 ${
           layout === 'board' ? 'w-full' : ''
         } ${
           isDragging
@@ -58,7 +61,8 @@ export function TaskCard({
           dragHandle === 'full'
             ? 'cursor-grab active:cursor-grabbing'
             : 'cursor-pointer'
-        } hover:shadow-md flex flex-col relative`}
+        } hover:shadow-md flex flex-col relative`,
+          className)}
       >
         {dragHandle !== 'full' && (
           <div

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-[33px] rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
@@ -100,7 +100,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn('text-[24px] leading-none font-semibold', className)}
       {...props}
     />
   );
@@ -113,7 +113,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-muted-foreground text-[16px] leading-[140%] font-normal text-[#6E726E]', className)}
       {...props}
     />
   );

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -100,7 +100,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-[24px] leading-none font-semibold', className)}
+      className={cn('text-[28px] leading-none font-semibold', className)}
       {...props}
     />
   );

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       data-slot="input"
       className={cn(
         'border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus:border-black focus:border-2 focus:outline-none',
+        'focus:border-black focus:border-1 focus:outline-none',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className,
       )}

--- a/frontend/src/components/ui/Modal/AddPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/AddPomodoro.tsx
@@ -244,7 +244,7 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
               </div>
             )}
             <div className="flex flex-col gap-[10px]">
-              <div className=" bg-[#F2F2F2] rounded-[10px] px-[25px] py-[20px] h-[87px]">
+              <div className=" bg-[#F2F2F2] rounded-[7px] px-[25px] py-[20px] h-[87px]">
                 <MultiSlider
                   min={0}
                   max={totalTime}

--- a/frontend/src/components/ui/Modal/AddPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/AddPomodoro.tsx
@@ -126,8 +126,17 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
         <div className="w-full flex justify-end">
           {page === 0 ? (
             <Button
-              className="px-8"
+              size="sm"
               onClick={() => setPage(1)}
+              variant={
+                linkedEisenhower?.id
+                  ? hours !== 0 || minutes !== 0
+                    ? 'black'
+                    : 'disabled'
+                  : title?.trim() && (hours !== 0 || minutes !== 0)
+                    ? 'black'
+                    : 'disabled'
+              }
               disabled={
                 linkedEisenhower?.id
                   ? hours === 0 && minutes === 0
@@ -139,8 +148,9 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
           ) : (
             <div className="flex w-full justify-between gap-4">
               <Button
+                size="sm"
                 variant="white"
-                className="px-8 flex-1"
+                className="flex-1"
                 onClick={() => {
                   setPage(0);
                 }}
@@ -149,7 +159,8 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
               </Button>
               <DialogClose asChild>
                 <Button
-                  className="px-8 w-full flex-1"
+                    size="sm"
+                  className=" w-full flex-1"
                   onClick={handleCreatePomodoro}
                 >
                   다음
@@ -229,7 +240,7 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
             ) : (
               <div className="flex px-4 py-4 border-1 border-[#E5E5E5] gap-2.5 rounded-[10px]">
                 <Timer className="text-primary-100" />
-                <p className="text-[16px] font-semibold">{title}</p>
+                <p className="text-[16px] h-[18px] font-semibold">{title}</p>
               </div>
             )}
             <div className="flex flex-col gap-[10px]">

--- a/frontend/src/components/ui/Modal/DeletePomodoro.tsx
+++ b/frontend/src/components/ui/Modal/DeletePomodoro.tsx
@@ -42,12 +42,13 @@ export default function DeletePomodoro({
         <div className="w-full flex justify-end">
           <div className="flex w-full justify-between gap-4">
             <DialogClose asChild>
-              <Button variant="white" className="px-8 flex-1">
+              <Button size="sm" variant="white" className="px-8 flex-1">
                 취소하기
               </Button>
             </DialogClose>
             <DialogClose asChild>
               <Button
+                size="sm"
                 className="px-8 w-full flex-1"
                 onClick={handleDeletePomodoro}
               >
@@ -63,14 +64,14 @@ export default function DeletePomodoro({
           {eisenhower ? (
             <div className="h-[153px] border-1"></div>
           ) : (
-            <div className="flex px-4 py-4 border-1 border-[#E5E5E5] gap-2.5 rounded-[10px]">
+            <div className="flex px-4 py-4 border-1 border-[#E5E5E5] gap-2.5 rounded-[7px]">
               <Timer className="text-primary-100" />
               <p className="text-[16px] font-semibold">title</p>
             </div>
           )}
           {pomodoro.executedCycles.length > 0 ? (
             <div className="flex flex-col gap-[10px]">
-              <div className=" bg-[#F2F2F2] rounded-[10px] px-[25px] py-[20px] h-[87px]">
+              <div className=" bg-[#F2F2F2] rounded-[7px] px-[25px] py-[20px] h-[87px]">
                 <MultiSlider
                   min={0}
                   max={totalExecutedTime}

--- a/frontend/src/components/ui/Modal/EndPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/EndPomodoro.tsx
@@ -38,15 +38,22 @@ export default function EndPomodoro({
           <div className="flex w-full flex items-center justify-between gap-4">
             <DialogClose asChild>
               <Button
+                size="sm"
                 variant="white"
-                className="px-8 flex-1"
+                className="flex-1"
                 onClick={() => handleContinue(true)}
               >
                 취소하기
               </Button>
             </DialogClose>
             <DialogClose asChild>
-              <Button className="px-8 w-full flex-1" onClick={finishPomodoro}>완료하기</Button>
+              <Button
+                size="sm"
+                className="w-full flex-1"
+                onClick={finishPomodoro}
+              >
+                완료하기
+              </Button>
             </DialogClose>
           </div>
         </div>
@@ -56,13 +63,13 @@ export default function EndPomodoro({
         {eisenhower ? (
           <div className="h-[153px] border-1"></div>
         ) : (
-          <div className="flex px-4 py-4 border-1 border-[#E5E5E5] gap-2.5 rounded-[10px]">
+          <div className="flex px-4 py-4 border-1 border-[#E5E5E5] gap-2.5 rounded-[7px] items-center">
             <Timer className="text-primary-100" />
-            <p className="text-[16px] font-semibold">title</p>
+            <p className="text-[16px] h-[18px] font-semibold">title</p>
           </div>
         )}
         <div className="flex flex-col gap-[10px]">
-          <div className="bg-[#F2F2F2] rounded-[10px] px-[25px] py-[20px] h-[87px]">
+          <div className="bg-[#F2F2F2] rounded-[7px] px-[25px] py-[20px] h-[87px]">
             <MultiSlider
               min={0}
               max={totalExecutedTime}

--- a/frontend/src/components/ui/MultiSlider.tsx
+++ b/frontend/src/components/ui/MultiSlider.tsx
@@ -158,19 +158,20 @@ const MultiSlider = React.forwardRef<
               }}
             >
               {/*  칸의 시간 글씨 보이는 기준*/}
-              {(intervals.length <= 1 || interval.duration >= 5) && (
-                <span
-                  style={{
-                    color:
-                      interval.type === 'focus'
-                        ? style?.fontColor || 'black'
-                        : 'black',
-                  }}
-                >
-                  {interval.type === 'focus' ? '집중' : '휴식'}{' '}
-                  {interval.duration}분
-                </span>
-              )}
+              {(intervals.length <= 1 || interval.duration >= 5) &&
+                interval.type == 'focus' && (
+                  <span
+                    style={{
+                      color:
+                        interval.type === 'focus'
+                          ? style?.fontColor || 'black'
+                          : 'black',
+                    }}
+                  >
+                    {interval.type === 'focus' ? '집중' : '휴식'}{' '}
+                    {interval.duration}분
+                  </span>
+                )}
             </div>
           ))}
           <SliderPrimitive.Root

--- a/frontend/src/components/ui/MultiSlider.tsx
+++ b/frontend/src/components/ui/MultiSlider.tsx
@@ -171,7 +171,7 @@ const MultiSlider = React.forwardRef<
                   }}
                 >
                   {interval.type === 'focus' ? '집중' : '휴식'}{' '}
-                  {interval.duration}분
+                  {Math.floor(interval.duration)}분
                 </span>
               ) : (
                 <Tooltip>
@@ -180,7 +180,7 @@ const MultiSlider = React.forwardRef<
                   </TooltipTrigger>
                   <TooltipContent side="top" sideOffset={4}>
                     {interval.type === 'focus' ? '집중' : '휴식'}{' '}
-                    {interval.duration}분
+                    {Math.floor(interval.duration)}분
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/frontend/src/components/ui/MultiSlider.tsx
+++ b/frontend/src/components/ui/MultiSlider.tsx
@@ -2,6 +2,11 @@ import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { cn } from '@/lib/utils';
 import { PomodoroCycle } from '@/types/pomodoro';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip';
 
 type MultiSliderProps = {
   cycles: PomodoroCycle[];
@@ -157,21 +162,28 @@ const MultiSlider = React.forwardRef<
                 fontSize: 'clamp(10px, 2vh, 16px)',
               }}
             >
-              {/*  칸의 시간 글씨 보이는 기준*/}
-              {(intervals.length <= 1 || interval.duration >= 5) &&
-                interval.type == 'focus' && (
-                  <span
-                    style={{
-                      color:
-                        interval.type === 'focus'
-                          ? style?.fontColor || 'black'
-                          : 'black',
-                    }}
-                  >
+              {interval.widthPercent >= 10 ? (<span
+                  style={{
+                    color:
+                      interval.type === 'focus'
+                        ? style?.fontColor || 'black'
+                        : 'black',
+                  }}
+                >
+                  {interval.type === 'focus' ? '집중' : '휴식'}{' '}
+                  {interval.duration}분
+                </span>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="w-full h-full  z-10" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={4}>
                     {interval.type === 'focus' ? '집중' : '휴식'}{' '}
                     {interval.duration}분
-                  </span>
-                )}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
           ))}
           <SliderPrimitive.Root

--- a/frontend/src/components/ui/SubSidebarAccordion.tsx
+++ b/frontend/src/components/ui/SubSidebarAccordion.tsx
@@ -21,7 +21,7 @@ export function SubSidebarAccordion({
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value={value}>
-        <AccordionTrigger className="hover:no-underline cursor-pointer pt-2.5 pb-2.5">
+        <AccordionTrigger className="hover:no-underline cursor-pointer">
           <div className="flex items-center gap-2">
             {icon}
             <span className="text-[18px] font-semibold">{title}</span>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         black: 'bg-black text-white hover:bg-black/90',
         white: 'bg-white text-black border hover:bg-gray-100',
         primary: 'bg-button-primary text-white hover:bg-button-primary/90',
-        disabled: 'bg-button-disabled text-white hover:bg-button-disabled',
+        disabled: 'bg-button-disabled text-white hover:bg-[#CECFCD]',
 
         /* shadcn/ui 기본 variants */
         destructive:

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -26,9 +26,9 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        default: 'h-12 rounded-md w-[180px] ',
+        sm: 'h-[42px] rounded-md gap-1.5 w-[160px] ',
+        lg: 'h-12 rounded-md w-[180px] ',
         icon: 'size-9',
       },
     },

--- a/frontend/src/components/ui/header/Header.tsx
+++ b/frontend/src/components/ui/header/Header.tsx
@@ -2,18 +2,20 @@ import { Bell, Search, Settings } from 'lucide-react';
 
 export default function Header() {
   return (
-    <header className="px-10 py-5 h-[84px] flex items-center justify-between border-b">
+    <header className="px-7.5 py-2.5 h-[84px] flex items-center justify-between h-fit sticky top-0 w-full bg-white border-b border-b-[#E5E5E5]">
       <div className="flex-1 max-w-md">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5" />
           <input
             type="text"
             placeholder="검색어를 입력하세요"
-            className="w-full bg-[#f2f2f2] rounded-full py-[10px] pl-10 pr-4 text-sm focus:outline-none"
+            className="w-full bg-[#f2f2f2] rounded-full py-[7px] pl-10 pr-4 text-sm focus:outline-none"
           />
         </div>
       </div>
-      <div className="flex items-center gap-[30px]">
+      <div className="flex items-center gap-[20px]">
+        <div>
+        </div>
         <button className="cursor-pointer">
           <Settings className="w-5 h-5 text-gray-600" />
         </button>

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -67,7 +67,7 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
               className={'close-button cursor-pointer hidden group-hover:block'}
               onClick={deletePomodoro}
             >
-              <X className="w-5 h-5 text-gray-700" />
+              <X className=" text-gray-700" size={18}/>
             </button>
           }
           linkedUnlinkedPomodoro={item}

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -48,17 +48,19 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
     navigate(`/pomodoro/${id}`);
   };
 
+  const cardBg = selected ? 'bg-[#ECE5FF] rounded-lg' : 'bg-white';
+
+
   return (
     <div
       className={cn(
-        'flex flex-col gap-2.5 p-5 rounded-md  cursor-pointer hover:bg-[rgba(123,104,238,0.1)] transition-colors group',
-        selected &&
-          'bg-[rgba(123,104,238,0.2)] hover:bg-[rgba(123,104,238,0.2)]',
+        'flex flex-col gap-[5px] p-5 rounded-md  cursor-pointer border-b hover:bg-[rgba(123,104,238,0.1)] transition-colors group',
+          cardBg
       )}
       onClick={(e) => pomodoroClick(e)}
     >
       <div className="flex justify-between pl-1">
-        <p className="font-semibold text-lg">{item.pomodoro.title}</p>
+        <p className="font-semibold text-[16px]">{item.pomodoro.title}</p>
         <DeletePomodoro
           trigger={
             <button
@@ -75,14 +77,14 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
       </div>
 
       {item.eisenhower && (
-        <div className="flex justify-end gap-2 w-full items-center">
-          <Link className="text-[#9F4BC9] w-4 h-4" />
-          <p className="text-[#9F4BC9] text-base">{item.eisenhower?.title}</p>
+        <div className="flex justify-end gap-1 w-full items-center">
+          <Link className="text-[#9F4BC9]" size={14} />
+          <p className="text-[#9F4BC9]  text-[14px]">{item.eisenhower?.title}</p>
         </div>
       )}
 
       <div className="px-1">
-        <p className="text-sm text-gray-500">
+        <p className="text-[14px] text-[#6E726E]">
           {formatToHourMin(item.pomodoro.totalExecutedTime)}
         </p>
       </div>

--- a/frontend/src/components/ui/pomodoro/PomodoroResult.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroResult.tsx
@@ -42,7 +42,7 @@ export default function PomodoroResult({
           <h2 className="font-semibold text-[18px]">계획 실행 시간</h2>
           <div className="px-[17px] py-[20px] bg-[#F2F2F2] rounded-[10px] w-full">
             <div
-              className="flex gap-1.25 h-[66px]"
+              className="flex gap-1.25 h-[50px]"
               style={{ width: `${plannedTimeRatio * 100}%` }}
             >
               <MultiSlider
@@ -60,7 +60,7 @@ export default function PomodoroResult({
           <h2 className="font-semibold text-[18px]">실제 실행 시간</h2>
           <div className="px-[17px] py-[20px] bg-[#F2F2F2] rounded-[10px] w-full">
             <div
-              className="flex gap-1.25 h-[66px]"
+              className="flex gap-1.25 h-[50px]"
               style={{ width: `${executedTimeRatio * 100}%` }}
             >
               <MultiSlider

--- a/frontend/src/components/ui/pomodoro/PomodoroResult.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroResult.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button.tsx';
 import { MultiSlider } from '@/components/ui/MultiSlider.tsx';
 import { useState } from 'react';
 import DeletePomodoro from '@/components/ui/Modal/DeletePomodoro.tsx';
-
 export default function PomodoroResult({
   linkedUnlinkedPomodoro,
 }: {
@@ -125,7 +124,8 @@ export default function PomodoroResult({
       <div className="flex w-full justify-end">
         <DeletePomodoro
             trigger = {<Button
-                className="w-[180px] h-[48px] text-[16px] black"
+                size='lg'
+                className=" text-[16px] black"
                 onClick={deletePomodoro}
             >
                 삭제하기

--- a/frontend/src/components/ui/pomodoro/PomodoroTimer.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroTimer.tsx
@@ -285,7 +285,7 @@ export function PomodoroTimer({
   return (
     <div className="flex flex-col items-center">
       <>
-        <div className="relative w-[340px] h-[340px] mb-8">
+        <div className="relative w-[320px] h-[320px] mb-8">
           {/* Canvas로 타이머 그리기 */}
           <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
 

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function Sidebar() {
     <div className="flex h-screen">
       <div className="flex h-full relative">
         <aside className="w-[230px] bg-white border-r border-gray-[#E5E5E5] px-[15px] py-[10px] flex flex-col gap-[20px]">
-          <div className="flex items-center gap-2  h-[45px] pl-[10px] pt-[5px]">
+          <div className="flex items-center gap-2  h-[45px] pl-[12px] pt-[5px]">
             <div className="w-8 h-8 bg-black rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">★</span>
             </div>

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Network,
@@ -68,15 +67,15 @@ export default function Sidebar() {
   return (
     <div className="flex h-screen">
       <div className="flex h-full relative">
-        <aside className="w-[250px] bg-white border-r border-gray-300 px-[22px] py-[20px]">
-          <div className="flex items-center gap-2 mb-6">
+        <aside className="w-[230px] bg-white border-r border-gray-[#E5E5E5] px-[15px] py-[10px] flex flex-col gap-[20px]">
+          <div className="flex items-center gap-2  h-[45px] pl-[10px] pt-[5px]">
             <div className="w-8 h-8 bg-black rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">★</span>
             </div>
-            <span className="text-lg font-semibold">Flowin</span>
+            <span className="text-lg font-semibold">AHZ</span>
           </div>
 
-          <div className="overflow-hidden">
+          <div className="overflow-hidden flex flex-col gap-[5px]">
             {navItems.map((item) => (
               <button
                 key={item.id}
@@ -84,7 +83,7 @@ export default function Sidebar() {
                 className={cn(
                   'flex items-center w-full px-4 py-3 gap-2 text-left transition rounded-md cursor-pointer relative group',
                   activeId === item.id
-                    ? 'bg-[#8F5AFF] text-white font-semibold'
+                    ? 'bg-[#8F5AFF] text-white'
                     : 'text-black hover:bg-gray-50',
                 )}
               >
@@ -104,8 +103,8 @@ export default function Sidebar() {
         {activeItemHasPanel && (
           <div
             className={cn(
-              'h-full bg-white border-r border-gray-300 transition-all duration-300 ease-in-out overflow-hidden',
-              panelVisible ? 'w-[300px] opacity-100' : 'w-0 opacity-0',
+              'h-full bg-white transition-all duration-300 ease-in-out overflow-hidden border-none',
+              panelVisible ? 'w-[300px] opacity-100' : 'w-0 opacity-0 border-r border-gray-300',
             )}
           >
             {activeId && <SubSidebar activeId={activeId} />}

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -12,13 +12,7 @@ import { useSidebarStore } from '@/store/sidebarStore';
 import SubSidebar from '@/components/ui/sidebar/subSidebar/SubSidebar';
 
 const navItems = [
-  {
-    id: 'todayList',
-    icon: <LayoutDashboard size={24} />,
-    label: '오늘의 할 일',
-    route: '/today',
-    hasPanel: false,
-  },
+
   {
     id: 'matrix',
     icon: <Grid2x2 size={24} />,

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -16,7 +16,7 @@ export default function CommonSubSidebarWrapper({
   const { setPanelVisible } = useSidebarStore();
 
   return (
-    <div className="relative w-[300px] border-r  h-full overflow-y-auto  ">
+    <div className="relative w-[300px] border-r  h-full overflow-y-auto scrollbar-hide ">
       <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
         <h2 className="font-bold text-lg">{title}</h2>
         <div className="flex items-center gap-[5px]">
@@ -29,8 +29,10 @@ export default function CommonSubSidebarWrapper({
           </button>
         </div>
       </div>
+      <div className="bg-[linear-gradient(to_bottom,_white,_transparent)] fixed top-[55px] w-[300px] h-[15px] z-10"></div>
 
-      <div className="px-[15px] py-[10px] gap-2.5">{children}</div>
+
+      <div className="px-[15px] py-[10px] gap-2.5" >{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -16,21 +16,21 @@ export default function CommonSubSidebarWrapper({
   const { setPanelVisible } = useSidebarStore();
 
   return (
-    <div className="relative w-[300px] border-r bg-white h-full overflow-y-auto">
-      <div className="p-4 h-[84px] flex items-center justify-between mb-4 border-b border-gray-300">
+    <div className="relative w-[300px] border-r  h-full overflow-y-auto  ">
+      <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
         <h2 className="font-bold text-lg">{title}</h2>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-[5px]">
           {addButton && <div>{addButton}</div>}
           <button
             onClick={() => setPanelVisible(false)}
             className="cursor-pointer"
           >
-            <ChevronsLeft size={20} />
+            <ChevronsLeft size={24} />
           </button>
         </div>
       </div>
 
-      <div className="p-4">{children}</div>
+      <div className="px-[15px] py-[10px] gap-2.5">{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -18,7 +18,7 @@ export default function CommonSubSidebarWrapper({
   return (
     <div className="relative w-[300px] border-r  h-full overflow-y-auto scrollbar-hide ">
       <div className="p-[15px] h-[55px] flex items-center justify-between border-b border-[#E5E5E5] bg-[#ffffff] z-10 sticky top-0">
-        <h2 className="font-bold text-lg">{title}</h2>
+        <h2 className="font-semibold text-lg">{title}</h2>
         <div className="flex items-center gap-[5px]">
           {addButton && <div>{addButton}</div>}
           <button
@@ -32,7 +32,7 @@ export default function CommonSubSidebarWrapper({
       <div className="bg-[linear-gradient(to_bottom,_white,_transparent)] fixed top-[55px] w-[300px] h-[15px] z-10"></div>
 
 
-      <div className="px-[15px] py-[10px] gap-2.5" >{children}</div>
+      <div className="px-[15px] py-[20px]" >{children}</div>
     </div>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/CommonSubSidebarWrapper.tsx
@@ -25,7 +25,7 @@ export default function CommonSubSidebarWrapper({
             onClick={() => setPanelVisible(false)}
             className="cursor-pointer"
           >
-            <ChevronsLeft size={24} />
+            <ChevronsLeft size={22} />
           </button>
         </div>
       </div>

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
@@ -26,7 +26,7 @@ export default function MindmapAddButton() {
 
   return (
     <Modal
-      trigger={<Plus size={20} className="cursor-pointer" />}
+      trigger={<Plus size={22} className="cursor-pointer" />}
       title="마인드맵 생성하기"
       description={`해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
         질문을 통해 더 깊이 고민할 수 있도록 도와줄게요`}

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -5,8 +5,9 @@ import { cn } from '@/lib/utils';
 import { useDeleteMindMap } from '@/store/mindmapListStore';
 import { MindMap } from '@/types/mindMap';
 import { Link, X } from 'lucide-react';
+import { TypeBadge } from '@/components/eisenhower/filter/TypeBadge';
 
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import { MouseEvent } from 'react';
 
 type MindmapCardProps = {
@@ -52,23 +53,15 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
   return (
     <div
       className={cn(
-        'p-[20px] cursor-pointer transition border-b flex flex-col gap-[10px]',
+        'p-[20px] cursor-pointer transition border-b flex flex-col gap-[5px] relative group',
         cardBg,
       )}
       onClick={handleClick}
     >
       <div className="flex items-center justify-between">
-        <div
-          className={cn(
-            'inline-flex items-center gap-1 px-2 py-1 rounded-full font-medium',
-            statusColor,
-          )}
-        >
-          <div className="w-[5px] h-[5px] rounded-full bg-primary-100" />
-          <p className="text-[12px] truncate">{type}</p>
-        </div>
+        <TypeBadge type={type}/>
         <Modal
-          trigger={<X size={16} className="close-button text-gray-700" />}
+          trigger={<X size={16} className="close-button text-gray-700 hidden group-hover:block" />}
           title="이 마인드맵을 삭제할까요?"
           description="해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
             질문을 통해 더 깊이 고민할 수 있도록 도와줄게요"
@@ -94,16 +87,16 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
         </Modal>
       </div>
 
-      <div className="font-heading-4 font-bold text-[18px]">{title}</div>
+      <div className="font-heading-4 font-semibold text-[16px] pl-1">{title}</div>
 
       {linked && (
-        <div className="flex items-center justify-end gap-1 text-primary-100">
+        <div className="flex items-center justify-end gap-1 text-[#9F4BC9]">
           <Link size={14} />
           <p>linked todo</p>
         </div>
       )}
 
-      <p className="text-[14px] text-gray-700">
+      <p className="text-[14px] text-[#6E726E]">
         최종 수정: {formatDate(lastModifiedAt)}
       </p>
     </div>

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -61,7 +61,7 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
       <div className="flex items-center justify-between">
         <TypeBadge type={type}/>
         <Modal
-          trigger={<X size={16} className="close-button text-gray-700 hidden group-hover:block" />}
+          trigger={<X size={18} className="close-button text-gray-700 hidden group-hover:block" />}
           title="이 마인드맵을 삭제할까요?"
           description="해야 할 일이나 생각이 떠올랐다면 여기 적어보세요! 
             질문을 통해 더 깊이 고민할 수 있도록 도와줄게요"

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapSubSidebar.tsx
@@ -17,37 +17,39 @@ export default function MindmapSubSidebar() {
 
   return (
     <CommonSubSidebarWrapper title="마인드맵" addButton={<MindmapAddButton />}>
-      <SubSidebarAccordion
-        value="linked"
-        icon={<Link className="w-4 h-4" />}
-        title="연결된 마인드맵"
-      >
-        <div className="space-y-4">
-          {connectedMindMaps.map((mindmap) => (
-            <MindmapCard
-              key={mindmap.id}
-              mindmap={mindmap}
-              selected={id === mindmap.id}
-            />
-          ))}
-        </div>
-      </SubSidebarAccordion>
+      <div className="flex flex-col gap-5">
+        <SubSidebarAccordion
+          value=" linked"
+          icon={<Link className=" w-4 h-4" />}
+          title=" 연결된 마인드맵"
+        >
+          <div className=" space-y-2">
+            {connectedMindMaps.map((mindmap) => (
+              <MindmapCard
+                key={mindmap.id}
+                mindmap={mindmap}
+                selected={id === mindmap.id}
+              />
+            ))}
+          </div>
+        </SubSidebarAccordion>
 
-      <SubSidebarAccordion
-        value="unlinked"
-        icon={<Unlink className="w-4 h-4" />}
-        title="자유로운 마인드맵"
-      >
-        <div className="space-y-4">
-          {freeMindMaps.map((mindmap) => (
-            <MindmapCard
-              key={mindmap.id}
-              mindmap={mindmap}
-              selected={id === mindmap.id}
-            />
-          ))}
-        </div>
-      </SubSidebarAccordion>
+        <SubSidebarAccordion
+          value=" unlinked"
+          icon={<Unlink className=" w-4 h-4" />}
+          title=" 자유로운 마인드맵"
+        >
+          <div className=" space-y-2">
+            {freeMindMaps.map((mindmap) => (
+              <MindmapCard
+                key={mindmap.id}
+                mindmap={mindmap}
+                selected={id === mindmap.id}
+              />
+            ))}
+          </div>
+        </SubSidebarAccordion>
+      </div>
     </CommonSubSidebarWrapper>
   );
 }

--- a/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
@@ -15,7 +15,7 @@ export default function PomodoroSubSidebar() {
     <CommonSubSidebarWrapper
       title="뽀모도로"
       addButton={
-        <AddPomodoro trigger={<Plus size={24} className="cursor-pointer" />} />
+        <AddPomodoro trigger={<Plus size={22} className="cursor-pointer" />} />
       }
     >
       <div>

--- a/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar.tsx
@@ -18,12 +18,13 @@ export default function PomodoroSubSidebar() {
         <AddPomodoro trigger={<Plus size={22} className="cursor-pointer" />} />
       }
     >
-      <div>
+      <div className="flex flex-col gap-5">
         <SubSidebarAccordion
           value="linked"
           icon={<LinkIcon className="w-4 h-4" />}
           title="연결된 뽀모도로"
         >
+          <div className=" space-y-2">
           {pomodoros.linkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
@@ -31,12 +32,14 @@ export default function PomodoroSubSidebar() {
               selected={item.pomodoro.id === Number(id)}
             />
           ))}
+      </div>
         </SubSidebarAccordion>
         <SubSidebarAccordion
           value="unlinked"
           icon={<Unlink className="w-4 h-4" />}
           title="자유로운 뽀모도로"
         >
+          <div className=" space-y-2">
           {pomodoros.unlinkedPomodoros?.map((item) => (
             <PomodoroItem
               key={item.pomodoro.id}
@@ -44,6 +47,7 @@ export default function PomodoroSubSidebar() {
               selected={item.pomodoro.id === Number(id)}
             />
           ))}
+          </div>
         </SubSidebarAccordion>
       </div>
     </CommonSubSidebarWrapper>

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -7,7 +7,7 @@ export default function DefaultLayout() {
     <div className="flex h-screen">
       <Sidebar />
 
-      <main className="flex-1 overflow-auto bg-white scrollbar-hide">
+      <main className="flex flex-col w-full min-h-0 overflow-auto bg-white scrollbar-hide">
         <Header />
         <section >
           <Outlet />

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -7,7 +7,7 @@ export default function DefaultLayout() {
     <div className="flex h-screen">
       <Sidebar />
 
-      <main className="flex-1 overflow-auto bg-white">
+      <main className="flex-1 overflow-auto bg-white scrollbar-hide">
         <Header />
         <section >
           <Outlet />

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -9,7 +9,7 @@ export default function DefaultLayout() {
 
       <main className="flex-1 overflow-auto bg-white">
         <Header />
-        <section className="px-10 py-[50px]">
+        <section >
           <Outlet />
         </section>
       </main>

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -7,9 +7,9 @@ export default function DefaultLayout() {
     <div className="flex h-screen">
       <Sidebar />
 
-      <main className="flex flex-col w-full min-h-0 overflow-auto bg-white scrollbar-hide">
+      <main className="flex flex-col w-full h-screen overflow-auto bg-white scrollbar-hide">
         <Header />
-        <section >
+        <section className="overflow-auto" >
           <Outlet />
         </section>
       </main>

--- a/frontend/src/pages/pomodoro.tsx
+++ b/frontend/src/pages/pomodoro.tsx
@@ -4,6 +4,7 @@ import { LinkedUnlinkedPomodoro } from '@/types/pomodoro';
 import { useParams, useNavigate } from 'react-router';
 import { useEffect } from 'react';
 import { usePomodoros } from '@/store/pomodoro';
+import { TaskCard } from '@/components/eisenhower/card/TaskCard.tsx';
 
 export default function Pomodoro() {
   const { id } = useParams();
@@ -36,11 +37,11 @@ export default function Pomodoro() {
     }
   }, [id, data, linkedPomodoros, unlinkedPomodoros, navigate]);
   return (
-    <div className="flex min-h-screen bg-white">
+    <div className="flex min-h-screen bg-white p-[30px]">
       <div className="flex-1">
-        <main className="flex flex-col gap-[50px]">
-          <div className="flex-1 flex-col gap-[25px]">
-            <h1 className="text-[40px] font-semibold">뽀모도로 실행</h1>
+        <main className="flex flex-col gap-[30px]">
+          <div className="flex-1 flex-col gap-[30px]">
+            <h1 className="text-[32px] font-semibold">뽀모도로 실행</h1>
             <p className="text-[16px] font-normal">
               성장한 뽀모도로 시간에 맞춰 집중과 휴식을 진행해보세요!
               <br />
@@ -49,9 +50,8 @@ export default function Pomodoro() {
           </div>
 
           <div className="flex flex-col items-center gap-[30px]">
-            {/*컴포넌트로 교체*/}
             {data?.eisenhower ? (
-              <div className="h-[153px] w-full border"></div>
+                <TaskCard task={data?.eisenhower} className='hover:shadow-none cursor-default'/>
             ) : null}
             {data?.pomodoro?.executedCycles?.length ? (
               <PomodoroResult linkedUnlinkedPomodoro={data} />

--- a/frontend/src/pages/pomodoro.tsx
+++ b/frontend/src/pages/pomodoro.tsx
@@ -37,11 +37,11 @@ export default function Pomodoro() {
     }
   }, [id, data, linkedPomodoros, unlinkedPomodoros, navigate]);
   return (
-    <div className="flex min-h-screen bg-white p-[30px]">
+    <div className="flex min-h-0 flex-1 bg-white p-[30px]">
       <div className="flex-1">
-        <main className="flex flex-col gap-[30px]">
-          <div className="flex-1 flex-col gap-[30px]">
-            <h1 className="text-[32px] font-semibold">뽀모도로 실행</h1>
+        <main className="flex flex-1 min-h-0 flex-col gap-[30px] h-full">
+          <div className=" flex-col gap-[10px] flex">
+            <h1 className="text-[32px] font-semibold h-[32px]">뽀모도로 실행</h1>
             <p className="text-[16px] font-normal text-[#6E726E]">
               성장한 뽀모도로 시간에 맞춰 집중과 휴식을 진행해보세요!
               <br />
@@ -49,7 +49,7 @@ export default function Pomodoro() {
             </p>
           </div>
 
-          <div className="flex flex-col items-center gap-[30px]">
+          <div className="flex flex-col items-center gap-[30px] min-h-0 flex-1 justify-center" >
             {data?.eisenhower ? (
                 <TaskCard task={data?.eisenhower} className='hover:shadow-none cursor-default'/>
             ) : null}

--- a/frontend/src/pages/pomodoro.tsx
+++ b/frontend/src/pages/pomodoro.tsx
@@ -40,7 +40,7 @@ export default function Pomodoro() {
     <div className="flex min-h-0 flex-1 bg-white p-[30px]">
       <div className="flex-1">
         <main className="flex flex-1 min-h-0 flex-col gap-[30px] h-full">
-          <div className=" flex-col gap-[10px] flex">
+          <div className=" flex-col gap-[15px] flex">
             <h1 className="text-[32px] font-semibold h-[32px]">뽀모도로 실행</h1>
             <p className="text-[16px] font-normal text-[#6E726E]">
               성장한 뽀모도로 시간에 맞춰 집중과 휴식을 진행해보세요!

--- a/frontend/src/pages/pomodoro.tsx
+++ b/frontend/src/pages/pomodoro.tsx
@@ -42,7 +42,7 @@ export default function Pomodoro() {
         <main className="flex flex-col gap-[30px]">
           <div className="flex-1 flex-col gap-[30px]">
             <h1 className="text-[32px] font-semibold">뽀모도로 실행</h1>
-            <p className="text-[16px] font-normal">
+            <p className="text-[16px] font-normal text-[#6E726E]">
               성장한 뽀모도로 시간에 맞춰 집중과 휴식을 진행해보세요!
               <br />
               집중 또는 휴식이 끝나면 종지 버튼을 눌러 주세요

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -54,3 +54,7 @@
   --color-question-input-hover: rgba(0, 0, 0, 0.02);
   --color-question-input-active: rgba(0, 0, 0, 0.05);
 }
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,60 +1,66 @@
 @import 'tailwindcss';
 
 @theme {
-  /* 공통 색상 */
-  --color-border-gray: #e3e3e3;
+    /* 공통 색상 */
+    --color-border-gray: #e3e3e3;
 
-  /* button 색상 */
-  --color-button-primary: #ffe277;
-  --color-button-disabled: #e7e7e7;
+    /* button 색상 */
+    --color-button-primary: #ffe277;
+    --color-button-disabled: #e7e7e7;
 
-  /* Gray Colors */
-  --color-gray-100: #fafafa;
-  --color-gray-200: #fafafa;
-  --color-gray-300: #e5e5e5;
-  --color-gray-400: #cecfcd;
-  --color-gray-500: #c8c8c8;
-  --color-gray-600: #aaaaaa;
-  --color-gray-700: #6e726e;
-  --color-gray-800: #3b3d3b;
+    /* Gray Colors */
+    --color-gray-100: #fafafa;
+    --color-gray-200: #fafafa;
+    --color-gray-300: #e5e5e5;
+    --color-gray-400: #cecfcd;
+    --color-gray-500: #c8c8c8;
+    --color-gray-600: #aaaaaa;
+    --color-gray-700: #6e726e;
+    --color-gray-800: #3b3d3b;
 
-  /* Primary Colors */
-  --color-primary-10: rgba(141, 92, 246, 0.1); /* opacity 10 */
-  --color-primary-20: rgba(141, 92, 246, 0.2); /* opacity 20 */
-  --color-primary-50: rgba(141, 92, 246, 0.5); /* opacity 50 */
-  --color-primary-70: rgba(141, 92, 246, 0.7); /* opacity 70 */
-  --color-primary-100: #8d5cf6;
+    /* Primary Colors */
+    --color-primary-10: rgba(141, 92, 246, 0.1); /* opacity 10 */
+    --color-primary-20: rgba(141, 92, 246, 0.2); /* opacity 20 */
+    --color-primary-50: rgba(141, 92, 246, 0.5); /* opacity 50 */
+    --color-primary-70: rgba(141, 92, 246, 0.7); /* opacity 70 */
+    --color-primary-100: #8d5cf6;
 
-  /*category chip bg color*/
-  --color-category-green: rgba(0, 184, 132, 0.2);
-  --color-category-gray: rgba(120, 119, 119, 0.2);
-  --color-category-yellow: rgba(255, 203, 17, 0.2);
-  --color-category-blue: rgba(70, 182, 254, 0.2);
-  --color-category-pink: rgba(255, 139, 195, 0.2);
-  --color-category-red: rgba(255, 30, 0, 0.2);
-  --color-category-orange: rgba(255, 132, 0, 0.2);
-  --color-category-brown: rgba(151, 75, 0, 0.2);
+    /*category chip bg color*/
+    --color-category-green: rgba(0, 184, 132, 0.2);
+    --color-category-gray: rgba(120, 119, 119, 0.2);
+    --color-category-yellow: rgba(255, 203, 17, 0.2);
+    --color-category-blue: rgba(70, 182, 254, 0.2);
+    --color-category-pink: rgba(255, 139, 195, 0.2);
+    --color-category-red: rgba(255, 30, 0, 0.2);
+    --color-category-orange: rgba(255, 132, 0, 0.2);
+    --color-category-brown: rgba(151, 75, 0, 0.2);
 
-  /* Font Sizes */
-  --font-heading-1: 32px;
-  --font-heading-2: 28px;
-  --font-heading-3: 22px;
-  --font-heading-4: 18px;
-  --font-heading-5: 16px;
-  --font-heading-6: 14px;
-  --font-body-1: 16px;
-  --font-body-2: 14px;
-  --font-body-3: 12px;
+    /* Font Sizes */
+    --font-heading-1: 32px;
+    --font-heading-2: 28px;
+    --font-heading-3: 22px;
+    --font-heading-4: 18px;
+    --font-heading-5: 16px;
+    --font-heading-6: 14px;
+    --font-body-1: 16px;
+    --font-body-2: 14px;
+    --font-body-3: 12px;
 
-  /* Font Family */
-  --font-primary: 'Inter', sans-serif;
+    /* Font Family */
+    --font-primary: 'Inter', sans-serif;
 
-  /* mindmap 관련 색상 */
-  --color-root-icon: #ffea9f;
-  --color-question-input-hover: rgba(0, 0, 0, 0.02);
-  --color-question-input-active: rgba(0, 0, 0, 0.05);
+    /* mindmap 관련 색상 */
+    --color-root-icon: #ffea9f;
+    --color-question-input-hover: rgba(0, 0, 0, 0.02);
+    --color-question-input-active: rgba(0, 0, 0, 0.05);
 }
 
 .scrollbar-hide::-webkit-scrollbar {
-  display: none;
+    display: none;
+}
+
+body {
+    font-family: 'Inter', sans-serif;
+    color:black;
+    font-weight: 400;
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -61,6 +61,6 @@
 
 body {
     font-family: 'Inter', sans-serif;
-    color:black;
+    color: black;
     font-weight: 400;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#115 

## 📝 작업 내용

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/9049d329-009e-420e-924a-6dfdebd1cadb" />
뽀모도로 페이지 (결과, 진행), 뽀모도로 모달 (생성, 삭제, 완료) 스타일링 수정했습니다.

- Dialog 전체 레이아웃 , 폰트 사이즈 수정
- Input active 상태 border 수정
- MultiSlider 숫자 버림 처리
- Button 사이즈 조절 (sm, lg), disable color 변경

## 💬 리뷰 요구사항(선택)
- TaskCard가 여기저기 동작없이 쓰이는 경우가 많아서 inactive variant로 하나 만들면 좋을 것 같습니다! 우선은 그냥 hover 스타일링 삭제해서 쓸 수 있도록 했는데 아이젠하워 수정하면서 구현되면 고쳐주세요!
- 사이드바 이슈랑 분리해서 작업했는데 push 하면서 섞여 들어간 것 같아요ㅠ! 충돌 날 수도...
- 색상 코드가 잘 못된건지 코드로 적혀있는데 디자인이랑 색상이 다르더라고요 확인 한번하고 나중에 정리해야 할 듯
