### PR TITLE
Qa/89 mindmap

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 *.local
 
+build
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/assets/q1.svg
+++ b/frontend/src/assets/q1.svg
@@ -1,0 +1,6 @@
+<svg width="26" height="25" viewBox="0 0 26 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.75 3.125V21.875" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="3.75" y="3" width="8" height="9" fill="#8D5CF6"/>
+<path d="M20.0417 3.125H5.45833C4.30774 3.125 3.375 4.05774 3.375 5.20833V19.7917C3.375 20.9423 4.30774 21.875 5.45833 21.875H20.0417C21.1923 21.875 22.125 20.9423 22.125 19.7917V5.20833C22.125 4.05774 21.1923 3.125 20.0417 3.125Z" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.375 12.5H22.125" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/q2.svg
+++ b/frontend/src/assets/q2.svg
@@ -1,0 +1,6 @@
+<svg width="26" height="25" viewBox="0 0 26 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.25 3.125V21.875" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.25 4H20.25C21.3546 4 22.25 4.89543 22.25 6V12H14.25V4Z" fill="#8D5CF6"/>
+<path d="M20.5417 3.125H5.95833C4.80774 3.125 3.875 4.05774 3.875 5.20833V19.7917C3.875 20.9423 4.80774 21.875 5.95833 21.875H20.5417C21.6923 21.875 22.625 20.9423 22.625 19.7917V5.20833C22.625 4.05774 21.6923 3.125 20.5417 3.125Z" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.875 12.5H22.625" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/q3.svg
+++ b/frontend/src/assets/q3.svg
@@ -1,0 +1,6 @@
+<svg width="26" height="25" viewBox="0 0 26 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.75 3.125V21.875" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.75 13H12.25V21.5H3.75V13Z" fill="#8D5CF6"/>
+<path d="M20.0417 3.125H5.45833C4.30774 3.125 3.375 4.05774 3.375 5.20833V19.7917C3.375 20.9423 4.30774 21.875 5.45833 21.875H20.0417C21.1923 21.875 22.125 20.9423 22.125 19.7917V5.20833C22.125 4.05774 21.1923 3.125 20.0417 3.125Z" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.375 12.5H22.125" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/q4.svg
+++ b/frontend/src/assets/q4.svg
@@ -1,0 +1,6 @@
+<svg width="26" height="25" viewBox="0 0 26 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.75 13H22.165V21.415H13.75V13Z" fill="#8D5CF6"/>
+<path d="M20.5417 3.125H5.95833C4.80774 3.125 3.875 4.05774 3.875 5.20833V19.7917C3.875 20.9423 4.80774 21.875 5.95833 21.875H20.5417C21.6923 21.875 22.625 20.9423 22.625 19.7917V5.20833C22.625 4.05774 21.6923 3.125 20.5417 3.125Z" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.25 3.21875V21.7812" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.96875 12.5H22.5312" stroke="#414141" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
+++ b/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
@@ -18,9 +18,13 @@ import { SECTION_TITLES } from '@/constants/eisenhower';
 import type { Category } from '@/types/category';
 import { Button } from '@/components/ui/button.tsx';
 import { useNavigate } from 'react-router';
-import { useCreateLinkedMindMap } from '@/store/mindmapListStore';
+import {
+  useCreateLinkedMindMap,
+  useDisconnectMindmapTask,
+} from '@/store/mindmapListStore';
 import useMatrixStore from '@/store/matrixStore';
 import AddPomodoro from '@/components/ui/Modal/AddPomodoro';
+import { useDisconnectPomodoroTask } from '@/store/pomodoro';
 
 interface TaskDetailSidebarProps {
   categories: Category[];
@@ -45,6 +49,9 @@ export function TaskDetailSidebar({
   const getActiveTask = useMatrixStore((state) => state.getActiveTask);
   const saveTask = useMatrixStore((state) => state.saveTask);
   const deleteTask = useMatrixStore((state) => state.deleteTask);
+
+  const disconnectMindMapTask = useDisconnectMindmapTask();
+  const disconnectPomodoroTask = useDisconnectPomodoroTask();
 
   const task = useMemo(() => {
     return getActiveTask();
@@ -78,7 +85,16 @@ export function TaskDetailSidebar({
 
   const handleDeleteTask = () => {
     if (task) {
-      deleteTask(task.id);
+      const { mindMapId, pomodoroId } = deleteTask(task.id);
+
+      if (mindMapId) {
+        disconnectMindMapTask(mindMapId);
+      }
+
+      // 포모도로 연결 해제
+      if (pomodoroId) {
+        disconnectPomodoroTask(pomodoroId as number);
+      }
     }
   };
 

--- a/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
+++ b/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
@@ -49,6 +49,9 @@ export function TaskDetailSidebar({
   const getActiveTask = useMatrixStore((state) => state.getActiveTask);
   const saveTask = useMatrixStore((state) => state.saveTask);
   const deleteTask = useMatrixStore((state) => state.deleteTask);
+  const connectTaskToMindMap = useMatrixStore(
+    (state) => state.connectTaskToMindMap,
+  );
 
   const disconnectMindMapTask = useDisconnectMindmapTask();
   const disconnectPomodoroTask = useDisconnectPomodoroTask();
@@ -122,6 +125,7 @@ export function TaskDetailSidebar({
     }
 
     const newMindmapId = createLinkedMindMap(task);
+    connectTaskToMindMap(task.id, newMindmapId);
     navigate(`/mindmap/${newMindmapId}`);
   };
 

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -8,9 +8,9 @@ import { X } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
 export default function QuestionListNode({
-                                           id,
-                                           data,
-                                         }: NodeProps<QuestionNodeType>) {
+  id,
+  data,
+}: NodeProps<QuestionNodeType>) {
   const nodes = useNodes();
   const edges = useEdges();
   const setNode = useSetNode();
@@ -20,13 +20,14 @@ export default function QuestionListNode({
   const isPending = data.isPending;
 
   const [displayedQuestions, setDisplayedQuestions] = useState<
-      Array<{
-        id: number;
-        text: string;
-        animating: boolean;
-      }>
+    Array<{
+      id: number;
+      text: string;
+      animating: boolean;
+    }>
   >([]);
   const [questionQueue, setQuestionQueue] = useState<string[]>([]);
+  const [hasFewQuestions, setHasFewQuestions] = useState(false);
 
   const handleQuestionClick = (selectedQuestion: string) => {
     const currentNode = nodes.find((node) => node.id === id);
@@ -44,6 +45,12 @@ export default function QuestionListNode({
   };
 
   useEffect(() => {
+    if (questions && questions.length <= 3) {
+      setHasFewQuestions(true);
+    } else {
+      setHasFewQuestions(false);
+    }
+
     if (questions && questions.length > 0) {
       const initial = questions.slice(0, 3).map((text, index) => ({
         id: index,
@@ -57,7 +64,7 @@ export default function QuestionListNode({
 
   const handleRemoveQuestion = (id: number) => {
     setDisplayedQuestions((prev) =>
-        prev.map((q) => (q.id === id ? { ...q, animating: true } : q)),
+      prev.map((q) => (q.id === id ? { ...q, animating: true } : q)),
     );
 
     setTimeout(() => {
@@ -103,67 +110,69 @@ export default function QuestionListNode({
 
   if (isPending) {
     return (
-        <div className="bg-white px-8 py-[30px] border-[1px] border-[#414141] rounded-[7px]">
-          <h3 className="text-[20px] font-semibold mb-5">질문 생성 중...</h3>
-          <ul className="flex flex-col gap-[10px]">
-            {[1, 2, 3].map((index) => (
-                <li
-                    key={index}
-                    className="w-[576px] p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center"
-                >
-                  <Skeleton className="w-full h-6" />
-                </li>
-            ))}
-            <li className="p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center opacity-50">
-              <span>직접 입력하기</span>
+      <div className="bg-white px-8 py-[30px] border-[1px] border-[#414141] rounded-[7px]">
+        <h3 className="text-[20px] font-semibold mb-5">질문 생성 중...</h3>
+        <ul className="flex flex-col gap-[10px]">
+          {[1, 2, 3].map((index) => (
+            <li
+              key={index}
+              className="w-[576px] p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center"
+            >
+              <Skeleton className="w-full h-6" />
             </li>
-          </ul>
+          ))}
+          <li className="p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center opacity-50">
+            <span>직접 입력하기</span>
+          </li>
+        </ul>
 
-          <NodeHandles />
-        </div>
+        <NodeHandles />
+      </div>
     );
   }
 
   return (
-      <>
-        <div className="bg-white px-8 py-[30px] border-[1px] border-[#414141] rounded-[7px]">
-          <h3 className="text-[20px] font-semibold mb-5">
-            다음 질문을 선택해주세요
-          </h3>
-          <ul className="flex flex-col gap-[10px]">
-            {displayedQuestions.map((question) => (
-                <li
-                    key={question.id}
-                    className={`w-[576px] p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center transition-all duration-300 hover:bg-question-input-hover active:bg-question-input-active cursor-pointer ${
-                        question.animating
-                            ? 'opacity-0 transform -translate-x-2'
-                            : 'opacity-100'
-                    }`}
-                    onClick={() => handleQuestionClick(question.text)}
-                >
-                  <span>{question.text}</span>
-                  <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRemoveQuestion(question.id);
-                      }}
-                      className="cursor-pointer"
-                      disabled={question.animating}
-                  >
-                    <X size={24} color="#414141" />
-                  </button>
-                </li>
-            ))}
+    <>
+      <div className="bg-white px-8 py-[30px] border-[1px] border-[#414141] rounded-[7px]">
+        <h3 className="text-[20px] font-semibold mb-5">
+          다음 질문을 선택해주세요
+        </h3>
+        <ul className="flex flex-col gap-[10px]">
+          {displayedQuestions.map((question) => (
             <li
-                onClick={activateDirectInputMode}
-                className="p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center cursor-pointer"
+              key={question.id}
+              className={`w-[576px] p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center transition-all duration-300 hover:bg-question-input-hover active:bg-question-input-active cursor-pointer ${
+                question.animating
+                  ? 'opacity-0 transform -translate-x-2'
+                  : 'opacity-100'
+              }`}
+              onClick={() => handleQuestionClick(question.text)}
             >
-              <span>직접 입력하기</span>
+              <span>{question.text}</span>
+              {!hasFewQuestions && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemoveQuestion(question.id);
+                  }}
+                  className="cursor-pointer"
+                  disabled={question.animating}
+                >
+                  <X size={24} color="#414141" />
+                </button>
+              )}
             </li>
-          </ul>
+          ))}
+          <li
+            onClick={activateDirectInputMode}
+            className="p-4 border-[1px] border-[#414141] rounded-[7px] flex justify-between items-center cursor-pointer"
+          >
+            <span>직접 입력하기</span>
+          </li>
+        </ul>
 
-          <NodeHandles />
-        </div>
-      </>
+        <NodeHandles />
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/reactFlow/ui/NodeSelectionPanel.tsx
+++ b/frontend/src/components/reactFlow/ui/NodeSelectionPanel.tsx
@@ -14,9 +14,19 @@ import {
 } from '@/store/nodeSelection';
 import useConvertScheduleToTodo from '@/hooks/queries/mindmap/useConvertScheduleToTodo';
 import { ConvertedToTaskReq } from '@/types/api/mindmap';
+import { useParams } from 'react-router';
+import { NodeToTaskModal } from '@/components/ui/Modal/NodeTaskModal';
 
 export function NodeSelectionPanel() {
   const [isOpen, setIsOpen] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [taskData, setTaskData] = useState<{
+    title: string;
+    id: string | number | null;
+  }>({ title: '', id: null });
+
+  const { id } = useParams<{ id: string }>();
+
   const selectedNodes = useSelectedNodes();
   const removeSelectedNode = useRemoveSelectedNode();
   const clearSelectedNodes = useClearSelectedNodes();
@@ -31,21 +41,22 @@ export function NodeSelectionPanel() {
   };
 
   const handleCreateSchedule = () => {
-    console.log('선택된 노드로 일정 생성:', selectedNodes);
-
     const requestData: ConvertedToTaskReq = {
       selectedNodes: selectedNodes.map((node) => ({
         summary: node.data.summary || node.data.label,
       })),
     };
 
-    /* 아이젠하워 개발 완료되면, 연결 시키는 부분 개발할 예정 */
     convertScheduleToTodoMutation(requestData, {
       onSuccess: (data) => {
-        console.log('data', data);
+        if (id) {
+          setTaskData({
+            title: data.task.title,
+            id: id,
+          });
 
-        clearSelectedNodes();
-        toggleNodeSelectionMode();
+          setIsDialogOpen(true);
+        }
       },
       onError: (error) => {
         console.error('할 일 생성 중 오류가 발생했습니다:', error);
@@ -54,74 +65,88 @@ export function NodeSelectionPanel() {
   };
 
   return (
-    <div className="w-[450px] fixed top-[65px] right-3 bg-white p-4 rounded-lg shadow-md border border-gray-200 z-[10]">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-semibold text-[18px]">일정으로 생성할 노드 선택</div>
-            <p className="text-sm text-[#6E726E]">
-              노드를 선택하여 하나의 일정으로 생성해 보세요
-            </p>
-          </div>
-          <CollapsibleTrigger asChild>
-            <Button variant="ghost" size="icon" className="p-0 h-8 w-8">
-              <ChevronUp
-                className={`h-5 w-5 transition-transform duration-200 ${isOpen ? '' : 'rotate-180'}`}
-              />
-            </Button>
-          </CollapsibleTrigger>
-        </div>
-
-        <CollapsibleContent className="transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-          {selectedNodes.length > 0 ? (
-            <ul className="flex-col space-y-1 mt-4 mb-4">
-              {selectedNodes.map((node) => (
-                <li
-                  key={node.id}
-                  className="flex items-center justify-between border-[#E5E5E5] border-[1px] px-[15px] py-[10px] rounded-[7px]"
-                >
-                  <p className="text-[14px]">{node.data.summary || node.data.label}</p>
-                  <X
-                    size={24}
-                    className="cursor-pointer hover:bg-gray-100 rounded-full p-1 transition-colors"
-                    onClick={() => removeSelectedNode(node.id)}
-                  />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="text-center p-4 mt-4 mb-4  text-[14px] text-[#6E726E]">
-              선택된 노드가 없습니다. 노드를 클릭하여 선택해주세요.
+    <>
+      <div className="w-[450px] fixed top-[65px] right-3 bg-white p-4 rounded-lg shadow-md border border-gray-200 z-[10]">
+        <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="font-semibold text-[18px]">
+                일정으로 생성할 노드 선택
+              </div>
+              <p className="text-sm text-[#6E726E]">
+                노드를 선택하여 하나의 일정으로 생성해 보세요
+              </p>
             </div>
-          )}
-
-          <div className="flex items-center gap-4">
-            <Button
-              size="sm"
-              variant="outline"
-              className="flex-1"
-              onClick={handleCancelSelection}
-            >
-              취소하기
-            </Button>
-            <Button
-              size="sm"
-              className="flex-1"
-              onClick={handleCreateSchedule}
-              variant={selectedNodes.length === 0 || isPending ?'disabled':'black' }
-            >
-              {isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />할 일 생성
-                  중...
-                </>
-              ) : (
-                '생성하기'
-              )}
-            </Button>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="p-0 h-8 w-8">
+                <ChevronUp
+                  className={`h-5 w-5 transition-transform duration-200 ${isOpen ? '' : 'rotate-180'}`}
+                />
+              </Button>
+            </CollapsibleTrigger>
           </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+
+          <CollapsibleContent className="transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+            {selectedNodes.length > 0 ? (
+              <ul className="flex-col space-y-1 mt-4 mb-4">
+                {selectedNodes.map((node) => (
+                  <li
+                    key={node.id}
+                    className="flex items-center justify-between border-[#E5E5E5] border-[1px] px-[15px] py-[10px] rounded-[7px]"
+                  >
+                    <p className="text-[14px]">
+                      {node.data.summary || node.data.label}
+                    </p>
+                    <X
+                      size={24}
+                      className="cursor-pointer hover:bg-gray-100 rounded-full p-1 transition-colors"
+                      onClick={() => removeSelectedNode(node.id)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-center p-4 mt-4 mb-4 text-[14px] text-[#6E726E]">
+                선택된 노드가 없습니다. 노드를 클릭하여 선택해주세요.
+              </div>
+            )}
+
+            <div className="flex items-center gap-4">
+              <Button
+                size="sm"
+                variant="outline"
+                className="flex-1"
+                onClick={handleCancelSelection}
+              >
+                취소하기
+              </Button>
+              <Button
+                size="sm"
+                className="flex-1"
+                onClick={handleCreateSchedule}
+                variant={
+                  selectedNodes.length === 0 || isPending ? 'disabled' : 'black'
+                }
+              >
+                {isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />할 일 생성
+                    중...
+                  </>
+                ) : (
+                  '생성하기'
+                )}
+              </Button>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+
+      <NodeToTaskModal
+        isOpen={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        taskData={taskData}
+      />
+    </>
   );
 }

--- a/frontend/src/components/ui/Modal/AddPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/AddPomodoro.tsx
@@ -103,7 +103,6 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
   };
 
   const handleCreatePomodoro = () => {
-    console.log('linkedEisenhower', linkedEisenhower);
     if (linkedEisenhower?.pomodoroId) {
       navigate(`/mindmap/${linkedEisenhower?.pomodoroId}`);
 

--- a/frontend/src/components/ui/Modal/AddPomodoro.tsx
+++ b/frontend/src/components/ui/Modal/AddPomodoro.tsx
@@ -3,15 +3,17 @@ import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronUp, Timer, RotateCw } from 'lucide-react';
 import { useState, useEffect, ChangeEvent, ReactNode } from 'react';
 import { MultiSlider } from '@/components/ui/MultiSlider.tsx';
-import { PomodoroCycle, Eisenhower } from '@/types/pomodoro';
+import { PomodoroCycle } from '@/types/pomodoro';
 import { Input } from '@/components/ui/Input.tsx';
 import { DialogClose } from '@radix-ui/react-dialog';
 import { useCreatePomodoro } from '@/store/pomodoro';
 import { useNavigate } from 'react-router';
+import { Task } from '@/types/task';
+import useMatrixStore from '@/store/matrixStore';
 
 type Props = {
   trigger: ReactNode;
-  linkedEisenhower?: Eisenhower;
+  linkedEisenhower?: Task;
 };
 
 export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
@@ -25,6 +27,10 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
   const navigate = useNavigate();
 
   const createPomodoro = useCreatePomodoro();
+
+  const connectTaskToPomodoro = useMatrixStore(
+    (state) => state.connectTaskToPomodoro,
+  );
 
   // 세션 간격 추천
   const generateSliderValuesFromTime = (hours: number, minutes: number) => {
@@ -97,6 +103,13 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
   };
 
   const handleCreatePomodoro = () => {
+    console.log('linkedEisenhower', linkedEisenhower);
+    if (linkedEisenhower?.pomodoroId) {
+      navigate(`/mindmap/${linkedEisenhower?.pomodoroId}`);
+
+      return;
+    }
+
     const newPomodoroId = createPomodoro({
       title: linkedEisenhower?.title || title,
       plannedCycles: cycleValue,
@@ -108,6 +121,7 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
       },
       eisenhower: linkedEisenhower || null,
     });
+    connectTaskToPomodoro(linkedEisenhower?.id, newPomodoroId);
 
     navigate(`/pomodoro/${newPomodoroId}`);
 
@@ -157,7 +171,7 @@ export default function AddPomodoro({ trigger, linkedEisenhower }: Props) {
               </Button>
               <DialogClose asChild>
                 <Button
-                    size="sm"
+                  size="sm"
                   className=" w-full flex-1"
                   onClick={handleCreatePomodoro}
                 >

--- a/frontend/src/components/ui/Modal/DeletePomodoro.tsx
+++ b/frontend/src/components/ui/Modal/DeletePomodoro.tsx
@@ -7,6 +7,7 @@ import { DialogClose } from '@radix-ui/react-dialog';
 import { ReactNode } from 'react';
 import { useDeletePomodoro } from '@/store/pomodoro';
 import { useNavigate } from 'react-router';
+import useMatrixStore from '@/store/matrixStore';
 
 export default function DeletePomodoro({
   trigger,
@@ -26,10 +27,13 @@ export default function DeletePomodoro({
   const navigate = useNavigate();
 
   const deletePomodoro = useDeletePomodoro();
+  const disconnectTaskFromPomodoro = useMatrixStore(
+    (state) => state.disconnectTaskFromPomodoro,
+  );
 
   const handleDeletePomodoro = () => {
-    // 삭제 api 추가
     deletePomodoro(pomodoro.id);
+    disconnectTaskFromPomodoro(eisenhower.id);
     navigate('/pomodoro');
   };
 

--- a/frontend/src/components/ui/Modal/NodeTaskModal.tsx
+++ b/frontend/src/components/ui/Modal/NodeTaskModal.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+  DialogFooter,
+} from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { CircleDashed, Tag, Calendar } from 'lucide-react';
+import { TypeBadge } from '@/components/eisenhower/filter/TypeBadge';
+import { CategoryBadge } from '@/components/eisenhower/filter/CategoryBadge';
+import { SingleDatePicker } from '@/components/eisenhower/filter/SingleDatePicker';
+import { useNavigate } from 'react-router';
+import useMatrixStore from '@/store/matrixStore';
+import {
+  useClearSelectedNodes,
+  useToggleNodeSelectionMode,
+} from '@/store/nodeSelection';
+import { Quadrant } from '@/types/task';
+
+import q1Image from '@/assets/q1.svg';
+import q2Image from '@/assets/q2.svg';
+import q3Image from '@/assets/q3.svg';
+import q4Image from '@/assets/q4.svg';
+
+type NodeToTaskModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskData: {
+    title: string;
+    id: string | number | null;
+  };
+};
+
+export function NodeToTaskModal({
+  isOpen,
+  onOpenChange,
+  taskData,
+}: NodeToTaskModalProps) {
+  const [dueDate, setDueDate] = useState<string>(
+    new Date().toISOString().split('T')[0],
+  );
+
+  const navigate = useNavigate();
+
+  const [priority, setPriority] = useState<Quadrant>('Q1');
+  const [memo, setMemo] = useState<string>('');
+
+  const { addTaskFromNode, setActiveTaskId } = useMatrixStore();
+  const clearSelectedNodes = useClearSelectedNodes();
+  const toggleNodeSelectionMode = useToggleNodeSelectionMode();
+
+  const handleConfirmCreateTask = () => {
+    if (taskData.id) {
+      const newTaskId = addTaskFromNode(
+        taskData.title,
+        taskData.id,
+        dueDate,
+        memo,
+        priority,
+      );
+
+      if (newTaskId) {
+        setActiveTaskId(newTaskId);
+
+        clearSelectedNodes();
+        toggleNodeSelectionMode();
+
+        navigate('/matrix');
+      }
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>새로운 일정 추가</DialogTitle>
+          <DialogDescription>
+            선택한 노드를 바탕으로 생성된 일정을 매트릭스에 추가해보세요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-4">
+          <div className="flex flex-col gap-[33px] px-[25px] py-[30px] border border-gray-300 rounded-[7px]">
+            <h3 className="text-[22px] font-semibold">{taskData.title}</h3>
+
+            <div className="flex flex-col gap-5">
+              <div className="flex items-center gap-1 mb-3">
+                <div className="w-24 flex items-center gap-1">
+                  <CircleDashed size={15} />
+                  <label className="text-[14px]">타입</label>
+                </div>
+                <TypeBadge type="TODO" />
+              </div>
+
+              <div className="flex items-center gap-1">
+                <div className="w-24 flex items-center gap-1">
+                  <Tag size={15} />
+                  <label className="text-[14px]">카테고리</label>
+                </div>
+                <CategoryBadge
+                  label="기타"
+                  colorClass="bg-yellow-100 text-yellow-600"
+                />
+              </div>
+
+              <div className="flex items-center gap-1">
+                <div className="w-24 flex items-center gap-1">
+                  <Calendar size={15} />
+                  <label className="text-[14px]">마감일</label>
+                </div>
+                <SingleDatePicker
+                  date={dueDate}
+                  onChange={(date) => setDueDate(date)}
+                />
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="w-24 flex items-center gap-1">
+                  <Calendar size={15} />
+                  <label className="text-[14px]">우선순위</label>
+                </div>
+                <div>
+                  <Tabs
+                    defaultValue="Q1"
+                    className="w-full"
+                    onValueChange={(value) => setPriority(value as Quadrant)}
+                  >
+                    <TabsList className="grid grid-cols-4 w-full h-10">
+                      <TabsTrigger value="Q1">
+                        <img src={q1Image} alt="q1" className="w-6 h-6" />
+                      </TabsTrigger>
+                      <TabsTrigger value="Q2">
+                        <img src={q2Image} alt="q1" className="w-6 h-6" />
+                      </TabsTrigger>
+                      <TabsTrigger value="Q3">
+                        <img src={q3Image} alt="q3" className="w-6 h-6" />
+                      </TabsTrigger>
+                      <TabsTrigger value="Q4">
+                        <img src={q4Image} alt="q4" className="w-6 h-6" />
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="w-24 flex items-center gap-1">
+                  <label className="text-[14px]">메모</label>
+                </div>
+                <div>
+                  <textarea
+                    placeholder="일정에 관한 메모를 입력하세요"
+                    className="w-full h-24 px-4 py-[14px] border border-gray-600 rounded-[6px] focus:outline-none resize-none text-[14px]"
+                    value={memo}
+                    onChange={(e) => setMemo(e.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="mt-6">
+          <div className="w-[180px] flex justify-end">
+            <DialogClose asChild>
+              <Button
+                size="sm"
+                variant="black"
+                className="flex-1"
+                onClick={handleConfirmCreateTask}
+              >
+                생성하기
+              </Button>
+            </DialogClose>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/Modal/NodeTaskModal.tsx
+++ b/frontend/src/components/ui/Modal/NodeTaskModal.tsx
@@ -41,7 +41,7 @@ export function NodeToTaskModal({
   onOpenChange,
   taskData,
 }: NodeToTaskModalProps) {
-  const [dueDate, setDueDate] = useState<string>(
+  const [dueDate, setDueDate] = useState<string | null>(
     new Date().toISOString().split('T')[0],
   );
 
@@ -56,7 +56,7 @@ export function NodeToTaskModal({
 
   const handleConfirmCreateTask = () => {
     if (taskData.id) {
-      const newTaskId = addTaskFromNode(
+      const newTask = addTaskFromNode(
         taskData.title,
         taskData.id,
         dueDate,
@@ -64,9 +64,8 @@ export function NodeToTaskModal({
         priority,
       );
 
-      if (newTaskId) {
-        setActiveTaskId(newTaskId);
-
+      if (newTask) {
+        setActiveTaskId(newTask.id);
         clearSelectedNodes();
         toggleNodeSelectionMode();
 

--- a/frontend/src/components/ui/Tabs.tsx
+++ b/frontend/src/components/ui/Tabs.tsx
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -23,8 +23,6 @@ function formatToHourMin(timeObj: TotalTime): string {
   return parts.join(' ');
 }
 
-const deletePomodoro = () => {};
-
 export function PomodoroItem({ item, selected }: PomodoroItemProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const setActiveTaskId = useMatrixStore((state) => state.setActiveTaskId);
@@ -63,6 +61,7 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
       navigate('/matrix');
     }
   };
+
   const cardBg = selected ? 'bg-[#ECE5FF] rounded-lg' : 'bg-white';
 
   return (
@@ -79,7 +78,6 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
           trigger={
             <button
               className={'close-button cursor-pointer hidden group-hover:block'}
-              onClick={deletePomodoro}
             >
               <X className=" text-gray-700" size={18} />
             </button>

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -20,14 +20,12 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
   const navigate = useNavigate();
   const deleteMindMap = useDeleteMindMap();
   const setActiveTaskId = useMatrixStore((state) => state.setActiveTaskId);
+  const disconnectTaskFromMindMap = useMatrixStore(
+    (state) => state.disconnectTaskFromMindMap,
+  );
 
   const { title, type, id, lastModifiedAt, linked, eisenhowerItemDTO } =
     mindmap;
-
-  const statusColor =
-    type === 'THINKING'
-      ? 'bg-purple-100 text-primary-100'
-      : 'bg-white border border-primary-100 text-primary-100';
 
   const cardBg = selected ? 'bg-[#ECE5FF] rounded-lg' : 'bg-white';
 
@@ -55,6 +53,7 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
 
   const handleDelete = () => {
     deleteMindMap(id);
+    disconnectTaskFromMindMap(eisenhowerItemDTO?.id);
     navigate('/mindmap');
   };
 
@@ -85,12 +84,18 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
           title="이 마인드맵을 삭제할까요?"
           description="해야 할 일이나 생각이 떠올랐다면 여기 적어보세요!
             질문을 통해 더 깊이 고민할 수 있도록 도와줄게요"
-          footer={<Button size='sm' onClick={handleDelete}>삭제하기</Button>}
+          footer={
+            <Button size="sm" onClick={handleDelete}>
+              삭제하기
+            </Button>
+          }
         >
           <div className="border-[1px] border-[#E5E5E5] p-[20px] rounded-[7px] flex flex-col gap-[10px]">
             <TypeBadge type={type} />
 
-            <div className="font-heading-4 font-semibold text-[18px] h-[18px]">{title}</div>
+            <div className="font-heading-4 font-semibold text-[18px] h-[18px]">
+              {title}
+            </div>
 
             <p className="text-[14px] text-[#6E726E]">
               최종 수정: {formatDate(lastModifiedAt)}

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,4 +1,3 @@
 export const ACCESS_TOKEN_KEY = 'accessToken';
 export const BASE_URL = import.meta.env.VITE_API_BASE_URL;
-export const GPT_BASE_URL =
-  import.meta.env.VITE_GPT_API_BASE_URL || 'http://3.36.179.66';
+export const GPT_BASE_URL = import.meta.env.VITE_GPT_API_BASE_URL;

--- a/frontend/src/pages/matrix.tsx
+++ b/frontend/src/pages/matrix.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { CompletedView } from '@/components/eisenhower/view/CompletedView.tsx';
 import { TaskDetailSidebar } from '@/components/eisenhower/TaskDetailSidebar';
@@ -65,6 +65,10 @@ export default function MatrixPage() {
     }),
     [uncompletedTasks],
   );
+
+  useEffect(() => {
+    setActiveTaskId(null);
+  }, [location.pathname]);
 
   return (
     <DndContext

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,5 +1,9 @@
 import FlowWrapper from '@/components/reactFlow/FlowWrapper';
 import { useMindMaps, useSetActiveMindMap } from '@/store/mindmapListStore';
+import {
+  useDisableSelectionMode,
+  useIsNodeSelectionMode,
+} from '@/store/nodeSelection';
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -8,6 +12,9 @@ export default function MindmapPage() {
   const setActiveMindMap = useSetActiveMindMap();
   const mindMaps = useMindMaps();
   const navigate = useNavigate();
+
+  const isNodeSelectionMode = useIsNodeSelectionMode();
+  const disableSelectionMode = useDisableSelectionMode();
 
   useEffect(() => {
     if (mindMaps.length === 0) {
@@ -38,9 +45,11 @@ export default function MindmapPage() {
     console.log('표시할 마인드맵이 없습니다');
   }, [id, mindMaps, navigate, setActiveMindMap]);
 
-  return (
-    <div className="h-full">
-      {id && <FlowWrapper mindmapId={id} />}
-    </div>
-  );
+  useEffect(() => {
+    if (isNodeSelectionMode) {
+      disableSelectionMode();
+    }
+  }, [location]);
+
+  return <div className="h-full">{id && <FlowWrapper mindmapId={id} />}</div>;
 }

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -49,7 +49,7 @@ export default function MindmapPage() {
     if (isNodeSelectionMode) {
       disableSelectionMode();
     }
-  }, [location]);
+  }, [location.pathname, id]);
 
   return <div className="h-full">{id && <FlowWrapper mindmapId={id} />}</div>;
 }

--- a/frontend/src/store/matrixStore.ts
+++ b/frontend/src/store/matrixStore.ts
@@ -4,6 +4,11 @@ import type { Task, TaskSections, Quadrant } from '@/types/task';
 import { toast } from 'sonner';
 import { nanoid } from 'nanoid/non-secure';
 
+type DeleteTaskResult = {
+  mindMapId: string | number | null;
+  pomodoroId: string | number | null;
+};
+
 export type MatrixState = {
   allTasks: Task[];
   tasksByQuadrant: TaskSections;
@@ -19,7 +24,7 @@ export type MatrixState = {
     memo: string,
     quadrant?: Quadrant,
   ) => Task;
-  deleteTask: (taskId: string | number) => void;
+  deleteTask: (taskId: string | number) => DeleteTaskResult;
   reorderTasks: (sectionId: Quadrant, newTasks: Task[]) => void;
   saveTask: (updatedTask: Task) => void;
   completeTask: (taskId: string | number) => void;
@@ -111,6 +116,11 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
   },
 
   deleteTask: (taskId) => {
+    const taskToDelete = get().allTasks.find((task) => task.id === taskId);
+
+    const mindMapId = taskToDelete?.mindMapId || null;
+    const pomodoroId = taskToDelete?.pomodoroId || null;
+
     set((state) => {
       const updatedTasks = state.allTasks.filter((task) => task.id !== taskId);
 
@@ -127,6 +137,11 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
     });
 
     toast.success('작업이 삭제되었습니다.');
+
+    return {
+      mindMapId,
+      pomodoroId,
+    };
   },
 
   reorderTasks: (sectionId, newTasks) =>

--- a/frontend/src/store/matrixStore.ts
+++ b/frontend/src/store/matrixStore.ts
@@ -28,6 +28,14 @@ export type MatrixState = {
   reorderTasks: (sectionId: Quadrant, newTasks: Task[]) => void;
   saveTask: (updatedTask: Task) => void;
   completeTask: (taskId: string | number) => void;
+  connectTaskToMindMap: (
+    taskId: string | number | null,
+    mindmapId: string | number | null,
+  ) => void;
+  connectTaskToPomodoro: (
+    taskId: string | number | null,
+    mindmapId: string | number | null,
+  ) => void;
 
   setActiveTaskId: (taskId: string | number | null) => void;
   getActiveTask: () => Task | null;
@@ -189,6 +197,42 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
         allTasks: updatedTasks,
       };
     }),
+
+  connectTaskToMindMap: (taskId, mindMapId) => {
+    set((state) => {
+      const updatedTasks = state.allTasks.map((task) =>
+        task.id === taskId ? { ...task, mindMapId } : task,
+      );
+
+      return {
+        allTasks: updatedTasks,
+        tasksByQuadrant: {
+          Q1: updatedTasks.filter((task) => task.quadrant === 'Q1'),
+          Q2: updatedTasks.filter((task) => task.quadrant === 'Q2'),
+          Q3: updatedTasks.filter((task) => task.quadrant === 'Q3'),
+          Q4: updatedTasks.filter((task) => task.quadrant === 'Q4'),
+        },
+      };
+    });
+  },
+
+  connectTaskToPomodoro: (taskId, pomodoroId) => {
+    set((state) => {
+      const updatedTasks = state.allTasks.map((task) =>
+        task.id === taskId ? { ...task, pomodoroId } : task,
+      );
+
+      return {
+        allTasks: updatedTasks,
+        tasksByQuadrant: {
+          Q1: updatedTasks.filter((task) => task.quadrant === 'Q1'),
+          Q2: updatedTasks.filter((task) => task.quadrant === 'Q2'),
+          Q3: updatedTasks.filter((task) => task.quadrant === 'Q3'),
+          Q4: updatedTasks.filter((task) => task.quadrant === 'Q4'),
+        },
+      };
+    });
+  },
 
   getTasksByQuadrant: () => {
     const { allTasks } = get();

--- a/frontend/src/store/matrixStore.ts
+++ b/frontend/src/store/matrixStore.ts
@@ -15,10 +15,10 @@ export type MatrixState = {
   addTaskFromNode: (
     title: string,
     mindmapNodeId: number | string,
-    duDate: string,
+    duDate: string | null,
     memo: string,
     quadrant?: Quadrant,
-  ) => number;
+  ) => Task;
   deleteTask: (taskId: string | number) => void;
   reorderTasks: (sectionId: Quadrant, newTasks: Task[]) => void;
   saveTask: (updatedTask: Task) => void;
@@ -107,7 +107,7 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
 
     toast.success('마인드맵에서 작업이 추가되었습니다.');
 
-    return id;
+    return newTask;
   },
 
   deleteTask: (taskId) => {

--- a/frontend/src/store/matrixStore.ts
+++ b/frontend/src/store/matrixStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { tasks, getTasksByQuadrant } from '@/mock/task';
 import type { Task, TaskSections, Quadrant } from '@/types/task';
 import { toast } from 'sonner';
+import { nanoid } from 'nanoid/non-secure';
 
 export type MatrixState = {
   allTasks: Task[];
@@ -11,6 +12,13 @@ export type MatrixState = {
   setTasks: (tasks: Task[]) => void;
   updateTask: (taskId: string | number, updatedTask: Task) => void;
   addTask: (newTask: Task) => void;
+  addTaskFromNode: (
+    title: string,
+    mindmapNodeId: number | string,
+    duDate: string,
+    memo: string,
+    quadrant?: Quadrant,
+  ) => number;
   deleteTask: (taskId: string | number) => void;
   reorderTasks: (sectionId: Quadrant, newTasks: Task[]) => void;
   saveTask: (updatedTask: Task) => void;
@@ -72,6 +80,35 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
         },
       };
     }),
+
+  addTaskFromNode: (title, mindmapId, dueDate, memo, quadrant = 'Q1') => {
+    const { addTask } = get();
+
+    const id = parseInt(nanoid(8), 36) % 10000;
+    const now = new Date();
+    const createdAt = now.toISOString();
+
+    const newTask: Task = {
+      id,
+      title,
+      memo,
+      category_id: 5,
+      quadrant,
+      type: 'TODO',
+      dueDate,
+      order: get().tasksByQuadrant[quadrant].length,
+      isCompleted: false,
+      createdAt,
+      mindMapId: mindmapId,
+      pomodoroId: null,
+    };
+
+    addTask(newTask);
+
+    toast.success('마인드맵에서 작업이 추가되었습니다.');
+
+    return id;
+  },
 
   deleteTask: (taskId) => {
     set((state) => {

--- a/frontend/src/store/matrixStore.ts
+++ b/frontend/src/store/matrixStore.ts
@@ -36,6 +36,8 @@ export type MatrixState = {
     taskId: string | number | null,
     mindmapId: string | number | null,
   ) => void;
+  disconnectTaskFromMindMap: (taskId: string) => void;
+  disconnectTaskFromPomodoro: (taskId: string) => void;
 
   setActiveTaskId: (taskId: string | number | null) => void;
   getActiveTask: () => Task | null;
@@ -220,6 +222,42 @@ const useMatrixStore = create<MatrixState>((set, get) => ({
     set((state) => {
       const updatedTasks = state.allTasks.map((task) =>
         task.id === taskId ? { ...task, pomodoroId } : task,
+      );
+
+      return {
+        allTasks: updatedTasks,
+        tasksByQuadrant: {
+          Q1: updatedTasks.filter((task) => task.quadrant === 'Q1'),
+          Q2: updatedTasks.filter((task) => task.quadrant === 'Q2'),
+          Q3: updatedTasks.filter((task) => task.quadrant === 'Q3'),
+          Q4: updatedTasks.filter((task) => task.quadrant === 'Q4'),
+        },
+      };
+    });
+  },
+
+  disconnectTaskFromMindMap: (taskId) => {
+    set((state) => {
+      const updatedTasks = state.allTasks.map((task) =>
+        task.id === taskId ? { ...task, mindMapId: null } : task,
+      );
+
+      return {
+        allTasks: updatedTasks,
+        tasksByQuadrant: {
+          Q1: updatedTasks.filter((task) => task.quadrant === 'Q1'),
+          Q2: updatedTasks.filter((task) => task.quadrant === 'Q2'),
+          Q3: updatedTasks.filter((task) => task.quadrant === 'Q3'),
+          Q4: updatedTasks.filter((task) => task.quadrant === 'Q4'),
+        },
+      };
+    });
+  },
+
+  disconnectTaskFromPomodoro: (taskId) => {
+    set((state) => {
+      const updatedTasks = state.allTasks.map((task) =>
+        task.id === taskId ? { ...task, pomodoroId: null } : task,
       );
 
       return {

--- a/frontend/src/store/mindmapListStore.ts
+++ b/frontend/src/store/mindmapListStore.ts
@@ -18,6 +18,7 @@ export type MindMapListState = {
     edges: MindMapEdge[],
   ) => void;
   deleteMindMap: (id: string) => void;
+  disconnectMindmapTask: (mindMapId: string | number) => void;
 };
 
 const useStore = create<MindMapListState>((set, get) => ({
@@ -122,6 +123,21 @@ const useStore = create<MindMapListState>((set, get) => ({
       activeMindMapId: newActiveMindMapId,
     });
   },
+
+  disconnectMindmapTask: (mindMapId) => {
+    const mindMapIndex = get().mindMaps.findIndex((m) => m.id === mindMapId);
+
+    if (mindMapIndex !== -1) {
+      const updatedMindMaps = [...get().mindMaps];
+      updatedMindMaps[mindMapIndex] = {
+        ...updatedMindMaps[mindMapIndex],
+        linked: false,
+        eisenhowerItemDTO: undefined,
+      };
+
+      set({ mindMaps: updatedMindMaps });
+    }
+  },
 }));
 
 export const useMindMaps = () => useStore((state) => state.mindMaps);
@@ -138,5 +154,7 @@ export const useSetActiveMindMap = () =>
 export const useSaveMindMapData = () =>
   useStore((state) => state.saveMindMapData);
 export const useDeleteMindMap = () => useStore((state) => state.deleteMindMap);
+export const useDisconnectMindmapTask = () =>
+  useStore((state) => state.disconnectMindmapTask);
 
 export default useStore;

--- a/frontend/src/store/mindmapListStore.ts
+++ b/frontend/src/store/mindmapListStore.ts
@@ -2,14 +2,14 @@ import { create } from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 import { MindMapNode, MindMap, TodoType, MindMapEdge } from '@/types/mindMap';
 import { mockMindMaps } from '@/mock/mindmap';
-import { TaskDetail } from '@/types/task';
+import { Task } from '@/types/task';
 
 export type MindMapListState = {
   mindMaps: MindMap[];
   activeMindMapId: string | null;
 
   createMindMap: (title: string, type: TodoType) => string;
-  createLinkedMindMap: (task: TaskDetail) => string;
+  createLinkedMindMap: (task: Task) => string;
   loadMindMapData: (id: string) => MindMap | null;
   setActiveMindMap: (id: string | null) => void;
   saveMindMapData: (

--- a/frontend/src/store/nodeSelection.ts
+++ b/frontend/src/store/nodeSelection.ts
@@ -9,6 +9,7 @@ interface NodeSelectionState {
   addSelectedNode: (node: MindMapNode) => void;
   removeSelectedNode: (nodeId: string) => void;
   clearSelectedNodes: () => void;
+  disableSelectionMode: () => void;
 }
 
 const useNodeSelectionStore = create<NodeSelectionState>((set) => ({
@@ -42,22 +43,25 @@ const useNodeSelectionStore = create<NodeSelectionState>((set) => ({
     })),
 
   clearSelectedNodes: () => set({ selectedNodes: [] }),
+
+  disableSelectionMode: () =>
+    set({
+      isNodeSelectionMode: false,
+      selectedNodes: [],
+    }),
 }));
 
 export const useIsNodeSelectionMode = () =>
   useNodeSelectionStore((state) => state.isNodeSelectionMode);
-
 export const useSelectedNodes = () =>
   useNodeSelectionStore((state) => state.selectedNodes);
-
 export const useToggleNodeSelectionMode = () =>
   useNodeSelectionStore((state) => state.toggleSelectionMode);
-
 export const useAddSelectedNode = () =>
   useNodeSelectionStore((state) => state.addSelectedNode);
-
 export const useRemoveSelectedNode = () =>
   useNodeSelectionStore((state) => state.removeSelectedNode);
-
 export const useClearSelectedNodes = () =>
   useNodeSelectionStore((state) => state.clearSelectedNodes);
+export const useDisableSelectionMode = () =>
+  useNodeSelectionStore((state) => state.disableSelectionMode);

--- a/frontend/src/store/pomodoro.ts
+++ b/frontend/src/store/pomodoro.ts
@@ -20,6 +20,7 @@ export type PomodoroListState = {
     eisenhower: Eisenhower | null;
   }) => string;
   deletePomodoro: (id: number) => void;
+  disconnectPomodoroTask: (pomodoroId: number) => void;
 };
 
 const useStore = create<PomodoroListState>((set) => ({
@@ -104,6 +105,39 @@ const useStore = create<PomodoroListState>((set) => ({
       return { pomodoros: updatedPomodoros };
     });
   },
+
+  disconnectPomodoroTask: (pomodoroId) => {
+    set((state) => {
+      const updatedPomodoros = { ...state.pomodoros };
+
+      if (updatedPomodoros.linkedPomodoros) {
+        const pomodoroIndex = updatedPomodoros.linkedPomodoros.findIndex(
+          (item) => item.pomodoro.id === pomodoroId,
+        );
+
+        if (pomodoroIndex !== -1) {
+          const pomodoro = updatedPomodoros.linkedPomodoros[pomodoroIndex];
+
+          const unlinkedPomodoro = {
+            pomodoro: pomodoro.pomodoro,
+            eisenhower: null,
+          };
+
+          updatedPomodoros.linkedPomodoros =
+            updatedPomodoros.linkedPomodoros.filter(
+              (item) => item.pomodoro.id !== pomodoroId,
+            );
+
+          updatedPomodoros.unlinkedPomodoros = [
+            ...(updatedPomodoros.unlinkedPomodoros || []),
+            unlinkedPomodoro,
+          ];
+        }
+      }
+
+      return { pomodoros: updatedPomodoros };
+    });
+  },
 }));
 
 export const usePomodoros = () => useStore((state) => state.pomodoros);
@@ -111,5 +145,7 @@ export const useCreatePomodoro = () =>
   useStore((state) => state.createPomodoro);
 export const useDeletePomodoro = () =>
   useStore((state) => state.deletePomodoro);
+export const useDisconnectPomodoroTask = () =>
+  useStore((state) => state.disconnectPomodoroTask);
 
 export default useStore;

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -1,4 +1,4 @@
-import { TaskDetail } from '@/types/task';
+import { Task } from '@/types/task';
 import { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
 
 export type TodoType = 'TODO' | 'THINKING';
@@ -36,5 +36,5 @@ export type MindMap = {
   nodes: MindMapNode[];
   edges: MindMapEdge[];
   linked: boolean;
-  eisenhowerItemDTO?: TaskDetail;
+  eisenhowerItemDTO?: Task;
 };

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -9,7 +9,7 @@ export interface Task {
   category_id: number | null;
   quadrant: Quadrant;
   type: ActualTaskType;
-  dueDate: string;
+  dueDate: string | null;
   order: number;
   isCompleted: boolean;
   createdAt: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #89 

## 📝 작업 내용
마인드맵 관련 QA를 진행했습니다. 

- [x] 노드 선택모드에서 URL 변경 시, 노드 선택 모드를 비활성화하도록 처리
- [x] 노드 선택 후 할 일 뽑아내고, 생성하는 기능 추가
- [x] 아이젠하워 Task 삭제 시, 연결된 마인드맵과 뽀모도로 연결 끊기
- [x] 마인드맵 or 뽀모도로 삭제 시, 아이젠하워 매트릭스 연결 끊기
- [x] 아이젠하워 매트릭스를 통해 마인드맵 & 뽀모도로 생성 시 연결되도록 처리
- [x] GPT BASE URL & gitignore 수정
- [x] 질문 목록 노드에서 질문 3개 이하일 때 x 아이콘 제거 -> 순환 안되도록 처리
