### PR TITLE
서브사이드바 관련 & 추가 수정사항 반영

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,17 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AHZ</title>
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="AHZ" />
+    <meta
+      property="og:description"
+      content="흩어진 생각을 정리하고, 일상 속 흐름을 바로 잡아주는 ADHD 맞춤형 서비스"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.ahz.co.kr/" />
+    <meta property="og:site_name" content="AHZ" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/ui/MultiSlider.tsx
+++ b/frontend/src/components/ui/MultiSlider.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-} from '@/components/ui/tooltip';
+} from '@/components/ui/Tooltip';
 
 type MultiSliderProps = {
   cycles: PomodoroCycle[];
@@ -162,7 +162,8 @@ const MultiSlider = React.forwardRef<
                 fontSize: 'clamp(10px, 2vh, 16px)',
               }}
             >
-              {interval.widthPercent >= 10 ? (<span
+              {interval.widthPercent >= 10 ? (
+                <span
                   style={{
                     color:
                       interval.type === 'focus'

--- a/frontend/src/components/ui/SubSidebarAccordion.tsx
+++ b/frontend/src/components/ui/SubSidebarAccordion.tsx
@@ -19,7 +19,7 @@ export function SubSidebarAccordion({
   children,
 }: SubSidebarAccordionProps) {
   return (
-    <Accordion type="single" collapsible>
+    <Accordion type="single" collapsible defaultValue={value}>
       <AccordionItem value={value}>
         <AccordionTrigger className="hover:no-underline cursor-pointer">
           <div className="flex items-center gap-2">

--- a/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
+++ b/frontend/src/components/ui/pomodoro/PomodoroItem.tsx
@@ -89,14 +89,14 @@ export function PomodoroItem({ item, selected }: PomodoroItemProps) {
       </div>
 
       {item.eisenhower && (
-        <div
-          onClick={handleLinkedTaskClick}
-          className="linked-icon flex justify-end gap-1 w-full items-center"
-        >
-          <Link className="text-[#9F4BC9]" size={14} />
-          <p className="text-[#9F4BC9]  text-[14px]">
-            {item.eisenhower?.title}
-          </p>
+        <div className="flex justify-end w-full">
+          <div
+            onClick={handleLinkedTaskClick}
+            className="linked-icon inline-flex items-center gap-1 text-[#9F4BC9] cursor-pointer"
+          >
+            <Link size={14} />
+            <p className="text-[14px]">{item.eisenhower?.title}</p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -1,18 +1,12 @@
 import { cn } from '@/lib/utils';
-import {
-  Network,
-  LayoutDashboard,
-  Grid2x2,
-  TimerReset,
-  ChevronsRight,
-} from 'lucide-react';
+import { Network, Grid2x2, TimerReset, ChevronsRight } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router';
 
 import { useSidebarStore } from '@/store/sidebarStore';
 import SubSidebar from '@/components/ui/sidebar/subSidebar/SubSidebar';
+import { useEffect } from 'react';
 
 const navItems = [
-
   {
     id: 'matrix',
     icon: <Grid2x2 size={24} />,
@@ -45,6 +39,12 @@ export default function Sidebar() {
     navItems.find((item) => location.pathname.includes(item.route)) || null;
   const activeId = activeItem?.id || null;
   const activeItemHasPanel = activeItem?.hasPanel || false;
+
+  useEffect(() => {
+    if (activeItemHasPanel) {
+      setPanelVisible(true);
+    }
+  }, [location.pathname, activeItemHasPanel, setPanelVisible]);
 
   const handleNavItemClick = (e: React.MouseEvent, route: string) => {
     const target = e.target as HTMLElement;
@@ -98,7 +98,9 @@ export default function Sidebar() {
           <div
             className={cn(
               'h-full bg-white transition-all duration-300 ease-in-out overflow-hidden border-none',
-              panelVisible ? 'w-[300px] opacity-100' : 'w-0 opacity-0 border-r border-gray-300',
+              panelVisible
+                ? 'w-[300px] opacity-100'
+                : 'w-0 opacity-0 border-r border-gray-300',
             )}
           >
             {activeId && <SubSidebar activeId={activeId} />}

--- a/frontend/src/components/ui/sidebar/subSidebar/SubSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/SubSidebar.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import MindmapSubSidebar from '@/components/ui/sidebar/subSidebar/mindmap/MindmapSubSidebar';
 import PomodoroSubSidebar from '@/components/ui/sidebar/subSidebar/pomodoro/PomodoroSubSidebar';
 

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapCard.tsx
@@ -109,12 +109,17 @@ export default function MindmapCard({ mindmap, selected }: MindmapCardProps) {
       </div>
 
       {linked && (
-        <div
-          onClick={handleLinkedTaskClick}
-          className="linked-icon flex items-center justify-end gap-1 text-[#9F4BC9]"
-        >
-          <Link size={14} />
-          <p>{eisenhowerItemDTO?.title}</p>
+        <div className="flex justify-end w-full">
+          <div
+            onClick={(e) => {
+              e.stopPropagation();
+              handleLinkedTaskClick();
+            }}
+            className="linked-icon items-center gap-1 text-[#9F4BC9] inline-flex"
+          >
+            <Link size={14} />
+            <p>{eisenhowerItemDTO?.title}</p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,3 +1,13 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
 export default function HomePage() {
+  const navigate = useNavigate();
+
+  // 임시로 matrix로 이동하도록 처리
+  useEffect(() => {
+    navigate('/matrix');
+  }, [navigate]);
+
   return <div>메인 페이지</div>;
 }

--- a/frontend/src/pages/matrix.tsx
+++ b/frontend/src/pages/matrix.tsx
@@ -65,10 +65,11 @@ export default function MatrixPage() {
     }),
     [uncompletedTasks],
   );
-
   useEffect(() => {
-    setActiveTaskId(null);
-  }, [location.pathname]);
+    if (!location.pathname.includes('/matrix')) {
+      setActiveTaskId(null);
+    }
+  }, [location, setActiveTaskId]);
 
   return (
     <DndContext

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 export default function RegisterPage() {
   const handleKakao = () => {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/kakao`;

--- a/frontend/src/store/sidebarStore.ts
+++ b/frontend/src/store/sidebarStore.ts
@@ -6,6 +6,6 @@ type SidebarState = {
 };
 
 export const useSidebarStore = create<SidebarState>((set) => ({
-  panelVisible: false,
+  panelVisible: true,
   setPanelVisible: (visible) => set({ panelVisible: visible }),
 }));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #127 

## 📝 작업 내용
- [x] 서브사이드바 아코디온 열려있는 것을 default로
- [x] 서브사이드바 초기값을 열린 상태로
- [x] 마인드맵 카드의 연결된 테스크 클릭 영역 수정
- [x] "/" 경로 접근 시 "/matrix"로 이동하도록 임시 처리