### PR TITLE
[FE] style: 아이젠하워 중간 발표 전 마지막 디자인 QA

### DIFF
--- a/frontend/src/components/eisenhower/AddTask.tsx
+++ b/frontend/src/components/eisenhower/AddTask.tsx
@@ -173,7 +173,6 @@ export function AddTask({
               </div>
             </div>
 
-            {/* 마감일 */}
             <div className="flex items-center gap-3">
               <span className="flex items-center gap-2 text-sm whitespace-nowrap">
                 <Calendar className="w-4 h-4" />
@@ -186,7 +185,6 @@ export function AddTask({
             </div>
           </div>
 
-          {/* 메모 입력 */}
           <div>
             <label className="text-sm block mb-1">메모</label>
             <textarea

--- a/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
+++ b/frontend/src/components/eisenhower/TaskDetailSidebar.tsx
@@ -302,8 +302,9 @@ export function TaskDetailSidebar({ categories }: TaskDetailSidebarProps) {
                 onClick={handleCreateMindmap}
                 className="flex-1 border rounded py-2"
               >
-                마인드맵 그리기
+                {task.mindMapId ? '마인드맵 이동하기' : '마인드맵 그리기'}
               </Button>
+
               {task.pomodoroId ? (
                 <Button
                   variant="primary"

--- a/frontend/src/components/eisenhower/filter/DateRangePicker.tsx
+++ b/frontend/src/components/eisenhower/filter/DateRangePicker.tsx
@@ -55,11 +55,11 @@ export function DateRangePicker({
       <PopoverTrigger asChild>
         <Button
           variant="primary"
-          className="flex items-center justify-between w-full md:w-auto min-w-[200px] bg-white shadow-none text-black p-0 hover:bg-white cursor-pointer"
+          className="flex items-center w-full md:w-auto min-w-[200px] bg-white shadow-none text-black p-0 hover:bg-white cursor-pointer"
         >
-          <div className="flex items-center">
-            <CalendarIcon className="mr-2 h-4 w-4 text-[#6e726e]" />
-            <span className="text-sm">{formatDateRange()}</span>
+          <div className="flex items-center gap-2 px-3 py-2">
+            <CalendarIcon className="w-4 h-4 text-[#6e726e] mb-1" />
+            <span className="text-sm leading-none">{formatDateRange()}</span>
           </div>
         </Button>
       </PopoverTrigger>

--- a/frontend/src/components/eisenhower/filter/SingleDatePicker.tsx
+++ b/frontend/src/components/eisenhower/filter/SingleDatePicker.tsx
@@ -37,7 +37,7 @@ export function SingleDatePicker({ date, onChange }: SingleDatePickerProps) {
           mode="single"
           selected={parsedDate ?? undefined}
           onSelect={(selected) => {
-            onChange(selected ? selected.toISOString().split('T')[0] : null);
+            onChange(selected ? format(selected, 'yyyy-MM-dd') : null);
           }}
           locale={ko}
         />

--- a/frontend/src/components/eisenhower/view/PriorityView.tsx
+++ b/frontend/src/components/eisenhower/view/PriorityView.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   DndContext,
   rectIntersection,
@@ -108,30 +108,6 @@ export function PriorityView({
       ? 'grid-cols-1 md:grid-cols-4'
       : 'grid-cols-1 md:grid-cols-2';
 
-  const quadrantIcons: Record<Quadrant, JSX.Element> = {
-    // 보드 숫자 아이콘
-    Q1: (
-      <div className="w-6 h-6 rounded-full border border-black flex items-center justify-center font-semibold text-sm">
-        1
-      </div>
-    ),
-    Q2: (
-      <div className="w-6 h-6 rounded-full border border-black flex items-center justify-center font-semibold text-sm">
-        2
-      </div>
-    ),
-    Q3: (
-      <div className="w-6 h-6 rounded-full border border-black flex items-center justify-center font-semibold text-sm">
-        3
-      </div>
-    ),
-    Q4: (
-      <div className="w-6 h-6 rounded-full border border-black flex items-center justify-center font-semibold text-sm">
-        4
-      </div>
-    ),
-  };
-
   type ViewMode = 'matrix' | 'board';
 
   const getQuadrantColors = (viewMode: ViewMode): Record<Quadrant, string> => {
@@ -192,22 +168,17 @@ export function PriorityView({
                 } min-h-[300px] flex flex-col ${quadrantColors[quadrant]}`}
               >
                 <div className="flex justify-between items-center pb-[14px]">
-                  <div className="flex gap-[5px] items-center justify-center">
-                    <div
-                      className={`${
-                        viewMode === 'board' ? 'w-5 h-5' : 'w-6 h-6'
-                      } `}
-                    >
-                      {quadrantIcons[quadrant]}
+                  <div className="flex items-center gap-2">
+                    <div className="w-6 h-6 flex items-center justify-center rounded-full border border-black text-sm font-semibold leading-none">
+                      {quadrant.replace('Q', '')}
                     </div>
+
                     <div
-                      className={`${
-                        viewMode === 'board' ? 'text-lg' : 'text-xl'
-                      } font-semibold flex items-center gap-[5px] max-w-[300px] w-full`}
+                      className={`${viewMode === 'board' ? 'text-lg' : 'text-xl'} font-semibold`}
                     >
                       {quadrantTitles[quadrant]}
                     </div>
-                    <div className="font-sm text-[#6E726E] not-italic">
+                    <div className="text-sm text-[#6E726E]">
                       {filtered.length}
                     </div>
                   </div>

--- a/frontend/src/hooks/useTaskFilters.ts
+++ b/frontend/src/hooks/useTaskFilters.ts
@@ -4,8 +4,12 @@ import type { TaskType } from '@/types/task.ts';
 export function useTaskFilters() {
   const [selectedType, setSelectedType] = useState<TaskType>('ALL');
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
-  const [startDate, setStartDate] = useState<Date>(new Date('2022-01-01'));
-  const [endDate, setEndDate] = useState<Date>(new Date('2025-12-31'));
+  const [startDate, setStartDate] = useState<Date>(new Date(Date.now()));
+  const [endDate, setEndDate] = useState<Date>(() => {
+    const today = new Date();
+    today.setDate(today.getDate() + 10);
+    return today;
+  });
 
   const setDateRange = (start: Date, end: Date) => {
     setStartDate(start);


### PR DESCRIPTION
- [ ] 날짜 선택이 처음에 2022년 01월 01로 되어있음 → 2025년으로 필터링 하려면 저 > 버튼을 엄청 눌러야해서… **초기값을 오늘 날짜 ~ +1주일 or 한달** 이렇게 설정하는게 좋을듯합니다! 이거는 어쨌든 날짜 필터링 버튼을 누르면 바로 보여지는 화면이라 시연 전에 수정이 되어야할듯)
- [ ] 보드 뷰 일때 아이콘이랑 텍스트 위아래 정렬
- [ ] 아이젠하워 테스크가 이미 연결된 마인드맵이 있으면, “마인드맵 그리기” 가 아니라 “마인드맵 이동”으로 텍스트 수정 해야할듯
- [ ] 보현님이 2차 QA 사항에 적어두셨는데, 아직 반영 안된듯! 클릭하면 -1일로 설정되는거
- [ ] 날짜 라벨이 혼자 위로가잇능거

- [ ] 모든 일정 -> 완료된 일정 레이아웃 동일한지 덜컹거리는거 없는지 → 없어보이는듯!