### PR TITLE
[BE] refactor: GPT API 예외 처리 및 문서화 작업

### DIFF
--- a/gpt/main.py
+++ b/gpt/main.py
@@ -4,10 +4,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from config import CORS_ORIGINS
 from routes import gpt_router
 from utils.logging import setup_logging
+from fastapi.responses import RedirectResponse
 
 app = FastAPI()
 
 app.include_router(gpt_router.router, prefix="/api/gpt")
+
+@app.get("/")
+async def root():
+    return RedirectResponse(url="/docs")  # FastAPI의 Swagger UI로 리다이렉트
 
 # CORS 설정 적용
 app.add_middleware(

--- a/gpt/models/request.py
+++ b/gpt/models/request.py
@@ -1,22 +1,50 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional, List, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, root_validator, model_validator
 
 
 class NodeSummaryData(BaseModel):
-    summary: Optional[str] = None
+    summary: str = Field(..., description="노드의 요약 또는 주제 내용입니다. (공백은 허용되지 않습니다.)")
+
+    @model_validator(mode="after")
+    def check_summary_not_blank(self):
+        if not self.summary.strip():
+            raise ValueError("summary는 공백일 수 없습니다.")
+        return self
+
+
 class MindmapNodeContextRequest(BaseModel):
-    mainNode: NodeSummaryData
-    parentNode: Optional[NodeSummaryData] = None
-    selectedNode: Optional[NodeSummaryData] = None
+    mainNode: NodeSummaryData = Field(..., description="필수: 메인노드의 주제는 필수값입니다.")
+    parentNode: Optional[NodeSummaryData] = Field(None, description="선택: 선택된 노드의 부모 노드")
+    selectedNode: Optional[NodeSummaryData] = Field(None, description="선택: 현재 선택된 노드")
+
 
 class NodeSummaryRequest(BaseModel):
-    question: str
-    answer: str
+    question: str = Field(..., description="사용자가 입력한 질문 내용")
+    answer: str = Field(..., description="질문에 대한 답변 내용")
+
+    @model_validator(mode="after")
+    def validate_question_and_answer(self):
+        if not self.question.strip():
+            raise ValueError("question은 빈 값이거나 공백일 수 없습니다.")
+        if not self.answer.strip():
+            raise ValueError("answer는 빈 값이거나 공백일 수 없습니다.")
+        return self
+
 
 class ConvertToTaskRequest(BaseModel):
-    selectedNodes: List[NodeSummaryData]
+    selectedNodes: List[NodeSummaryData] = Field(
+        ..., description="작업으로 변환할 선택된 노드 목록 (최소 1개 이상)"
+    )
+
+    @model_validator(mode="after")
+    def validate_selected_nodes(self):
+        if not self.selectedNodes:
+            raise ValueError("selectedNodes는 최소 1개 이상의 항목을 포함해야 합니다.")
+        return self
+
+
 class EisenhowerTaskRequest(BaseModel):
     title: str = Field(..., description="작업 제목")
     currentQuadrant: Literal["Q1", "Q2", "Q3", "Q4"] = Field(..., description="사용자가 선택한 현재 사분면")
-    dueDate: Optional[datetime] = Field(None, description="마감일 (선택 사항)")
+    dueDate: Optional[date] = Field(None, description="마감일 (선택 사항)")

--- a/gpt/models/response.py
+++ b/gpt/models/response.py
@@ -3,15 +3,21 @@ from typing import List, Literal
 
 
 class GeneratedQuestionsResponse(BaseModel):
-    generated_questions: List[str]
+    generated_questions: List[str] = Field(
+        ..., description="GPT가 생성한 질문 리스트"
+    )
 
 
 class ConvertedTaskResponse(BaseModel):
-    title: str
+    title: str = Field(
+        ..., description="선택된 노드들을 바탕으로 생성된 작업 제목"
+    )
 
 
 class SummarizedNodeResponse(BaseModel):
-    summary: str
+    summary: str = Field(
+        ..., description="질문과 답변을 요약한 결과"
+    )
 
 
 class EisenhowerRecommendationResponse(BaseModel):

--- a/gpt/routes/gpt_router.py
+++ b/gpt/routes/gpt_router.py
@@ -17,9 +17,6 @@ gpt_service = GPTService(api_key=OPENAI_API_KEY)
 @router.post("/generate/todo-questions", response_model=GeneratedQuestionsResponse)
 @safe_gpt_handler
 async def generate_todo_questions(request: MindmapNodeContextRequest):
-    if not request.mainNode or not request.mainNode.summary.strip():
-        raise HTTPException(status_code=400, detail="mainNode.summary 값이 비어 있거나 잘못되었습니다.")
-
     path_text = build_mindmap_context_text(request)
 
     user_prompt = load_prompt_template("prompts/todo_prompt.txt", {
@@ -38,9 +35,6 @@ async def generate_todo_questions(request: MindmapNodeContextRequest):
 @router.post("/generate/thinking-questions", response_model=GeneratedQuestionsResponse)
 @safe_gpt_handler
 async def generate_thinking_questions(request: MindmapNodeContextRequest):
-    if not request.mainNode or not request.mainNode.summary or not request.mainNode.summary.strip():
-        raise HTTPException(status_code=400, detail="mainNode.summary 값이 비어 있거나 잘못되었습니다.")
-
     path_text = build_mindmap_context_text(request)
 
     user_prompt = load_prompt_template("prompts/thinking_prompt.txt", {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #151 

## 📝 작업 내용
- 기존 Request, Response에 대한 Swagger에서 표시되는 추가설명 작성
- 입력값 검증을 Request 클래스 들에서 각각 담당하도록 코드 리팩터링
- root 경로로 접근시 /docs 경로로 redirect 시키는 코드 작성
 - 보다 편한 Swagger 접근을 위함

### 스크린샷 
![image](https://github.com/user-attachments/assets/6f83a566-7d36-4509-890c-68a56cf3a7de)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
