### PR TITLE
feat: 마인드맵 수정 요청 시 Req body 변경 및 카테고리 조회

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/eisenhower/exception/MindMapNotLinkedToEisenhowerException.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/exception/MindMapNotLinkedToEisenhowerException.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.eisenhower.exception;
+
+import capstone.backend.global.api.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class MindMapNotLinkedToEisenhowerException extends ApiException {
+    public MindMapNotLinkedToEisenhowerException() {
+        super(HttpStatus.NOT_FOUND, "연결된 아이젠하워가 없습니다.");
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
@@ -14,4 +14,6 @@ public interface EisenhowerItemRepository extends JpaRepository<EisenhowerItem, 
     Page<EisenhowerItem> findByMemberIdAndTitleContaining(Long memberId, String keyword, Pageable pageable);
 
     List<EisenhowerItem> findAllByDueDateAndIsCompleted(LocalDate today, boolean isCompleted);
+
+    Optional<EisenhowerItem> findByMindMap_IdAndMemberId(Long mindMapId, Long memberId);
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
@@ -15,5 +15,5 @@ public interface EisenhowerItemRepository extends JpaRepository<EisenhowerItem, 
 
     List<EisenhowerItem> findAllByDueDateAndIsCompleted(LocalDate today, boolean isCompleted);
 
-    Optional<EisenhowerItem> findByMindMap_IdAndMemberId(Long mindMapId, Long memberId);
+    Optional<EisenhowerItem> findByMemberIdAndMindMapId(Long memberId, Long mindMapId);
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
@@ -4,6 +4,7 @@ import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemCreateReques
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemFilterRequest;
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemOrderUpdateRequest;
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemUpdateRequest;
+import capstone.backend.domain.eisenhower.dto.response.EisenhowerCategoryResponse;
 import capstone.backend.domain.eisenhower.dto.response.EisenhowerItemResponse;
 import capstone.backend.domain.eisenhower.entity.EisenhowerCategory;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
@@ -98,5 +99,13 @@ public class EisenhowerItemService {
     public Page<EisenhowerItemResponse> searchItems(Long memberId, String keyword, Pageable pageable) {
         return eisenhowerItemRepository.findByMemberIdAndTitleContaining(memberId, keyword, pageable)
                 .map(EisenhowerItemResponse::from);
+    }
+
+    //마인드맵 추출 시, 연관된 아이젠하워 카테고리 조회
+    public EisenhowerCategoryResponse getCategoryByMindMapId(Long mindMapId, Long memberId){
+        return eisenhowerItemRepository.findByMindMap_IdAndMemberId(mindMapId, memberId)
+            .map(EisenhowerItem::getCategory)
+            .map(EisenhowerCategoryResponse::from)
+            .orElse(null);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
@@ -10,6 +10,7 @@ import capstone.backend.domain.eisenhower.entity.EisenhowerCategory;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
 import capstone.backend.domain.eisenhower.exception.CategoryNotFoundException;
 import capstone.backend.domain.eisenhower.exception.EisenhowerItemNotFoundException;
+import capstone.backend.domain.eisenhower.exception.MindMapNotLinkedToEisenhowerException;
 import capstone.backend.domain.eisenhower.repository.EisenhowerCategoryRepository;
 import capstone.backend.domain.eisenhower.repository.EisenhowerItemRepository;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
@@ -103,9 +104,9 @@ public class EisenhowerItemService {
 
     //마인드맵 추출 시, 연관된 아이젠하워 카테고리 조회
     public EisenhowerCategoryResponse getCategoryByMindMapId(Long mindMapId, Long memberId){
-        return eisenhowerItemRepository.findByMindMap_IdAndMemberId(mindMapId, memberId)
-            .map(EisenhowerItem::getCategory)
-            .map(EisenhowerCategoryResponse::from)
-            .orElse(null);
+        EisenhowerItem item = eisenhowerItemRepository.findByMemberIdAndMindMapId(memberId, mindMapId)
+            .orElseThrow(MindMapNotLinkedToEisenhowerException::new);
+
+        return EisenhowerCategoryResponse.from(item.getCategory());
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -1,5 +1,6 @@
 package capstone.backend.domain.mindmap.controller;
 
+import capstone.backend.domain.mindmap.dto.request.UpdateMindMapRequest;
 import capstone.backend.domain.mindmap.dto.request.UpdateMindMapTitleRequest;
 import capstone.backend.domain.mindmap.dto.response.SidebarMindMapResponse;
 import capstone.backend.global.api.dto.ApiResponse;
@@ -59,7 +60,7 @@ public class MindMapController {
     public ApiResponse<String> updateMindMap(
         @Parameter(name = "id", description = "수정 마인드맵 ID", required = true, in = ParameterIn.PATH)
         @PathVariable Long id,
-        @Valid @RequestBody MindMapRequest mindMapRequest,
+        @Valid @RequestBody UpdateMindMapRequest mindMapRequest,
         @AuthenticationPrincipal CustomOAuth2User user
     ){
         mindMapService.updateMindMap(user.getMemberId(), id, mindMapRequest);

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -1,5 +1,7 @@
 package capstone.backend.domain.mindmap.controller;
 
+import capstone.backend.domain.eisenhower.dto.response.EisenhowerCategoryResponse;
+import capstone.backend.domain.eisenhower.service.EisenhowerItemService;
 import capstone.backend.domain.mindmap.dto.request.UpdateMindMapRequest;
 import capstone.backend.domain.mindmap.dto.request.UpdateMindMapTitleRequest;
 import capstone.backend.domain.mindmap.dto.response.SidebarMindMapResponse;
@@ -24,6 +26,7 @@ import java.util.List;
 public class MindMapController {
 
     private final MindMapService mindMapService;
+    private final EisenhowerItemService eisenhowerItemService;
 
     @PostMapping("/root")
     @Operation(summary = "마인드맵 루트 노드 생성")
@@ -85,5 +88,16 @@ public class MindMapController {
         @AuthenticationPrincipal CustomOAuth2User user
     ) {
         return ApiResponse.ok(mindMapService.getMindMapList(user.getMemberId()));
+    }
+
+    @GetMapping("/category/{id}")
+    @Operation(summary = "마인드맵 추출 시, 연관된 아이젠하워 카테고리 조회")
+    public ApiResponse<EisenhowerCategoryResponse> getCategoryByMindMapId(
+        @Parameter(description = "마인드맵 ID", required = true, in = ParameterIn.PATH)
+        @PathVariable Long id,
+        @AuthenticationPrincipal CustomOAuth2User user
+    ){
+        EisenhowerCategoryResponse category = eisenhowerItemService.getCategoryByMindMapId(id, user.getMemberId());
+        return ApiResponse.ok(category);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/MindMapRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/MindMapRequest.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.mindmap.dto.request;
 
-import capstone.backend.domain.mindmap.entity.Edge;
 import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.mindmap.entity.Node;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,8 +22,5 @@ public record MindMapRequest(
 
     @Schema(description = "마인드맵 노드 정보")
     @NotEmpty(message = "노드 정보를 입력해주세요.")
-    List<Node> nodes,
-
-    @Schema(description = "마인드맵 엣지 정보")
-    List<Edge> edges
+    List<Node> nodes
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/UpdateMindMapRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/request/UpdateMindMapRequest.java
@@ -1,0 +1,16 @@
+package capstone.backend.domain.mindmap.dto.request;
+
+import capstone.backend.domain.mindmap.entity.Edge;
+import capstone.backend.domain.mindmap.entity.Node;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record UpdateMindMapRequest(
+    @Schema(description = "마인드맵 노드 정보")
+    @NotEmpty(message = "노드 정보를 입력해주세요.")
+    List<Node> nodes,
+
+    @Schema(description = "마인드맵 엣지 정보")
+    List<Edge> edges
+) { }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/entity/MindMap.java
@@ -3,6 +3,7 @@ package capstone.backend.domain.mindmap.entity;
 import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
+import capstone.backend.domain.mindmap.dto.request.UpdateMindMapRequest;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import lombok.*;
@@ -62,9 +63,7 @@ public class MindMap {
             .build();
     }
 
-    public void update(MindMapRequest mindMapRequest) {
-        this.title = mindMapRequest.title();
-        this.type = mindMapRequest.type();
+    public void update(UpdateMindMapRequest mindMapRequest) {
         this.nodes = mindMapRequest.nodes() != null ? new ArrayList<>(mindMapRequest.nodes()) : null;
         this.edges = mindMapRequest.edges() != null ? new ArrayList<>(mindMapRequest.edges()) : null;
     }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -7,6 +7,7 @@ import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.mindmap.dto.request.MindMapRequest;
+import capstone.backend.domain.mindmap.dto.request.UpdateMindMapRequest;
 import capstone.backend.domain.mindmap.dto.request.UpdateMindMapTitleRequest;
 import capstone.backend.domain.mindmap.dto.response.MindMapResponse;
 import capstone.backend.domain.mindmap.dto.response.SidebarMindMapResponse;
@@ -79,11 +80,9 @@ public class MindMapService {
 
     //마인드맵 노드 수정, 하위노드, 엣지 삭제
     @Transactional
-    public void updateMindMap(Long memberId, Long mindMapId, MindMapRequest mindMapRequest) {
+    public void updateMindMap(Long memberId, Long mindMapId, UpdateMindMapRequest mindMapRequest) {
         MindMap mindMap = mindMapRepository.findByIdAndMemberId(mindMapId, memberId)
             .orElseThrow(MindMapNotFoundException::new);
-
-        sanitizeMindMapRequest(mindMapRequest);
 
         mindMap.update(mindMapRequest);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #158 

## 📝 작업 내용

- 마인드맵 수정 요청 시, nodes / edges 구조만 받아서 업데이트할 수 있도록 했습니다.
- 아이젠하워로 노드 추출 시, 마인드맵과 연관된 아이젠하워가 존재할 경우 아이젠하워의 카테고리를 가져와 적용할 수 있도록 했습니다.