### PR TITLE
[BE] fix: swagger config 설정 변경 및 컨트롤러 네이밍 설정

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
@@ -6,11 +6,13 @@ import capstone.backend.domain.auth.service.AuthService;
 import capstone.backend.global.api.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증/인가", description = "JWT 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "유저 정보 API")
+@Tag(name = "유저 정보", description = "유저 정보 관련 API")
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/controller/MindMapController.java
@@ -10,6 +10,7 @@ import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "마인드맵", description = "마인드맵 관련 API")
 @RestController
 @RequestMapping("/api/mindmap")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/DailyPomodoroSummaryController.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/DailyPomodoroSummaryController.java
@@ -7,6 +7,7 @@ import capstone.backend.domain.pomodoro.service.DailyPomodoroSummaryService;
 import capstone.backend.global.api.dto.ApiResponse;
 import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "데이터 분석 - 뽀모도로 타이머", description = "뽀모도로 타이머 이용량 관련 API")
 @RestController
 @RequestMapping("/api/data/pomodoro")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/DailyPomodoroSummaryController.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/DailyPomodoroSummaryController.java
@@ -7,20 +7,14 @@ import capstone.backend.domain.pomodoro.service.DailyPomodoroSummaryService;
 import capstone.backend.global.api.dto.ApiResponse;
 import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
-@Validated
 @RestController
 @RequestMapping("/api/data/pomodoro")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/PomodoroController.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/PomodoroController.java
@@ -11,11 +11,13 @@ import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "뽀모도로 타이머", description = "뽀모도로 타이머 관련 API")
 @RestController
 @RequestMapping("/api/pomodoro")
 @RequiredArgsConstructor

--- a/backend/src/main/java/capstone/backend/global/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/capstone/backend/global/swagger/SwaggerConfig.java
@@ -16,9 +16,9 @@ import java.util.List;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "Flowin",
-                version = "1.0",
-                description = "ADHD 환자를 위한 디지털 치료 솔루션 서비스"
+                title = "AHZ (ADHD Zone)",
+                version = "1.0.0",
+                description = "흩어진 생각을 정리하고, 일상 흐름을 바로 잡아주는 ADHD 맞춤형 서비스"
         ),
         security = @SecurityRequirement(name = "JWT")
 )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #161 

## 📝 작업 내용

1. `Swagger-ui.html`에서 보여지는 **App name** 및 **description** 변경
2. 버전 1.0 -> 1.0.0으로 수정
3. 각 컨트롤러 별 네이밍 정보 수정
4. `DailyPomodoroController.java`에서 `@ModelAttribute`로 인해 사용하지 않는 `@Validated` 어노테이션 제거

### 스크린샷 (선택)
<img width="688" alt="image" src="https://github.com/user-attachments/assets/beeff22d-b095-473d-b811-0e9fbb12246e" />



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
