### PR TITLE
[FE] feat: 마인드맵 API 연동

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,10 +1,10 @@
 export const ENDPOINTS = {
   /* 마인드맵 관련 엔드포인트 */
   MINDMAP: {
-    GENERATE_SCHEDULE: '/api/gpt/generate_schedule',
-    GENERATE_THOUGHT: '/api/gpt/generate_thought',
-    CONVERT_TO_TASK: '/api/gpt/convert_to_task',
-    SUMMARIZE_NODE: '/api/gpt/summarize_node',
+    GENERATE_TODO: '/api/gpt/generate/todo-questions',
+    GENERATE_THOUGHT: '/api/gpt/generate/thinking-questions',
+    CONVERT_TO_TASK: '/api/gpt/convert-to-task',
+    SUMMARIZE_NODE: '/api/gpt/summarize-node',
 
     CREATE_ROOT_NODE: '/api/mindmap/root',
     GET_LIST: '/api/mindmap/list',

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -8,6 +8,7 @@ export const ENDPOINTS = {
 
     CREATE_ROOT_NODE: '/api/mindmap/root',
     GET_LIST: '/api/mindmap/list',
+    DETAIL: (id: number) => `/api/mindmap/${id}`,
   },
 
   /* 인증 관련 엔드포인트 */

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -7,6 +7,8 @@ export const ENDPOINTS = {
     GENERATE_THOUGHT: '/api/gpt/generate_thought',
     CONVERT_TO_TASK: '/api/gpt/convert_to_task',
     SUMMARIZE_NODE: '/api/gpt/summarize_node',
+
+    CREATE_ROOT_NODE: '/api/mindmap/root',
   },
   AUTH: {
     ACCESS_TOKEN: '/api/auth/token',

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,5 +1,3 @@
-/* API 엔드포인트 상수 관리 */
-
 export const ENDPOINTS = {
   /* 마인드맵 관련 엔드포인트 */
   MINDMAP: {
@@ -9,7 +7,10 @@ export const ENDPOINTS = {
     SUMMARIZE_NODE: '/api/gpt/summarize_node',
 
     CREATE_ROOT_NODE: '/api/mindmap/root',
+    GET_LIST: '/api/mindmap/list',
   },
+
+  /* 인증 관련 엔드포인트 */
   AUTH: {
     ACCESS_TOKEN: '/api/auth/token',
     REFRESH_TOKEN: '/api/auth/reissue',

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -90,12 +90,11 @@ function FlowContent({ mindmap }: FlowWrapperProps) {
         forceSave(nodes, edges);
       }
     };
-  }, []); // 빈 의존성 배열
+  }, []);
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
       onNodesChange(changes);
-      console.log(nodes, edges);
       debounceSave(nodes, edges);
     },
     [onNodesChange, nodes, edges, debounceSave],

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -46,10 +46,10 @@ import useGenerateThought from '@/hooks/queries/mindmap/useGenerateThought';
 import { NodeSelectionPanel } from '@/components/reactFlow/ui/NodeSelectionPanel';
 
 const nodeTypes = {
-  root: RootNode,
-  summary: SummaryNode,
-  answer: AnswerInputNode,
-  question: QuestionListNode,
+  ROOT: RootNode,
+  SUMMARY: SummaryNode,
+  ANSWER: AnswerInputNode,
+  QUESTION: QuestionListNode,
 };
 
 const edgeTypes = {
@@ -148,7 +148,7 @@ function FlowContent({ mindmapId }: FlowContentProps) {
       const childNodePosition = getChildNodePosition(event as MouseEvent);
 
       if (childNodePosition && connectingNodeId.current) {
-        const mainNode = nodes.find((node) => node.type === 'root');
+        const mainNode = nodes.find((node) => node.type === 'ROOT');
         const selectedNode = nodes.find(
           (node) => node.id === connectingNodeId.current,
         );
@@ -177,8 +177,8 @@ function FlowContent({ mindmapId }: FlowContentProps) {
           -> null로 처리
           */
           const requestData: GenerateReq = {
-            mainNode: mainNode?.data?.label
-              ? { summary: mainNode.data.label }
+            mainNode: mainNode?.data?.summary
+              ? { summary: mainNode.data.summary }
               : null,
             parentNode:
               parentNode?.id !== mainNode?.id && parentNode?.data?.summary
@@ -256,7 +256,7 @@ function FlowContent({ mindmapId }: FlowContentProps) {
 
     if (activeState) {
       const node = nodes.find((n) => n.id === activeState.nodeId);
-      if (node && (node.type === 'question' || node.type === 'answer')) {
+      if (node && (node.type === 'QUESTION' || node.type === 'ANSWER')) {
         restoreActiveState();
       }
     }

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -43,6 +43,7 @@ import { findParentNode } from '@/lib/mindMap';
 import useGenerateThought from '@/hooks/queries/mindmap/useGenerateThought';
 
 import { NodeSelectionPanel } from '@/components/reactFlow/ui/NodeSelectionPanel';
+import { MindMapDetail } from '@/types/mindMap';
 
 const nodeTypes = {
   ROOT: RootNode,
@@ -58,10 +59,10 @@ const edgeTypes = {
 const nodeOrigin: NodeOrigin = [0.5, 0.5];
 
 type FlowWrapperProps = {
-  mindmapId?: number;
+  mindmap?: MindMapDetail;
 };
 
-function FlowContent({ mindmapId }: FlowWrapperProps) {
+function FlowContent({ mindmap }: FlowWrapperProps) {
   const nodes = useNodes();
   const edges = useEdges();
   const onNodesChange = useNodesChange();
@@ -81,6 +82,8 @@ function FlowContent({ mindmapId }: FlowWrapperProps) {
   const { screenToFlowPosition } = useReactFlow();
   const connectingNodeId = useRef<string | null>(null);
   const ignoreNextPaneClick = useRef(false);
+
+  const mindmapId = mindmap?.id;
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -173,9 +176,7 @@ function FlowContent({ mindmapId }: FlowWrapperProps) {
           const newNodeId = addChildNode(selectedNode, childNodePosition, true);
 
           if (mindmapId) {
-            const mindMapData = loadMindMapData(mindmapId);
-
-            if (mindMapData?.type === 'TODO') {
+            if (mindmap?.type === 'TODO') {
               generateScheduleMutation(requestData, {
                 onSuccess: (data) => {
                   updateNodeQuestions(
@@ -191,7 +192,7 @@ function FlowContent({ mindmapId }: FlowWrapperProps) {
               });
             }
 
-            if (mindMapData?.type === 'THINKING') {
+            if (mindmap?.type === 'THINKING') {
               generateThoughtMutation(requestData, {
                 onSuccess: (data) => {
                   updateNodeQuestions(
@@ -267,7 +268,7 @@ function FlowContent({ mindmapId }: FlowWrapperProps) {
   );
 }
 
-function FlowWrapper({ mindmapId }: FlowWrapperProps) {
+function FlowWrapper({ mindmap }: FlowWrapperProps) {
   const isNodeSelectionMode = useIsNodeSelectionMode();
 
   return (
@@ -275,7 +276,7 @@ function FlowWrapper({ mindmapId }: FlowWrapperProps) {
       {isNodeSelectionMode && <NodeSelectionPanel />}
 
       <ReactFlowProvider>
-        <FlowContent mindmapId={mindmapId} />
+        <FlowContent mindmap={mindmap} />
       </ReactFlowProvider>
     </div>
   );

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -12,7 +12,7 @@ import {
 } from '@xyflow/react';
 
 import '@xyflow/react/dist/style.css';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import {
   useNodes,
@@ -22,7 +22,6 @@ import {
   useNodesChange,
   useUpdateNodeQuestions,
   useUpdateNodePending,
-  useSetInitialData,
   useActiveState,
   useRestoreActiveState,
 } from '@/store/mindMapStore';
@@ -58,11 +57,11 @@ const edgeTypes = {
 
 const nodeOrigin: NodeOrigin = [0.5, 0.5];
 
-type FlowContentProps = {
-  mindmapId?: number | null;
+type FlowWrapperProps = {
+  mindmapId?: number;
 };
 
-function FlowContent({ mindmapId }: FlowContentProps) {
+function FlowContent({ mindmapId }: FlowWrapperProps) {
   const nodes = useNodes();
   const edges = useEdges();
   const onNodesChange = useNodesChange();
@@ -70,7 +69,6 @@ function FlowContent({ mindmapId }: FlowContentProps) {
   const addChildNode = useAddChildNode();
   const updateNodeQuestions = useUpdateNodeQuestions();
   const updateNodePending = useUpdateNodePending();
-  const setInitialData = useSetInitialData();
   const activeState = useActiveState();
   const restoreActiveState = useRestoreActiveState();
 
@@ -83,23 +81,6 @@ function FlowContent({ mindmapId }: FlowContentProps) {
   const { screenToFlowPosition } = useReactFlow();
   const connectingNodeId = useRef<string | null>(null);
   const ignoreNextPaneClick = useRef(false);
-
-  useEffect(() => {
-    if (mindmapId) {
-      const mindMapData = loadMindMapData(mindmapId);
-      if (mindMapData) {
-        if (mindMapData.nodes && mindMapData.edges) {
-          setInitialData(mindMapData.nodes, mindMapData.edges);
-        }
-      }
-
-      if (!mindMapData) {
-        console.error(
-          `마인드맵 ID ${mindmapId}에 해당하는 데이터를 찾을 수 없습니다.`,
-        );
-      }
-    }
-  }, [mindmapId, loadMindMapData, setInitialData]);
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -264,29 +245,27 @@ function FlowContent({ mindmapId }: FlowContentProps) {
 
   return (
     <div className="w-full h-full">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={handleNodesChange}
-        onEdgesChange={handleEdgesChange}
-        onConnectStart={onConnectStart}
-        onConnectEnd={onConnectEnd}
-        onPaneClick={onPaneClick}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        nodeOrigin={nodeOrigin}
-        connectionLineType={ConnectionLineType.Straight}
-        fitView
-      >
-        <Controls showInteractive={false} />
-      </ReactFlow>
+      {
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={handleNodesChange}
+          onEdgesChange={handleEdgesChange}
+          onConnectStart={onConnectStart}
+          onConnectEnd={onConnectEnd}
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          nodeOrigin={nodeOrigin}
+          connectionLineType={ConnectionLineType.Straight}
+          fitView
+        >
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      }
     </div>
   );
 }
-
-type FlowWrapperProps = {
-  mindmapId?: number | null;
-};
 
 function FlowWrapper({ mindmapId }: FlowWrapperProps) {
   const isNodeSelectionMode = useIsNodeSelectionMode();

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -26,7 +26,7 @@ export default function AnswerInputNode({
 }: NodeProps<AnswerNodeType>) {
   const initialAnswer = data.answer || '';
   const isEditing = data.isEditing || false;
-  const isDirectQuestion = data.label === '직접 입력하기';
+  const isDirectQuestion = data.question === '직접 입력하기';
 
   const [answer, setAnswer] = useState(initialAnswer);
   const [customQuestion, setCustomQuestion] = useState('');
@@ -75,10 +75,10 @@ export default function AnswerInputNode({
       const currentNode = nodes.find((node) => node.id === id);
       if (currentNode) {
         // 직접 입력 모드일 때는 사용자가 입력한 질문을, 아닐 때는 원래 레이블을 사용
-        const questionText = isDirectQuestion ? customQuestion : data.label;
+        const questionText = isDirectQuestion ? customQuestion : data.question;
 
         const requestData: SummarizedNodeReq = {
-          question: questionText,
+          question: questionText || '',
           answer,
         };
 
@@ -86,10 +86,10 @@ export default function AnswerInputNode({
           onSuccess: (data) => {
             setNode(id, {
               ...currentNode,
-              type: 'summary',
+              type: 'SUMMARY',
               data: {
                 ...currentNode.data,
-                label: questionText,
+                question: questionText,
                 answer,
                 summary: data.summary,
               },
@@ -100,7 +100,7 @@ export default function AnswerInputNode({
             if (parentNode) {
               const filteredQuestions = parentNode.data.recommendedQuestions
                 ? parentNode.data.recommendedQuestions.filter(
-                    (q) => q !== currentNode.data.label,
+                    (q) => q !== currentNode.data.question,
                   )
                 : [];
 
@@ -120,10 +120,10 @@ export default function AnswerInputNode({
       const currentNode = nodes.find((node) => node.id === id);
       if (currentNode) {
         // 직접 입력 모드일 때는 사용자가 입력한 질문을, 아닐 때는 원래 레이블을 사용
-        const questionText = isDirectQuestion ? customQuestion : data.label;
+        const questionText = isDirectQuestion ? customQuestion : data.question;
 
         const requestData: SummarizedNodeReq = {
-          question: questionText,
+          question: questionText || '',
           answer,
         };
 
@@ -134,7 +134,7 @@ export default function AnswerInputNode({
                 ...currentNode,
                 data: {
                   ...currentNode.data,
-                  label: questionText,
+                  question: questionText,
                   answer,
                   summary: data.summary,
                 },
@@ -167,7 +167,7 @@ export default function AnswerInputNode({
           />
         </div>
       ) : (
-        <p className="text-[20px] font-semibold mb-[15px]">{data.label}</p>
+        <p className="text-[20px] font-semibold mb-[15px]">{data.question}</p>
       )}
 
       <div className="mb-[20px]">
@@ -260,9 +260,9 @@ export default function AnswerInputNode({
             >
               <div className="rounded-[7px] px-6 py-4 border-1 border-[#AAAAAA]">
                 <p className="font-semibold text-[18px] mb-1">
-                  {isDirectQuestion ? customQuestion : data.label}
+                  {isDirectQuestion ? customQuestion : data.question}
                 </p>
-                <p className='font-normal text-[16px]'>{answer}</p>
+                <p className="font-normal text-[16px]">{answer}</p>
               </div>
             </Modal>
           </>

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -35,10 +35,10 @@ export default function QuestionListNode({
     if (currentNode) {
       setNode(id, {
         ...currentNode,
-        type: 'answer',
+        type: 'ANSWER',
         data: {
           ...currentNode.data,
-          label: selectedQuestion,
+          question: selectedQuestion,
         },
       });
     }
@@ -99,10 +99,10 @@ export default function QuestionListNode({
     if (currentNode) {
       setNode(id, {
         ...currentNode,
-        type: 'answer',
+        type: 'ANSWER',
         data: {
           ...currentNode.data,
-          label: '직접 입력하기',
+          question: '직접 입력하기',
         },
       });
     }

--- a/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/RootNode.tsx
@@ -13,7 +13,7 @@ export default function RootNode({ data, selected }: NodeProps<RootNodeType>) {
       <div className="dragHandle absolute top-3 right-1 z-20 cursor-grab opacity-0 group-hover:opacity-100 transition-opacity duration-200">
         <GripVertical size={32} color="#B9B9B7" />
       </div>
-      <p className="text-[32px] font-semibold">{data.label}</p>
+      <p className="text-[32px] font-semibold">{data?.summary}</p>
 
       <NodeHandles type="full" />
     </div>

--- a/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
@@ -33,7 +33,7 @@ export default function SummaryNode({ id, data }: NodeProps<SummaryNodeType>) {
     if (currentNode) {
       setNode(id, {
         ...currentNode,
-        type: 'answer',
+        type: 'ANSWER',
         data: {
           ...currentNode.data,
           isEditing: true,

--- a/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
+++ b/frontend/src/components/ui/sidebar/subSidebar/mindmap/MindmapAddButton.tsx
@@ -1,8 +1,10 @@
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/Input';
+import useCreateRootNode from '@/hooks/queries/mindmap/useCreateRootNode';
+import { generateStringId } from '@/lib/generateNumericId';
 import { cn } from '@/lib/utils';
-import { useCreateMindMap } from '@/store/mindmapListStore';
+import { CreateRootNodeReq } from '@/types/api/mindmap';
 import { ActualTaskType } from '@/types/commonTypes';
 import { DialogClose } from '@radix-ui/react-dialog';
 import { Plus } from 'lucide-react';
@@ -12,12 +14,41 @@ import { useNavigate } from 'react-router';
 export default function MindmapAddButton() {
   const [selectedType, setSelectedType] = useState<ActualTaskType>('TODO');
   const [subject, setSubject] = useState('');
-  const createMindmap = useCreateMindMap();
   const navigate = useNavigate();
 
+  const { createRootNodeMutation } = useCreateRootNode();
+
   const handleCreateClick = () => {
-    const newMindmapId = createMindmap(subject, selectedType);
-    navigate(`/mindmap/${newMindmapId}`);
+    const requestData: CreateRootNodeReq = {
+      eisenhowerId: null,
+      title: subject,
+      type: selectedType,
+      nodes: [
+        {
+          id: generateStringId(),
+          type: 'ROOT',
+          data: {
+            question: null,
+            answer: null,
+            summary: subject,
+            depth: 0,
+            recommendedQuestions: null,
+          },
+          position: { x: 0, y: 0 },
+          measured: { width: 250, height: 122 },
+        },
+      ],
+      edges: [],
+    };
+
+    createRootNodeMutation(requestData, {
+      onSuccess: (data) => {
+        navigate(`/mindmap/${data.content}`);
+      },
+      onError: (error) => {
+        console.error('요약 생성 중 오류가 발생했습니다:', error);
+      },
+    });
   };
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/hooks/queries/mindmap/useCreateRootNode.ts
+++ b/frontend/src/hooks/queries/mindmap/useCreateRootNode.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { mindmapService } from '@/services/mindmapService';
+import { CreateRootNodeReq } from '@/types/api/mindmap';
+
+const useCreateRootNode = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (data: CreateRootNodeReq) =>
+      mindmapService.createRootNode(data),
+  });
+
+  return {
+    createRootNodeMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useCreateRootNode;

--- a/frontend/src/hooks/queries/mindmap/useDeleteMindmap.ts
+++ b/frontend/src/hooks/queries/mindmap/useDeleteMindmap.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { mindmapService } from '@/services/mindmapService';
+
+const useDeleteMindmap = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (id: number) => mindmapService.delete(id),
+  });
+
+  return {
+    deleteMindmapMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useDeleteMindmap;

--- a/frontend/src/hooks/queries/mindmap/useGetMindmapDetail.ts
+++ b/frontend/src/hooks/queries/mindmap/useGetMindmapDetail.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { mindmapService } from '@/services/mindmapService';
+import { GetMindmapDetailRes } from '@/types/api/mindmap';
+import { useEffect } from 'react';
+import { useSetInitialData } from '@/store/mindMapStore';
+
+const useGetMindmapDetail = (id: number) => {
+  const setInitialData = useSetInitialData();
+
+  const { data, isLoading, error, isPending } = useQuery<GetMindmapDetailRes>({
+    queryKey: ['mindmapDetail', id],
+    queryFn: () => mindmapService.getDetail(id),
+    refetchOnWindowFocus: false,
+    retry: 1,
+    enabled: !!id,
+  });
+
+  useEffect(() => {
+    if (data?.content) {
+      setInitialData(data.content.nodes, data.content.edges);
+    }
+  }, [data?.content, setInitialData]);
+
+  return {
+    mindmapDetail: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetMindmapDetail;

--- a/frontend/src/hooks/queries/mindmap/useGetMindmapList.ts
+++ b/frontend/src/hooks/queries/mindmap/useGetMindmapList.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { mindmapService } from '@/services/mindmapService';
+import { GetMindmapListRes } from '@/types/api/mindmap';
+import { useSetMindMaps } from '@/store/mindmapListStore';
+import { useEffect } from 'react';
+
+const useGetMindmapList = () => {
+  const setMindMaps = useSetMindMaps();
+
+  const { data, isLoading, error, isPending } = useQuery<GetMindmapListRes>({
+    queryKey: ['mindmapList'],
+    queryFn: () => mindmapService.getList(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    if (data?.content) {
+      setMindMaps(data.content);
+    }
+  }, [data?.content, setMindMaps]);
+
+  return {
+    mindmapList: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetMindmapList;

--- a/frontend/src/hooks/queries/mindmap/useUpdateMindmap.ts
+++ b/frontend/src/hooks/queries/mindmap/useUpdateMindmap.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { mindmapService } from '@/services/mindmapService';
+import { UpdateMindmapReq } from '@/types/api/mindmap';
+
+const useUpdateMindmap = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: UpdateMindmapReq }) =>
+      mindmapService.update(id, data),
+  });
+
+  return {
+    updateMindmapMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useUpdateMindmap;

--- a/frontend/src/hooks/useDebounceMindmapUpdate.ts
+++ b/frontend/src/hooks/useDebounceMindmapUpdate.ts
@@ -1,0 +1,93 @@
+import { useCallback, useRef, useEffect } from 'react';
+import useUpdateMindmap from '@/hooks/queries/mindmap/useUpdateMindmap';
+import { MindMapNode, MindMapEdge } from '@/types/mindMap';
+import { UpdateMindmapReq } from '@/types/api/mindmap';
+
+export const useDebounceMindmapUpdate = (
+  mindmapId: number | undefined,
+  debounceTime = 5000,
+) => {
+  const { updateMindmapMutation } = useUpdateMindmap();
+  const debounceSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceSaveTimerRef.current) {
+        clearTimeout(debounceSaveTimerRef.current);
+      }
+    };
+  }, []);
+
+  const debounceSave = useCallback(
+    (nodes: MindMapNode[], edges: MindMapEdge[]) => {
+      if (debounceSaveTimerRef.current) {
+        clearTimeout(debounceSaveTimerRef.current);
+      }
+
+      if (!mindmapId) return;
+
+      debounceSaveTimerRef.current = setTimeout(() => {
+        const updateData: UpdateMindmapReq = {
+          nodes,
+          edges,
+        };
+
+        updateMindmapMutation(
+          {
+            id: mindmapId,
+            data: updateData,
+          },
+          {
+            onSuccess: (data) => {
+              console.log('data', data);
+            },
+            onError: (error) => {
+              console.error('error', error);
+            },
+          },
+        );
+
+        console.log('마인드맵이 자동 저장되었습니다.');
+        debounceSaveTimerRef.current = null;
+      }, debounceTime);
+    },
+    [mindmapId, updateMindmapMutation, debounceTime],
+  );
+
+  const forceSave = useCallback(
+    (nodes: MindMapNode[], edges: MindMapEdge[]) => {
+      console.log('forceSave!!!');
+      if (debounceSaveTimerRef.current) {
+        clearTimeout(debounceSaveTimerRef.current);
+        debounceSaveTimerRef.current = null;
+      }
+
+      if (!mindmapId) return;
+
+      const updateData: UpdateMindmapReq = {
+        nodes,
+        edges,
+      };
+
+      updateMindmapMutation(
+        {
+          id: mindmapId,
+          data: updateData,
+        },
+        {
+          onSuccess: (data) => {
+            console.log('data', data);
+          },
+          onError: (error) => {
+            console.error('error', error);
+          },
+        },
+      );
+
+      console.log('마인드맵이 강제 저장되었습니다.');
+    },
+    [mindmapId, updateMindmapMutation],
+  );
+
+  return { debounceSave, forceSave };
+};

--- a/frontend/src/mock/mindmap.ts
+++ b/frontend/src/mock/mindmap.ts
@@ -9,7 +9,7 @@ export const mockMindMaps: MindMap[] = [
     nodes: [
       {
         id: '1',
-        type: 'root',
+        type: 'ROOT',
         data: {
           label: '운동하기',
           depth: 0,
@@ -30,7 +30,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'uxlQN81Ebq0PlGHsrKdze',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '운동을 위해 원하는 운동 종류는 무엇인가요?',
           depth: 1,
@@ -57,7 +57,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'B2VExZjto9WGhC-mbXOKx',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '운동을 시작하기 위한 최적의 시간을 언제로 정할 수 있을까요?',
           depth: 2,
@@ -78,7 +78,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'Nnl3RXHcCgf-EW2xAhLr5',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '주당 몇 번 운동할 계획인가요?',
           depth: 1,
@@ -106,7 +106,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'TKs3tPQueLJx-3Tqha_Lm',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '운동을 혼자 할 것인가, 친구나 그룹과 함께 할 것인가요?',
           depth: 2,
@@ -127,7 +127,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: '53so4XZQyzfUDm-8hwnMp',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '운동을 할 수 있는 장소는 어디인가요?',
           depth: 1,
@@ -201,7 +201,7 @@ export const mockMindMaps: MindMap[] = [
     nodes: [
       {
         id: '1',
-        type: 'root',
+        type: 'ROOT',
         data: {
           label: '여행 계획',
           depth: 0,
@@ -222,7 +222,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'destinationNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 나라나 도시로 여행을 가고 싶으신가요?',
           depth: 1,
@@ -249,7 +249,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'tripDurationNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '여행 기간은 얼마나 계획하고 계신가요?',
           depth: 1,
@@ -275,7 +275,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'transportationNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '교통수단은 어떻게 계획하고 계신가요?',
           depth: 2,
@@ -296,7 +296,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'budgetNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '여행 예산은 어느 정도로 생각하고 계신가요?',
           depth: 1,
@@ -353,7 +353,7 @@ export const mockMindMaps: MindMap[] = [
     nodes: [
       {
         id: '1',
-        type: 'root',
+        type: 'ROOT',
         data: {
           label: '학습 계획',
           depth: 0,
@@ -374,7 +374,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'subjectNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 과목이나 분야를 공부하고 싶으신가요?',
           depth: 1,
@@ -401,7 +401,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'programmingLanguageNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 프로그래밍 언어에 관심이 있으신가요?',
           depth: 2,
@@ -422,7 +422,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'studyTimeNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '하루에 얼마나 공부할 계획인가요?',
           depth: 1,
@@ -449,7 +449,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'studyMethodNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 방식으로 공부할 계획인가요?',
           depth: 1,
@@ -517,7 +517,7 @@ export const mockMindMaps: MindMap[] = [
     nodes: [
       {
         id: '1',
-        type: 'root',
+        type: 'ROOT',
         data: {
           label: '취미 생활',
           depth: 0,
@@ -538,7 +538,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'hobbyTypeNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 취미에 관심이 있으신가요?',
           depth: 1,
@@ -565,7 +565,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'artStyleNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '어떤 그림 스타일에 관심이 있으신가요?',
           depth: 2,
@@ -586,7 +586,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'hobbyTimeNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '취미 활동에 투자할 수 있는 시간은 얼마나 되나요?',
           depth: 1,
@@ -612,7 +612,7 @@ export const mockMindMaps: MindMap[] = [
       },
       {
         id: 'hobbyGoalNode',
-        type: 'summary',
+        type: 'SUMMARY',
         data: {
           label: '취미 활동을 통해 얻고 싶은 것은 무엇인가요?',
           depth: 1,

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,70 +1,41 @@
-import FlowWrapper from '@/components/reactFlow/FlowWrapper';
 import useGetMindmapList from '@/hooks/queries/mindmap/useGetMindmapList';
-import { parseIdParam } from '@/lib/parseIdParam';
-import { useSetActiveMindMap } from '@/store/mindmapListStore';
-import {
-  useDisableSelectionMode,
-  useIsNodeSelectionMode,
-} from '@/store/nodeSelection';
+import { useNavigate } from 'react-router';
 import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router';
 
 export default function MindmapPage() {
-  const { id } = useParams();
-  const numericId = parseIdParam(id);
-  const setActiveMindMap = useSetActiveMindMap();
   const navigate = useNavigate();
-
   const { mindmapList, isLoading, error } = useGetMindmapList();
-
-  const isNodeSelectionMode = useIsNodeSelectionMode();
-  const disableSelectionMode = useDisableSelectionMode();
 
   useEffect(() => {
     if (isLoading) return;
 
     if (error) {
       console.error('마인드맵 목록을 불러오는데 실패했습니다:', error);
-      navigate('/mindmap');
       return;
     }
 
     if (!mindmapList || mindmapList.length === 0) {
-      navigate('/mindmap');
       return;
     }
 
-    const isValidId =
-      id && mindmapList.some((mindmap) => mindmap.id === numericId);
-
-    if (id && isValidId) {
-      setActiveMindMap(numericId);
-      return;
-    }
-
+    // 연결된 마인드맵이 있으면 그걸로 이동
     const linkedMindMaps = mindmapList.filter((mindmap) => mindmap.linked);
     if (linkedMindMaps.length > 0) {
       navigate(`/mindmap/${linkedMindMaps[0].id}`, { replace: true });
       return;
     }
 
+    // 없으면 첫 번째 마인드맵으로 이동
     const freeMindMaps = mindmapList.filter((mindmap) => !mindmap.linked);
     if (freeMindMaps.length > 0) {
       navigate(`/mindmap/${freeMindMaps[0].id}`, { replace: true });
       return;
     }
-
-    // 추후 디자인 나오면 대체할 예정
-    console.log('표시할 마인드맵이 없습니다');
-  }, [id, mindmapList, navigate, setActiveMindMap]);
-
-  useEffect(() => {
-    if (isNodeSelectionMode) {
-      disableSelectionMode();
-    }
-  }, [location.pathname, id]);
+  }, [mindmapList, isLoading, error, navigate]);
 
   return (
-    <div className="h-full">{id && <FlowWrapper mindmapId={numericId} />}</div>
+    <div className="h-full">
+      <h1>마인드맵 목록</h1>
+    </div>
   );
 }

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,6 +1,7 @@
 import FlowWrapper from '@/components/reactFlow/FlowWrapper';
+import useGetMindmapList from '@/hooks/queries/mindmap/useGetMindmapList';
 import { parseIdParam } from '@/lib/parseIdParam';
-import { useMindMaps, useSetActiveMindMap } from '@/store/mindmapListStore';
+import { useSetActiveMindMap } from '@/store/mindmapListStore';
 import {
   useDisableSelectionMode,
   useIsNodeSelectionMode,
@@ -12,33 +13,42 @@ export default function MindmapPage() {
   const { id } = useParams();
   const numericId = parseIdParam(id);
   const setActiveMindMap = useSetActiveMindMap();
-  const mindMaps = useMindMaps();
   const navigate = useNavigate();
+
+  const { mindmapList, isLoading, error } = useGetMindmapList();
 
   const isNodeSelectionMode = useIsNodeSelectionMode();
   const disableSelectionMode = useDisableSelectionMode();
 
   useEffect(() => {
-    if (mindMaps.length === 0) {
+    if (isLoading) return;
+
+    if (error) {
+      console.error('마인드맵 목록을 불러오는데 실패했습니다:', error);
+      navigate('/mindmap');
+      return;
+    }
+
+    if (!mindmapList || mindmapList.length === 0) {
       navigate('/mindmap');
       return;
     }
 
     const isValidId =
-      id && mindMaps.some((mindmap) => mindmap.id === numericId);
+      id && mindmapList.some((mindmap) => mindmap.id === numericId);
 
     if (id && isValidId) {
       setActiveMindMap(numericId);
       return;
     }
 
-    const linkedMindMaps = mindMaps.filter((mindmap) => mindmap.linked);
+    const linkedMindMaps = mindmapList.filter((mindmap) => mindmap.linked);
     if (linkedMindMaps.length > 0) {
       navigate(`/mindmap/${linkedMindMaps[0].id}`, { replace: true });
       return;
     }
 
-    const freeMindMaps = mindMaps.filter((mindmap) => !mindmap.linked);
+    const freeMindMaps = mindmapList.filter((mindmap) => !mindmap.linked);
     if (freeMindMaps.length > 0) {
       navigate(`/mindmap/${freeMindMaps[0].id}`, { replace: true });
       return;
@@ -46,7 +56,7 @@ export default function MindmapPage() {
 
     // 추후 디자인 나오면 대체할 예정
     console.log('표시할 마인드맵이 없습니다');
-  }, [id, mindMaps, navigate, setActiveMindMap]);
+  }, [id, mindmapList, navigate, setActiveMindMap]);
 
   useEffect(() => {
     if (isNodeSelectionMode) {

--- a/frontend/src/pages/mindmapDetail.tsx
+++ b/frontend/src/pages/mindmapDetail.tsx
@@ -18,7 +18,7 @@ export default function MindmapDetailPage() {
   const disableSelectionMode = useDisableSelectionMode();
 
   // 마인드맵 상세 데이터 가져오기
-  const { mindmapDetail } = useGetMindmapDetail(numericId);
+  const { mindmapDetail } = useGetMindmapDetail(numericId as number);
 
   useEffect(() => {
     if (isNodeSelectionMode) {
@@ -34,7 +34,7 @@ export default function MindmapDetailPage() {
 
   return (
     <div className="h-full">
-      {mindmapDetail && <FlowWrapper mindmapId={mindmapDetail.id} />}
+      {mindmapDetail && <FlowWrapper mindmap={mindmapDetail} />}
     </div>
   );
 }

--- a/frontend/src/pages/mindmapDetail.tsx
+++ b/frontend/src/pages/mindmapDetail.tsx
@@ -1,0 +1,40 @@
+import FlowWrapper from '@/components/reactFlow/FlowWrapper';
+import useGetMindmapDetail from '@/hooks/queries/mindmap/useGetMindmapDetail';
+import { parseIdParam } from '@/lib/parseIdParam';
+import { useParams } from 'react-router';
+import { useEffect } from 'react';
+import { useSetActiveMindMap } from '@/store/mindmapListStore';
+import {
+  useDisableSelectionMode,
+  useIsNodeSelectionMode,
+} from '@/store/nodeSelection';
+
+export default function MindmapDetailPage() {
+  const { id } = useParams();
+  const numericId = parseIdParam(id);
+  const setActiveMindMap = useSetActiveMindMap();
+
+  const isNodeSelectionMode = useIsNodeSelectionMode();
+  const disableSelectionMode = useDisableSelectionMode();
+
+  // 마인드맵 상세 데이터 가져오기
+  const { mindmapDetail } = useGetMindmapDetail(numericId);
+
+  useEffect(() => {
+    if (isNodeSelectionMode) {
+      disableSelectionMode();
+    }
+  }, [id, isNodeSelectionMode, disableSelectionMode]);
+
+  useEffect(() => {
+    if (numericId) {
+      setActiveMindMap(numericId);
+    }
+  }, [numericId, setActiveMindMap]);
+
+  return (
+    <div className="h-full">
+      {mindmapDetail && <FlowWrapper mindmapId={mindmapDetail.id} />}
+    </div>
+  );
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -14,7 +14,8 @@ export default [
 
   layout('layouts/DefaultLayout.tsx', [
     index('pages/home.tsx'),
-    route('mindmap/:id?', 'pages/mindmap.tsx'),
+    route('mindmap', 'pages/mindmap.tsx'),
+    route('mindmap/:id', 'pages/mindmapDetail.tsx'),
     route('today', 'pages/today.tsx'),
     route('matrix', 'pages/matrix.tsx'),
     route('pomodoro/:id?', 'pages/pomodoro.tsx'),

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -10,6 +10,7 @@ import {
   SummarizedNodeRes,
   CreateRootNodeReq,
   CreateRootNodeRes,
+  GetMindmapListRes,
 } from '@/types/api/mindmap';
 
 export const mindmapService = {
@@ -57,6 +58,13 @@ export const mindmapService = {
     const response = await apiClient.post<CreateRootNodeRes>(
       ENDPOINTS.MINDMAP.CREATE_ROOT_NODE,
       data,
+    );
+    return response.data;
+  },
+
+  getList: async (): Promise<GetMindmapListRes> => {
+    const response = await apiClient.get<GetMindmapListRes>(
+      ENDPOINTS.MINDMAP.GET_LIST,
     );
     return response.data;
   },

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -13,6 +13,8 @@ import {
   GetMindmapListRes,
   GetMindmapDetailRes,
   DeleteMindmapRes,
+  UpdateMindmapReq,
+  UpdateMindmapRes,
 } from '@/types/api/mindmap';
 
 export const mindmapService = {
@@ -81,6 +83,17 @@ export const mindmapService = {
   delete: async (id: number): Promise<DeleteMindmapRes> => {
     const response = await apiClient.delete<DeleteMindmapRes>(
       ENDPOINTS.MINDMAP.DETAIL(id),
+    );
+    return response.data;
+  },
+
+  update: async (
+    id: number,
+    data: UpdateMindmapReq,
+  ): Promise<UpdateMindmapRes> => {
+    const response = await apiClient.put<UpdateMindmapRes>(
+      ENDPOINTS.MINDMAP.DETAIL(id),
+      data,
     );
     return response.data;
   },

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -12,6 +12,7 @@ import {
   CreateRootNodeRes,
   GetMindmapListRes,
   GetMindmapDetailRes,
+  DeleteMindmapRes,
 } from '@/types/api/mindmap';
 
 export const mindmapService = {
@@ -72,6 +73,13 @@ export const mindmapService = {
 
   getDetail: async (id: number): Promise<GetMindmapDetailRes> => {
     const response = await apiClient.get<GetMindmapDetailRes>(
+      ENDPOINTS.MINDMAP.DETAIL(id),
+    );
+    return response.data;
+  },
+
+  delete: async (id: number): Promise<DeleteMindmapRes> => {
+    const response = await apiClient.delete<DeleteMindmapRes>(
       ENDPOINTS.MINDMAP.DETAIL(id),
     );
     return response.data;

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -11,6 +11,7 @@ import {
   CreateRootNodeReq,
   CreateRootNodeRes,
   GetMindmapListRes,
+  GetMindmapDetailRes,
 } from '@/types/api/mindmap';
 
 export const mindmapService = {
@@ -65,6 +66,13 @@ export const mindmapService = {
   getList: async (): Promise<GetMindmapListRes> => {
     const response = await apiClient.get<GetMindmapListRes>(
       ENDPOINTS.MINDMAP.GET_LIST,
+    );
+    return response.data;
+  },
+
+  getDetail: async (id: number): Promise<GetMindmapDetailRes> => {
+    const response = await apiClient.get<GetMindmapDetailRes>(
+      ENDPOINTS.MINDMAP.DETAIL(id),
     );
     return response.data;
   },

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -20,7 +20,7 @@ export const mindmapService = {
     data: GenerateReq,
   ): Promise<GeneratedScheduleRes> => {
     const response = await gptClient.post<GeneratedScheduleRes>(
-      ENDPOINTS.MINDMAP.GENERATE_SCHEDULE,
+      ENDPOINTS.MINDMAP.GENERATE_TODO,
       data,
     );
     return response.data;

--- a/frontend/src/services/mindmapService.ts
+++ b/frontend/src/services/mindmapService.ts
@@ -1,4 +1,4 @@
-import { gptClient } from '@/api/client';
+import { apiClient, gptClient } from '@/api/client';
 import { ENDPOINTS } from '@/api/endpoints';
 import {
   GenerateReq,
@@ -8,6 +8,8 @@ import {
   ConvertedToTaskRes,
   SummarizedNodeReq,
   SummarizedNodeRes,
+  CreateRootNodeReq,
+  CreateRootNodeRes,
 } from '@/types/api/mindmap';
 
 export const mindmapService = {
@@ -44,6 +46,16 @@ export const mindmapService = {
   ): Promise<SummarizedNodeRes> => {
     const response = await gptClient.post<SummarizedNodeRes>(
       ENDPOINTS.MINDMAP.SUMMARIZE_NODE,
+      data,
+    );
+    return response.data;
+  },
+
+  createRootNode: async (
+    data: CreateRootNodeReq,
+  ): Promise<CreateRootNodeRes> => {
+    const response = await apiClient.post<CreateRootNodeRes>(
+      ENDPOINTS.MINDMAP.CREATE_ROOT_NODE,
       data,
     );
     return response.data;

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -22,25 +22,9 @@ export type RFState = {
   edges: MindMapEdge[];
   activeState: ActiveState | null;
 
-  onNodesChange: (
-    changes: NodeChange[],
-    saveMindMapData?: (
-      id: number,
-      nodes: MindMapNode[],
-      edges: MindMapEdge[],
-    ) => void,
-    activeMindMapId?: number | null,
-  ) => void;
+  onNodesChange: (changes: NodeChange[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
 
-  onEdgesChange: (
-    changes: EdgeChange[],
-    saveMindMapData?: (
-      id: number,
-      nodes: MindMapNode[],
-      edges: MindMapEdge[],
-    ) => void,
-    activeMindMapId?: number | null,
-  ) => void;
   addChildNode: (
     selectedNode: MindMapNode,
     position: XYPosition,
@@ -63,27 +47,16 @@ const useStore = create<RFState>((set, get) => ({
   edges: initialEdges,
   activeState: null,
 
-  onNodesChange: (changes, saveMindMapData, activeMindMapId) => {
-    const updatedNodes = applyNodeChanges(
-      changes,
-      get().nodes,
-    ) as MindMapNode[];
-
-    set({ nodes: updatedNodes });
-
-    if (saveMindMapData && activeMindMapId) {
-      saveMindMapData(activeMindMapId, updatedNodes, get().edges);
-    }
+  onNodesChange: (changes: NodeChange[]) => {
+    set({
+      nodes: applyNodeChanges(changes, get().nodes) as MindMapNode[],
+    });
   },
 
-  onEdgesChange: (changes, saveMindMapData, activeMindMapId) => {
-    const updatedEdges = applyEdgeChanges(changes, get().edges);
-
-    set({ edges: updatedEdges });
-
-    if (saveMindMapData && activeMindMapId) {
-      saveMindMapData(activeMindMapId, get().nodes, updatedEdges);
-    }
+  onEdgesChange: (changes: EdgeChange[]) => {
+    set({
+      edges: applyEdgeChanges(changes, get().edges),
+    });
   },
 
   addChildNode: (

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -96,9 +96,9 @@ const useStore = create<RFState>((set, get) => ({
 
     const newNode: MindMapNode = {
       id: newNodeId,
-      type: 'question',
+      type: 'QUESTION',
       data: {
-        label: '다음 질문을 선택해주세요',
+        question: '다음 질문을 선택해주세요',
         depth: parentDepth + 1,
         recommendedQuestions: [],
         isPending,

--- a/frontend/src/store/mindmapListStore.ts
+++ b/frontend/src/store/mindmapListStore.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
-import { MindMapNode, MindMap, MindMapEdge } from '@/types/mindMap';
-import { mockMindMaps } from '@/mock/mindmap';
+import {
+  MindMapNode,
+  MindMap,
+  MindMapEdge,
+  MindMapSummary,
+} from '@/types/mindMap';
 import { Task } from '@/types/task';
 import { generateNumericId, generateStringId } from '@/lib/generateNumericId';
 import { ActualTaskType } from '@/types/commonTypes';
@@ -9,6 +13,7 @@ export type MindMapListState = {
   mindMaps: MindMap[];
   activeMindMapId: number | null;
 
+  setMindMaps: (mindMaps: MindMapSummary[]) => void;
   createMindMap: (title: string, type: ActualTaskType) => number;
   createLinkedMindMap: (task: Task) => number;
   loadMindMapData: (id: number) => MindMap | null;
@@ -23,8 +28,10 @@ export type MindMapListState = {
 };
 
 const useStore = create<MindMapListState>((set, get) => ({
-  mindMaps: mockMindMaps,
+  mindMaps: [],
   activeMindMapId: null,
+
+  setMindMaps: (mindMaps) => set({ mindMaps }),
 
   createMindMap: (title, type) => {
     const id = generateNumericId();
@@ -144,6 +151,7 @@ const useStore = create<MindMapListState>((set, get) => ({
 export const useMindMaps = () => useStore((state) => state.mindMaps);
 export const useActiveMindMapId = () =>
   useStore((state) => state.activeMindMapId);
+export const useSetMindMaps = () => useStore((state) => state.setMindMaps);
 export const useCreateMindMap = () => useStore((state) => state.createMindMap);
 export const useCreateLinkedMindMap = () =>
   useStore((state) => state.createLinkedMindMap);

--- a/frontend/src/store/mindmapListStore.ts
+++ b/frontend/src/store/mindmapListStore.ts
@@ -18,11 +18,6 @@ export type MindMapListState = {
   createLinkedMindMap: (task: Task) => number;
   loadMindMapData: (id: number) => MindMap | null;
   setActiveMindMap: (id: number | null) => void;
-  saveMindMapData: (
-    id: number,
-    nodes: MindMapNode[],
-    edges: MindMapEdge[],
-  ) => void;
   disconnectMindmapTask: (mindMapId: number) => void;
 };
 
@@ -104,21 +99,6 @@ const useStore = create<MindMapListState>((set, get) => ({
     set({ activeMindMapId: id });
   },
 
-  saveMindMapData: (id, nodes, edges) => {
-    const mindMapIndex = get().mindMaps.findIndex((m) => m.id === id);
-
-    if (mindMapIndex !== -1) {
-      const updatedMindMaps = [...get().mindMaps];
-      updatedMindMaps[mindMapIndex] = {
-        ...updatedMindMaps[mindMapIndex],
-        nodes,
-        edges,
-      };
-
-      set({ mindMaps: updatedMindMaps });
-    }
-  },
-
   disconnectMindmapTask: (mindMapId) => {
     const mindMapIndex = get().mindMaps.findIndex((m) => m.id === mindMapId);
 
@@ -147,9 +127,6 @@ export const useLoadMindMapData = () =>
   useStore((state) => state.loadMindMapData);
 export const useSetActiveMindMap = () =>
   useStore((state) => state.setActiveMindMap);
-export const useSaveMindMapData = () =>
-  useStore((state) => state.saveMindMapData);
-export const useDeleteMindMap = () => useStore((state) => state.deleteMindMap);
 export const useDisconnectMindmapTask = () =>
   useStore((state) => state.disconnectMindmapTask);
 

--- a/frontend/src/store/mindmapListStore.ts
+++ b/frontend/src/store/mindmapListStore.ts
@@ -23,7 +23,6 @@ export type MindMapListState = {
     nodes: MindMapNode[],
     edges: MindMapEdge[],
   ) => void;
-  deleteMindMap: (id: number) => void;
   disconnectMindmapTask: (mindMapId: number) => void;
 };
 
@@ -118,18 +117,6 @@ const useStore = create<MindMapListState>((set, get) => ({
 
       set({ mindMaps: updatedMindMaps });
     }
-  },
-
-  deleteMindMap: (id) => {
-    const { mindMaps, activeMindMapId } = get();
-    const updatedMindMaps = mindMaps.filter((mindMap) => mindMap.id !== id);
-
-    const newActiveMindMapId = activeMindMapId === id ? null : activeMindMapId;
-
-    set({
-      mindMaps: updatedMindMaps,
-      activeMindMapId: newActiveMindMapId,
-    });
   },
 
   disconnectMindmapTask: (mindMapId) => {

--- a/frontend/src/types/api/mindmap/request.ts
+++ b/frontend/src/types/api/mindmap/request.ts
@@ -1,3 +1,6 @@
+import { ActualTaskType } from '@/types/commonTypes';
+import { MindMapEdge, MindMapNode } from '@/types/mindMap';
+
 export type GenerateReq = {
   mainNode: {
     summary: string;
@@ -17,4 +20,12 @@ export type ConvertedToTaskReq = {
 export type SummarizedNodeReq = {
   question: string;
   answer: string;
+};
+
+export type CreateRootNodeReq = {
+  eisenhowerId: number | null;
+  title: string;
+  type: ActualTaskType;
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
 };

--- a/frontend/src/types/api/mindmap/request.ts
+++ b/frontend/src/types/api/mindmap/request.ts
@@ -29,3 +29,8 @@ export type CreateRootNodeReq = {
   nodes: MindMapNode[];
   edges: MindMapEdge[];
 };
+
+export type UpdateMindmapReq = {
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
+};

--- a/frontend/src/types/api/mindmap/response.ts
+++ b/frontend/src/types/api/mindmap/response.ts
@@ -1,3 +1,5 @@
+import { MindMapSummary } from '@/types/mindMap';
+
 export type GeneratedScheduleRes = {
   generated_questions: string[];
 };
@@ -17,7 +19,13 @@ export type SummarizedNodeRes = {
 };
 
 export type CreateRootNodeRes = {
-  content: number;
   error: string | null;
   statusCode: number;
+  content: number;
+};
+
+export type GetMindmapListRes = {
+  statusCode: number;
+  error: string | null;
+  content: MindMapSummary[];
 };

--- a/frontend/src/types/api/mindmap/response.ts
+++ b/frontend/src/types/api/mindmap/response.ts
@@ -15,3 +15,9 @@ export type ConvertedToTaskRes = {
 export type SummarizedNodeRes = {
   summary: string;
 };
+
+export type CreateRootNodeRes = {
+  content: number;
+  error: string | null;
+  statusCode: number;
+};

--- a/frontend/src/types/api/mindmap/response.ts
+++ b/frontend/src/types/api/mindmap/response.ts
@@ -35,3 +35,9 @@ export type GetMindmapDetailRes = {
   error: string | null;
   content: MindMapDetail;
 };
+
+export type DeleteMindmapRes = {
+  statusCode: number;
+  error: string | null;
+  content: string;
+};

--- a/frontend/src/types/api/mindmap/response.ts
+++ b/frontend/src/types/api/mindmap/response.ts
@@ -1,4 +1,4 @@
-import { MindMapSummary } from '@/types/mindMap';
+import { MindMapDetail, MindMapSummary } from '@/types/mindMap';
 
 export type GeneratedScheduleRes = {
   generated_questions: string[];
@@ -28,4 +28,10 @@ export type GetMindmapListRes = {
   statusCode: number;
   error: string | null;
   content: MindMapSummary[];
+};
+
+export type GetMindmapDetailRes = {
+  statusCode: number;
+  error: string | null;
+  content: MindMapDetail;
 };

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -1,22 +1,22 @@
 import { ActualTaskType, EisenhowerBase } from '@/types/commonTypes';
 import { Node as ReactFlowNode, Edge as ReactFlowEdge } from '@xyflow/react';
 
-export type MindMapNodeType = 'root' | 'question' | 'answer' | 'summary';
+export type MindMapNodeType = 'ROOT' | 'QUESTION' | 'ANSWER' | 'SUMMARY';
 
 export type MindMapNodeData = {
-  label: string;
+  question?: string | null;
   answer?: string | null;
-  summary?: string | null;
+  summary: string | null;
   depth: number;
-  recommendedQuestions?: string[];
+  recommendedQuestions?: string[] | null;
   isPending?: boolean;
   isEditing?: boolean;
 };
 
-export type RootNodeType = ReactFlowNode<MindMapNodeData, 'root'>;
-export type QuestionNodeType = ReactFlowNode<MindMapNodeData, 'question'>;
-export type AnswerNodeType = ReactFlowNode<MindMapNodeData, 'answer'>;
-export type SummaryNodeType = ReactFlowNode<MindMapNodeData, 'summary'>;
+export type RootNodeType = ReactFlowNode<MindMapNodeData, 'ROOT'>;
+export type QuestionNodeType = ReactFlowNode<MindMapNodeData, 'QUESTION'>;
+export type AnswerNodeType = ReactFlowNode<MindMapNodeData, 'ANSWER'>;
+export type SummaryNodeType = ReactFlowNode<MindMapNodeData, 'SUMMARY'>;
 
 export type MindMapNode =
   | RootNodeType

--- a/frontend/src/types/mindMap.ts
+++ b/frontend/src/types/mindMap.ts
@@ -36,3 +36,21 @@ export type MindMap = {
   linked: boolean;
   eisenhowerItemDTO?: EisenhowerBase;
 };
+
+export type MindMapSummary = {
+  id: number;
+  title: string;
+  type: ActualTaskType;
+  lastModifiedAt: string;
+  linked: boolean;
+  eisenhowerItemDTO: EisenhowerBase | null;
+};
+
+export type MindMapDetail = {
+  id: number;
+  title: string;
+  type: ActualTaskType;
+  lastModifiedAt: string;
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #138 

## 📝 작업 내용
### 마인드맵 타입 수정
백엔드 Swagger 문서에 맞게 마인드맵 관련 타입들을 수정하였습니다.

**nodeTypes**
- `root` -> `ROOT`
- `summary` -> `SUMMARY`
- `answer` -> `ANSWER`
- `question` -> `QUESTION`

**MindmapNodeData**
- `label` -> `summary`로 통일

**기존의 MindMap Type 분리**
- `MindMapSummary`: 마인드맵 리스트 조회 시 응답받는 데이터 구조
- `MindMapDetail`: 마인드맵 상세 조회 시 응답받는 데이터 구조


### 마인드맵 리스트&상세 조회, 생성, 삭제 API 연동
기존 Store 기반으로 구현되어 있던 로직을 API 호출 방식으로 대체하였습니다.
크게 복잡한 변경은 없으며, 기존 로직을 API 연동 방식으로 갈아낀 수준입니다.

API 연동 과정에서, 더 이상 사용되지 않는 store 내부 함수들은 정리하여 제거하였습니다.

리스트 및 상세 조회 시 쿼리 키를 활용한 최적화는, TanStack Query 관련 최적화 이슈에서 별도로 다뤄볼 예정입니다.

### 마인드맵 수정 API 디바운싱 적용
마인드맵은 노드 및 엣지의 수정이 자주 발생하는 특성상, 매번 API를 호출하게 되면 네트워크 낭비 및 서버 부하가 커질 수 있습니다.
이를 방지하기 위해 `useDebounceMindmapUpdate` 훅을 통해 디바운싱 로직을 구현하였습니다.
- `debounceSave()`: 수정이 발생할 때마다 타이머를 초기화하고, 일정 시간(default: 5초) 동안 추가 수정이 없을 경우에만 API 호출이 발생합니다.
- `forceSave()`: 디바운싱 대기 시간과 관계없이 즉시 저장을 실행합니다. 특정 시점(예: 페이지 이탈 전 등)에 강제 저장이 필요할 경우 활용할 예정입니다. 

이 방식으로 빈번한 수정에도 불필요한 API 호출을 최소화하면서, 데이터 유실 없이 안정적으로 저장할 수 있도록 했습니다.

## 💬 리뷰 요구사항(선택)
현재 마인드맵 기획이 뒤집어진 상태라, 우선 Swagger 상 정의된 API 연동 작업만 완료한 상황입니다.
마인드맵 관련 추가 처리 사항은 전부 배제하고, 기능 연결 위주로 작업했다고 봐주시면 될 것 같습니다!

API 요청에 대한 로딩/에러 처리, TanStack Query 및 Zustand 관련 최적화는 뽀모도로 API 연동 작업을 1차적으로 마친 후, 전체적으로 다듬어보려 합니다.

추후 기획 상세 플로우가 정리되면, 그에 맞춰 마인드맵 코드도 전체적으로 리팩토링할 예정입니다 😄