### PR TITLE
[BE] fix: HTTPS 적용으로 인한 cookie 설정 변경

### DIFF
--- a/backend/src/main/java/capstone/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/capstone/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -76,6 +76,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
 
         String uri  = request.getRequestURI();
-        return Stream.of("/api/auth/refresh-token").anyMatch(uri::equalsIgnoreCase);
+        return Stream.of("/api/auth/reissue").anyMatch(uri::equalsIgnoreCase);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #166 

## 📝 작업 내용

https 적용으로 인한 쿠키 Samesite 및 secure 설정
- https에서는 samesite = None, secure = true 설정 필요
- 크롬 브라우저 쿠키 디폴트 값이 samesite = Lax로 변경됨. (따라서, 설정이 필요함)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

### 꼭! 프론트에서 HTTPS 적용된 이후에 Merge 해주세요!
