### PR TITLE
[BE] fix: 사용하지 않는 controller v1으로 분기 & 기획 수정 이후 사용하는 controller를 v2로 분기

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v1/PomodoroV1Controller.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v1/PomodoroV1Controller.java
@@ -1,7 +1,6 @@
-package capstone.backend.domain.pomodoro.controller;
+package capstone.backend.domain.pomodoro.controller.v1;
 
 
-import capstone.backend.domain.pomodoro.dto.request.RecordPomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.request.CreatePomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.response.PomodoroDTO;
 import capstone.backend.domain.pomodoro.dto.response.SidebarResponse;
@@ -18,11 +17,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "뽀모도로 타이머", description = "뽀모도로 타이머 관련 API")
+@Tag(name = "(미사용) 뽀모도로 타이머 V1", description = "Version 1. 뽀모도로 타이머 관련 API")
 @RestController
-@RequestMapping("/api/pomodoro")
+@RequestMapping("/api/pomodoro/v1")
 @RequiredArgsConstructor
-public class PomodoroController {
+public class PomodoroV1Controller {
 
     private final PomodoroService pomodoroService;
 
@@ -51,18 +50,6 @@ public class PomodoroController {
             @AuthenticationPrincipal CustomOAuth2User user
     ) {
         return ApiResponse.ok(pomodoroService.findById(user.getMemberId(), id));
-    }
-
-    @PatchMapping("/{id}")
-    @Operation(summary = "뽀모도로 완료 및 기록")
-    public ApiResponse<Void> setPomodoro(
-            @Parameter(name = "id", description = "뽀모도로 ID", required = true, in = ParameterIn.PATH)
-            @PathVariable Long id,
-            @Valid @RequestBody RecordPomodoroRequest request,
-            @AuthenticationPrincipal CustomOAuth2User user
-    ) {
-        pomodoroService.recordPomodoro(user.getMemberId(), id, request);
-        return ApiResponse.ok();
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/DailyPomodoroSummaryController.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/DailyPomodoroSummaryController.java
@@ -1,4 +1,4 @@
-package capstone.backend.domain.pomodoro.controller;
+package capstone.backend.domain.pomodoro.controller.v2;
 
 
 import capstone.backend.domain.pomodoro.dto.request.MonthlyParamsDTO;
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-@Tag(name = "데이터 분석 - 뽀모도로 타이머", description = "뽀모도로 타이머 이용량 관련 API")
+@Tag(name = "데이터 분석 - 뽀모도로 타이머 V2", description = "뽀모도로 타이머 이용량 관련 API")
 @RestController
-@RequestMapping("/api/data/pomodoro")
+@RequestMapping("/api/data/pomodoro/v2")
 @RequiredArgsConstructor
 public class DailyPomodoroSummaryController {
 

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/PomodoroV2Controller.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/PomodoroV2Controller.java
@@ -1,0 +1,35 @@
+package capstone.backend.domain.pomodoro.controller.v2;
+
+
+import capstone.backend.domain.pomodoro.dto.request.RecordPomodoroRequest;
+import capstone.backend.domain.pomodoro.service.PomodoroService;
+import capstone.backend.global.api.dto.ApiResponse;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "뽀모도로 타이머 V2", description = "Version 2. 기획 수정 후 뽀모도로 타이머 관련 API")
+@RestController
+@RequestMapping("/api/pomodoro/v2")
+@RequiredArgsConstructor
+public class PomodoroV2Controller {
+
+    private final PomodoroService pomodoroService;
+
+    @PatchMapping
+    @Operation(summary = "뽀모도로 완료 및 기록")
+    public ApiResponse<Void> setPomodoro(
+            @Valid @RequestBody RecordPomodoroRequest request,
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        pomodoroService.recordPomodoro(user.getMemberId(), request);
+        return ApiResponse.ok();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
@@ -101,20 +101,11 @@ public class PomodoroService {
 
     // 뽀모도로 완료 기록
     @Transactional
-    public void recordPomodoro(Long memberId, Long pomodoroId, RecordPomodoroRequest request) {
-        Pomodoro pomodoro = pomodoroRepository.findByIdAndMemberId(pomodoroId, memberId)
-                .orElseThrow(PomodoroNotFoundException::new);
-
+    public void recordPomodoro(Long memberId, RecordPomodoroRequest request) {
         List<PomodoroCycle> executedCycles = request.executedCycles();
-        pomodoro.recordCompletedAt(executedCycles);
 
         // 최적화된 시간 계산
         int[] times = calculateTotalTimeSummary(executedCycles);
-
-        // Pomodoro 객체 업데이트 (JPA Dirty Checking)
-        pomodoro.updateTotalExecutedWorkingTime(convertSecondsToLocalTime(times[0]));
-        pomodoro.updateTotalExecutedBreakTime(convertSecondsToLocalTime(times[1]));
-        pomodoro.updateTotalExecutedTime(convertSecondsToLocalTime(times[2]));
 
         // 일일 뽀모도로 총 시간 업데이트
         dailyPomodoroSummaryService.updateDailyPomodoroSummary(memberId, times[2]);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #170 

## 📝 작업 내용

사용하지 않는 controller v1으로 분기 & 기획 수정 이후 사용하는 controller를 v2로 분기

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

수정된 기획으로 만들어진 것도 다 v2로 할 건지, 버블 같이 이번에 새로 만들어진 도메인은 v1으로 둘 건지 어떻게 하면 좋을까요?

더 수정될 수 있으니 머지는 최종 정해지면 두 분 리뷰 받고 제가 하겠습니다!
