### PR TITLE
[BE] feat: Bubble 도메인 관련 API 설계

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/backend/src/main/java/capstone/backend/domain/bubble/controller/v2/BubbleController.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/controller/v2/BubbleController.java
@@ -1,0 +1,87 @@
+package capstone.backend.domain.bubble.controller.v2;
+
+
+import capstone.backend.domain.bubble.dto.request.ConfirmBubbleRequest;
+import capstone.backend.domain.bubble.dto.request.PromptRequest;
+import capstone.backend.domain.bubble.dto.response.BubbleDTO;
+import capstone.backend.domain.bubble.service.BubbleService;
+import capstone.backend.domain.bubble.service.WebFluxService;
+import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemCreateRequest;
+import capstone.backend.domain.member.scheme.Member;
+import capstone.backend.domain.member.service.MemberService;
+import capstone.backend.global.api.dto.ApiResponse;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "버블 API", description = "버블 관련 API 구현")
+@RestController
+@RequestMapping("/api/v2/bubble")
+@RequiredArgsConstructor
+public class BubbleController {
+
+    private final BubbleService bubbleService;
+    private final MemberService memberService;
+    private final WebFluxService webFluxService;
+
+    @GetMapping
+    @Operation(summary = "버블 전체 조회 API", description = "버블 전체 조회 시 prompt, id 반환")
+    public ApiResponse<List<BubbleDTO>> getBubbles(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        return ApiResponse.ok(bubbleService.findBubbles(user.getMemberId()));
+    }
+
+    @PostMapping("/create")
+    @Operation(summary = "버블 생성 API", description = "프롬프트를 기준으로 GPT API에서 뽑아준 청크 단위로 버블 생성 후 반환")
+    public ApiResponse<List<BubbleDTO>> createBubbles(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody PromptRequest request
+    ) {
+        Member member = memberService.findById(user.getMemberId());
+        return ApiResponse.ok(webFluxService.createBubblesSync(request, member));
+//        return webFluxService.createBubblesAsync(request, member).map(ApiResponse::ok);
+    }
+
+    @PostMapping("/confirm-eisenhower/{id}")
+    @Operation(summary = "버블 확정 (아이젠하워)", description = "버블 내용을 바탕으로 아이젠하워 TODO 생성")
+    public ApiResponse<Void> confirmEisenhower(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody EisenhowerItemCreateRequest request,
+            @Parameter(name = "bubble id", description = "버블 ID", example = "1", required = true)
+            @PathVariable Long id
+    ) {
+        bubbleService.confirmToEisenhower(request, user.getMemberId(), id);
+        return ApiResponse.ok();
+    }
+
+    @PostMapping("/confirm-inventory/{id}")
+    @Operation(summary = "버블 확정 (보관함)", description = "버블 내용을 바탕으로 보관함 Item 생성")
+    public ApiResponse<Void> confirmInventory(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody ConfirmBubbleRequest request,
+            @Parameter(name = "bubble id", description = "버블 ID", example = "1", required = true)
+            @PathVariable Long id
+    ) {
+        bubbleService.confirmToInventory(request, user.getMemberId(), id);
+        return ApiResponse.ok();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "버블 삭제", description = "특정 버블 삭제 API")
+    public ApiResponse<Void> deleteBubble(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Parameter(name = "bubble id", description = "버블 ID", example = "1", required = true)
+            @PathVariable Long id
+    ) {
+        bubbleService.deleteBubble(user.getMemberId(), id);
+        return ApiResponse.ok();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/request/ConfirmBubbleRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/request/ConfirmBubbleRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.NotBlank;
 public record ConfirmBubbleRequest(
         @NotBlank(message = "버블의 텍스트를 입력해주세요.")
         @Schema(description = "버블의 텍스트", example = "캡스톤 개발을 해야 한다.")
-        String prompt
+        String text
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/request/ConfirmBubbleRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/request/ConfirmBubbleRequest.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.bubble.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ConfirmBubbleRequest(
+        @NotBlank(message = "버블의 텍스트를 입력해주세요.")
+        @Schema(description = "버블의 텍스트", example = "캡스톤 개발을 해야 한다.")
+        String prompt
+) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/request/PromptRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/request/PromptRequest.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.bubble.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record PromptRequest(
+        @NotBlank(message = "프롬프트를 입력해주세요.")
+        @Schema(description = "사용자가 입력한 프롬프트", example = "하 오늘 캡스톤 개발해야되는데 운동도 가야되는데")
+        String prompt
+) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/request/PromptRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/request/PromptRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.NotBlank;
 public record PromptRequest(
         @NotBlank(message = "프롬프트를 입력해주세요.")
         @Schema(description = "사용자가 입력한 프롬프트", example = "하 오늘 캡스톤 개발해야되는데 운동도 가야되는데")
-        String prompt
+        String text
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/response/BubbleDTO.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/response/BubbleDTO.java
@@ -1,0 +1,15 @@
+package capstone.backend.domain.bubble.dto.response;
+
+import capstone.backend.domain.bubble.entity.Bubble;
+
+public record BubbleDTO(
+        Long bubbleId,
+        String title
+) {
+    public BubbleDTO(Bubble bubble) {
+        this(
+                bubble.getId(),
+                bubble.getTitle()
+        );
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/response/PromptResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/response/PromptResponse.java
@@ -1,7 +1,10 @@
 package capstone.backend.domain.bubble.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record PromptResponse(
+        @JsonProperty("extracted_chunks")
         List<String> chunks
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/response/PromptResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/response/PromptResponse.java
@@ -1,0 +1,7 @@
+package capstone.backend.domain.bubble.dto.response;
+
+import java.util.List;
+
+public record PromptResponse(
+        List<String> chunks
+) {}

--- a/backend/src/main/java/capstone/backend/domain/bubble/entity/Bubble.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/entity/Bubble.java
@@ -1,0 +1,32 @@
+package capstone.backend.domain.bubble.entity;
+
+
+import capstone.backend.domain.member.scheme.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Bubble {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "bubble_id")
+    private Long id;
+
+    @Column(nullable = false, name = "title")
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public static Bubble create(String title, Member member) {
+        return Bubble.builder()
+                .title(title)
+                .member(member)
+                .build();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/exception/BubbleNotFoundException.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/exception/BubbleNotFoundException.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.bubble.exception;
+
+import capstone.backend.global.api.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class BubbleNotFoundException extends ApiException {
+    public BubbleNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "버블을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
@@ -1,0 +1,11 @@
+package capstone.backend.domain.bubble.repository;
+
+
+import capstone.backend.domain.bubble.entity.Bubble;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BubbleRepository extends JpaRepository<Bubble, Long> {
+    List<Bubble> findAllByMemberId(Long memberId);
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
@@ -5,7 +5,9 @@ import capstone.backend.domain.bubble.entity.Bubble;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
     List<Bubble> findAllByMemberId(Long memberId);
+    Optional<Bubble> findByMemberIdAndId(Long memberId, Long id);
 }

--- a/backend/src/main/java/capstone/backend/domain/bubble/service/BubbleService.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/service/BubbleService.java
@@ -1,0 +1,60 @@
+package capstone.backend.domain.bubble.service;
+
+
+import capstone.backend.domain.bubble.dto.request.ConfirmBubbleRequest;
+import capstone.backend.domain.bubble.dto.response.BubbleDTO;
+import capstone.backend.domain.bubble.entity.Bubble;
+import capstone.backend.domain.bubble.exception.BubbleNotFoundException;
+import capstone.backend.domain.bubble.repository.BubbleRepository;
+import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemCreateRequest;
+import capstone.backend.domain.eisenhower.service.EisenhowerItemService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class BubbleService {
+
+    private final BubbleRepository bubbleRepository;
+    private final EisenhowerItemService eisenhowerItemService;
+
+    // 버블 전체 조회
+    public List<BubbleDTO> findBubbles(Long memberId) {
+        return bubbleRepository.findAllByMemberId(memberId)
+                .stream().map(BubbleDTO::new).toList();
+    }
+
+    // 버블 확정 (아이젠하워로)
+    @Transactional
+    public void confirmToEisenhower(EisenhowerItemCreateRequest request, Long memberId, Long bubbleId) {
+        Bubble bubble = bubbleRepository.findByMemberIdAndId(memberId, bubbleId).orElseThrow(BubbleNotFoundException::new);
+
+        eisenhowerItemService.createItem(request, memberId);
+        bubbleRepository.delete(bubble);
+        log.info("Eisenhower item confirmed for bubble {}", bubbleId);
+    }
+
+    // 버블 확정 (생각 바구니로)
+    @Transactional
+    public void confirmToInventory(ConfirmBubbleRequest request, Long memberId, Long bubbleId) {
+        Bubble bubble = bubbleRepository.findByMemberIdAndId(memberId, bubbleId).orElseThrow(BubbleNotFoundException::new);
+
+        // TODO 추후 보관함 생성 로직 구현
+
+
+        bubbleRepository.delete(bubble);
+    }
+
+    // 버블 삭제
+    @Transactional
+    public void deleteBubble(Long memberId, Long bubbleId) {
+        Bubble bubble = bubbleRepository.findByMemberIdAndId(memberId, bubbleId).orElseThrow(BubbleNotFoundException::new);
+        bubbleRepository.delete(bubble);
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/service/WebFluxService.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/service/WebFluxService.java
@@ -1,0 +1,62 @@
+package capstone.backend.domain.bubble.service;
+
+
+import capstone.backend.domain.bubble.dto.request.PromptRequest;
+import capstone.backend.domain.bubble.dto.response.BubbleDTO;
+import capstone.backend.domain.bubble.dto.response.PromptResponse;
+import capstone.backend.domain.bubble.entity.Bubble;
+import capstone.backend.domain.bubble.repository.BubbleRepository;
+import capstone.backend.domain.member.scheme.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WebFluxService {
+
+    private final WebClient.Builder webClientBuilder;
+    private final BubbleRepository bubbleRepository;
+
+    @Value("${url.path.model.prompt}")
+    private String gptServerEndpoint;
+
+    // memberRepository에서 직접 조회하는 경우 동기적으로 작동함
+    // 따라서, 한 트랜잭션 안에 member를 조회하는 로직을 제외하고 Member 객체를 받게 로직 설정
+    @Transactional
+    public Mono<List<BubbleDTO>> createBubbles(PromptRequest request, Member member) {
+        log.info("GPT API 호출");
+
+        WebClient webClient = webClientBuilder.build();
+
+        return webClient.post()
+                .uri(gptServerEndpoint)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(PromptResponse.class)
+                .map(response -> {
+                    // 요청 결과를 Bubble 엔티티로 변환
+                    List<Bubble> bubbles = response.chunks().stream()
+                            .map(title -> Bubble.create(title, member))
+                            .toList();
+
+                    // 저장
+                    bubbleRepository.saveAll(bubbles);
+
+                    log.info("Bubbles 저장 완료: count = {}", bubbles.size());
+
+                    // DTO 변환
+                    return bubbles.stream()
+                            .map(BubbleDTO::new)
+                            .toList();
+                });
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package capstone.backend.domain.member.service;
 import capstone.backend.domain.member.dto.response.UserDataDTO;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
+import capstone.backend.domain.member.scheme.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,4 +20,9 @@ public class MemberService {
                 .map(UserDataDTO::new)
                 .orElseThrow(MemberNotFoundException::new);
     }
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    }
+
 }

--- a/backend/src/main/java/capstone/backend/global/api/webflux/WebFluxConfig.java
+++ b/backend/src/main/java/capstone/backend/global/api/webflux/WebFluxConfig.java
@@ -23,7 +23,7 @@ public class WebFluxConfig {
     private String gptServerDomain;
 
     @Bean
-    public WebClient.Builder webClientBuilder() {
+    public WebClient webClient() {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 5초 동안 연결 안 되면 실패
                 .responseTimeout(Duration.ofMinutes(1))             // 1분 동안 응답 안올 시 에러
@@ -52,6 +52,6 @@ public class WebFluxConfig {
                                                 throwable instanceof java.util.concurrent.TimeoutException
                                         )
                         )
-                );
+                ).build();
     }
 }

--- a/backend/src/main/java/capstone/backend/global/api/webflux/WebFluxConfig.java
+++ b/backend/src/main/java/capstone/backend/global/api/webflux/WebFluxConfig.java
@@ -1,0 +1,57 @@
+package capstone.backend.global.api.webflux;
+
+import capstone.backend.global.api.exception.ApiException;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+
+@Configuration
+public class WebFluxConfig {
+
+    @Value("${url.base.model}")
+    private String gptServerDomain;
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 5초 동안 연결 안 되면 실패
+                .responseTimeout(Duration.ofMinutes(1))             // 1분 동안 응답 안올 시 에러
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(5))  // 읽기 타임아웃 5초
+                                .addHandlerLast(new WriteTimeoutHandler(5)) // 쓰기 타임아웃 5초
+                );
+
+        // API 요청 결과 에러 핸들링
+        return WebClient.builder()
+                .baseUrl(gptServerDomain)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter((request, next) -> next.exchange(request)
+                        .flatMap(response -> {
+                            if (response.statusCode().isError()) {
+                                HttpStatus status = (HttpStatus) response.statusCode();
+                                return response.bodyToMono(String.class)
+                                        .flatMap(body -> Mono.error(new ApiException(status, "API Error: " + body)));
+                            }
+                            return Mono.just(response);
+                        })
+                        .retryWhen(
+                                Retry.fixedDelay(1, Duration.ofSeconds(2)) // 실패하면 2초 간격으로 한 번 더 재시도
+                                        .filter(throwable ->
+                                                throwable instanceof ApiException ||
+                                                throwable instanceof java.util.concurrent.TimeoutException
+                                        )
+                        )
+                );
+    }
+}

--- a/backend/src/main/java/capstone/backend/global/database/querydsl/QuerydslConfig.java
+++ b/backend/src/main/java/capstone/backend/global/database/querydsl/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package capstone.backend.global.querydsl.config;
+package capstone.backend.global.database.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/backend/src/main/java/capstone/backend/global/database/redis/RedisConfig.java
+++ b/backend/src/main/java/capstone/backend/global/database/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package capstone.backend.global.redis;
+package capstone.backend.global.database.redis;
 
 import capstone.backend.global.property.RedisProperty;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/capstone/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/capstone/backend/global/security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] SWAGGER_ENDPOINTS = { "/swagger", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**" };
-    private static final String[] PUBLIC_ENDPOINTS = { "/", "/api/auth/**", "/config/**" };
+    private static final String[] PUBLIC_ENDPOINTS = { "/", "/api/auth/**", "/actuator/**" };
     private static final String[] STATIC_ENDPOINTS = { "/error", "/favicon.ico", "/static/**",
             "/public/**", "/resources/**", "/META-INF/resources/**" };
 

--- a/backend/src/main/java/capstone/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/capstone/backend/global/security/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
     private final OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    private static final String[] WEBCLIENT_ENDPOINTS = { "/api/bubble/v2/create" };
     private static final String[] SWAGGER_ENDPOINTS = { "/swagger", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**" };
     private static final String[] PUBLIC_ENDPOINTS = { "/", "/api/auth/**", "/actuator/**" };
     private static final String[] STATIC_ENDPOINTS = { "/error", "/favicon.ico", "/static/**",
@@ -51,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .requestMatchers(STATIC_ENDPOINTS).permitAll()
+                        .requestMatchers(WEBCLIENT_ENDPOINTS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #172 

## 📝 작업 내용

1. 프롬프트 입력 시 청크 단위로 버블 생성 로직 구현 (비동기 -> 동기 처리로 변경)
2. WebFlux 호출 설정 코드 작성
3. global 레이어에 있는 Database 코드 변경
4. 버블 삭제 로직 구현
5. 버블 확정 로직 구현

### 스크린샷 (선택)
- 버블 생성
<img width="678" alt="image" src="https://github.com/user-attachments/assets/f7d4e1de-f945-4cd1-94e6-ffbf3823e1de" />

## 💬 리뷰 요구사항(선택)

현재 **버블 확정 시 보관함으로 빼는 로직**이 작성되지 않았습니다.

따라서, 보관함 feature 브랜치 먼저 병합 후 로직 수정 진행하겠습니다.
