### PR TITLE
수정된 마인드맵 기능 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dagrejs/dagre": "^1.1.4",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -589,6 +590,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.4.tgz",
+      "integrity": "sha512-QUTc54Cg/wvmlEUxB+uvoPVKFazM1H18kVHBQNmK2NbrDR5ihOCR6CXLnDSZzMcSQKJtabPUWridBOlJM3WkDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.2.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.1.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -1,0 +1,95 @@
+import { useMindmapStoreV2 } from '@/store/mindmapStoreV2';
+import { Handle, NodeProps, Position } from '@xyflow/react';
+import { CirclePlus } from 'lucide-react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export default function CustomNode({ data, id, isConnectable }: NodeProps) {
+  const isHorizontal = data.layoutDirection === 'LR';
+  const [labelText, setLabelText] = useState(data.label || '');
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const updateNodeLabel = useMindmapStoreV2((state) => state.updateNodeLabel);
+  const updateNodeHeight = useMindmapStoreV2((state) => state.updateNodeHeight);
+  const addChildNode = useMindmapStoreV2((state) => state.addChildNode);
+
+  useEffect(() => {
+    setLabelText(data.label || '');
+  }, [data.label]);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+
+      if (nodeRef.current) {
+        const totalHeight = nodeRef.current.offsetHeight;
+        updateNodeHeight(id, totalHeight);
+      }
+    }
+  }, [labelText, id, updateNodeHeight]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newValue = e.target.value;
+      setLabelText(newValue);
+
+      updateNodeLabel(id, newValue);
+    },
+    [id, updateNodeLabel],
+  );
+
+  const handlePlusClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      addChildNode(id);
+    },
+    [id, addChildNode],
+  );
+
+  return (
+    <div
+      ref={nodeRef}
+      className="px-6 py-4 bg-white border border-[#CDCED6] rounded-md w-[172px] relative"
+    >
+      <textarea
+        ref={textareaRef}
+        value={labelText}
+        onChange={handleChange}
+        placeholder="텍스트를 입력하세요"
+        className="text-[14px] text-center font-semibold w-full outline-none bg-transparent resize-none overflow-hidden min-h-[20px]"
+        rows={1}
+      />
+
+      {/* CirclePlus 아이콘 */}
+      <div
+        className="absolute left-1/2 -translate-x-1/2 bottom-0 translate-y-1/2 z-10"
+        onClick={handlePlusClick}
+      >
+        <CirclePlus
+          className="plus-btn cursor-pointer text-blue bg-white rounded-full"
+          size={16}
+        />
+      </div>
+
+      {/* 핸들 */}
+      <Handle
+        type="source"
+        position={isHorizontal ? Position.Right : Position.Bottom}
+        id="source"
+        className="opacity-0"
+        style={{ width: '1px', height: '1px' }}
+        isConnectable={isConnectable}
+      />
+
+      <Handle
+        type="target"
+        position={isHorizontal ? Position.Left : Position.Top}
+        id="target"
+        className="opacity-0"
+        style={{ width: '1px', height: '1px' }}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -1,4 +1,4 @@
-import { useMindmapStoreV2 } from '@/store/mindmapStoreV2';
+import { useMindmapStore } from '@/store/mindMapStore';
 import { Handle, NodeProps, Position } from '@xyflow/react';
 import { CirclePlus } from 'lucide-react';
 import { useState, useCallback, useEffect, useRef } from 'react';
@@ -9,9 +9,9 @@ export default function CustomNode({ data, id, isConnectable }: NodeProps) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const updateNodeLabel = useMindmapStoreV2((state) => state.updateNodeLabel);
-  const updateNodeHeight = useMindmapStoreV2((state) => state.updateNodeHeight);
-  const addChildNode = useMindmapStoreV2((state) => state.addChildNode);
+  const updateNodeLabel = useMindmapStore((state) => state.updateNodeLabel);
+  const updateNodeHeight = useMindmapStore((state) => state.updateNodeHeight);
+  const addChildNode = useMindmapStore((state) => state.addChildNode);
 
   useEffect(() => {
     setLabelText(data.label || '');

--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -1,9 +1,18 @@
 import { useMindmapStore } from '@/store/mindMapStore';
-import { Handle, NodeProps, Position } from '@xyflow/react';
+import { Handle, Node, NodeProps, Position } from '@xyflow/react';
 import { CirclePlus } from 'lucide-react';
 import { useState, useCallback, useEffect, useRef } from 'react';
 
-export default function CustomNode({ data, id, isConnectable }: NodeProps) {
+type CustomNodeData = {
+  label: string;
+  layoutDirection: string;
+};
+
+export default function CustomNode({
+  data,
+  id,
+  isConnectable,
+}: NodeProps<Node<CustomNodeData>>) {
   const isHorizontal = data.layoutDirection === 'LR';
   const [labelText, setLabelText] = useState(data.label || '');
   const nodeRef = useRef<HTMLDivElement>(null);
@@ -61,7 +70,6 @@ export default function CustomNode({ data, id, isConnectable }: NodeProps) {
         rows={1}
       />
 
-      {/* CirclePlus 아이콘 */}
       <div
         className="absolute left-1/2 -translate-x-1/2 bottom-0 translate-y-1/2 z-10"
         onClick={handlePlusClick}
@@ -72,7 +80,6 @@ export default function CustomNode({ data, id, isConnectable }: NodeProps) {
         />
       </div>
 
-      {/* 핸들 */}
       <Handle
         type="source"
         position={isHorizontal ? Position.Right : Position.Bottom}

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useState } from 'react';
+import {
+  ReactFlow,
+  ConnectionLineType,
+  Panel,
+  useNodesState,
+  useEdgesState,
+  ReactFlowProvider,
+  Node,
+  Edge,
+  NodeMouseHandler,
+  Position,
+} from '@xyflow/react';
+import dagre from '@dagrejs/dagre';
+
+import '@xyflow/react/dist/style.css';
+import {
+  initialEdges,
+  initialNodes,
+} from '@/components/mindmap/initailElements';
+
+const flowStyles = {
+  background: '#E8EFFF',
+};
+
+const nodeStyles = {
+  transition: 'all 0.5s ease',
+};
+
+const edgeStyles = {
+  transition: 'all 0.5s ease',
+  strokeWidth: 1.5,
+  stroke: '#0080ff',
+};
+
+const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+
+const nodeWidth = 172;
+const nodeHeight = 36;
+
+// 루트 노드 ID - 추후 삭제
+const ROOT_NODE_ID = '4';
+
+const getLayoutedElements = (
+  nodes: Node[],
+  edges: Edge[],
+  direction: 'TB' | 'LR' = 'TB',
+) => {
+  const isHorizontal = direction === 'LR';
+
+  // 루트 노드의 현재 위치 저장
+  const rootNode = nodes.find((node) => node.id === ROOT_NODE_ID);
+  const rootPosition = rootNode ? { ...rootNode.position } : { x: 0, y: 0 };
+
+  // Dagre를 사용하여 전체 그래프 레이아웃 계산
+  dagreGraph.setGraph({ rankdir: direction });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  // 루트 노드의 Dagre 계산 위치 가져오기
+  const dagreeRootPos = dagreGraph.node(ROOT_NODE_ID);
+  if (!dagreeRootPos) {
+    return { nodes, edges };
+  }
+
+  // Dagre가 계산한 루트 위치와 실제 루트 위치 간의 차이 계산
+  const diffX = rootPosition.x - (dagreeRootPos.x - nodeWidth / 2);
+  const diffY = rootPosition.y - (dagreeRootPos.y - nodeHeight / 2);
+
+  // 모든 노드에 대해 위치 조정 (트리 구조는 유지하면서 전체를 이동)
+  const newNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    if (!nodeWithPosition) {
+      return node;
+    }
+
+    // Dagre 계산 위치에 차이값을 더해 조정
+    const position = {
+      x: nodeWithPosition.x - nodeWidth / 2 + diffX,
+      y: nodeWithPosition.y - nodeHeight / 2 + diffY,
+    };
+
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      position,
+    };
+  });
+
+  return { nodes: newNodes, edges };
+};
+
+// 초기 레이아웃 계산
+const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+  initialNodes,
+  initialEdges.map((edge) => ({
+    ...edge,
+    animated: true,
+    style: edgeStyles,
+  })),
+);
+
+function FlowContent() {
+  const [nodes, setNodes, onNodesChange] = useNodesState(layoutedNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(layoutedEdges);
+  const [currentDirection, setCurrentDirection] = useState<'TB' | 'LR'>('TB');
+
+  // 레이아웃 변경 시 부드러운 애니메이션 적용
+  const onLayout = useCallback(
+    (direction: 'TB' | 'LR') => {
+      setCurrentDirection(direction);
+      const { nodes: layoutedNodes, edges: layoutedEdges } =
+        getLayoutedElements(nodes, edges, direction);
+
+      setNodes(layoutedNodes);
+      setEdges(layoutedEdges);
+    },
+    [nodes, edges, setNodes, setEdges],
+  );
+
+  // 노드 클릭 핸들러 추가
+  const onNodeClick: NodeMouseHandler = useCallback(
+    (event, clickedNode) => {
+      // 랜덤 ID 생성
+      const randomId = Math.random().toString(36).substring(2, 10);
+      const newNodeId = `node-${randomId}`;
+
+      // 새 하위 노드 생성
+      const newChildNode: Node = {
+        id: newNodeId,
+        data: { label: `Child of ${clickedNode.id}` },
+        // 초기 위치는 클릭된 노드 아래에 배치 (정확한 위치는 어차피 재배치됨!)
+        position: {
+          x: clickedNode.position.x + 100,
+          y: clickedNode.position.y + 100,
+        },
+        targetPosition:
+          currentDirection === 'LR' ? Position.Left : Position.Top,
+        sourcePosition:
+          currentDirection === 'LR' ? Position.Right : Position.Bottom,
+        style: nodeStyles,
+      };
+
+      // 상위 노드와 하위 노드를 연결하는 새 엣지 생성
+      const newEdge: Edge = {
+        id: `edge-${clickedNode.id}-${newNodeId}`,
+        source: clickedNode.id,
+        target: newNodeId,
+        type: ConnectionLineType.SmoothStep,
+        animated: true,
+        style: edgeStyles,
+      };
+
+      // 새 노드와 엣지 추가 후 레이아웃 재계산
+      const updatedNodes = [...nodes, newChildNode];
+      const updatedEdges = [...edges, newEdge];
+
+      const { nodes: layoutedNodes, edges: layoutedEdges } =
+        getLayoutedElements(updatedNodes, updatedEdges, currentDirection);
+
+      setNodes(layoutedNodes);
+      setEdges(layoutedEdges);
+    },
+    [nodes, edges, currentDirection, setNodes, setEdges],
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onNodeClick={onNodeClick}
+      connectionLineType={ConnectionLineType.SmoothStep}
+      fitView
+      style={flowStyles}
+      defaultViewport={{ x: 0, y: 0, zoom: 1 }}
+      nodesDraggable={false}
+    >
+      <Panel position="top-right">
+        <div className="flex gap-2">
+          <button
+            onClick={() => onLayout('TB')}
+            className="px-3 py-1 bg-blue-500 text-white rounded"
+          >
+            vertical layout
+          </button>
+          <button
+            onClick={() => onLayout('LR')}
+            className="px-3 py-1 bg-blue-500 text-white rounded"
+          >
+            horizontal layout
+          </button>
+        </div>
+      </Panel>
+    </ReactFlow>
+  );
+}
+
+function MindmapWrapper() {
+  return (
+    <ReactFlowProvider>
+      <FlowContent />
+    </ReactFlowProvider>
+  );
+}
+
+export default MindmapWrapper;

--- a/frontend/src/components/mindmap/initailElements.ts
+++ b/frontend/src/components/mindmap/initailElements.ts
@@ -1,0 +1,68 @@
+import { Edge, Node } from '@xyflow/react';
+
+const nodeStyles = {
+  transition: 'all 0.5s ease',
+};
+
+const edgeStyles = {
+  transition: 'all 0.5s ease',
+  strokeWidth: 1.5,
+  stroke: '#0080ff',
+};
+
+const position = { x: 0, y: 0 };
+const edgeType = 'smoothstep';
+
+export const initialNodes: Node[] = [
+  {
+    id: '4',
+    data: { label: 'node 4' },
+    position,
+    style: nodeStyles,
+  },
+  {
+    id: '5',
+    data: { label: 'node 5' },
+    position,
+    style: nodeStyles,
+  },
+  {
+    id: '6',
+    data: { label: 'node 6' },
+    position,
+    style: nodeStyles,
+  },
+  {
+    id: '7',
+    data: { label: 'node 7' },
+    position,
+    style: nodeStyles,
+  },
+];
+
+export const initialEdges: Edge[] = [
+  {
+    id: 'e45',
+    source: '4',
+    target: '5',
+    type: edgeType,
+    animated: true,
+    style: edgeStyles,
+  },
+  {
+    id: 'e56',
+    source: '5',
+    target: '6',
+    type: edgeType,
+    animated: true,
+    style: edgeStyles,
+  },
+  {
+    id: 'e57',
+    source: '5',
+    target: '7',
+    type: edgeType,
+    animated: true,
+    style: edgeStyles,
+  },
+];

--- a/frontend/src/components/mindmap/initailElements.ts
+++ b/frontend/src/components/mindmap/initailElements.ts
@@ -1,68 +1,21 @@
 import { Edge, Node } from '@xyflow/react';
 
+/* 추후에 마인드맵 초기 데이터 설정하는 부분이랑 연결할 예정 */
+
 const nodeStyles = {
   transition: 'all 0.5s ease',
 };
 
-const edgeStyles = {
-  transition: 'all 0.5s ease',
-  strokeWidth: 1.5,
-  stroke: '#0080ff',
-};
-
 const position = { x: 0, y: 0 };
-const edgeType = 'smoothstep';
 
 export const initialNodes: Node[] = [
   {
-    id: '4',
-    data: { label: 'node 4' },
+    id: '1',
+    data: { label: 'root' },
     position,
-    style: nodeStyles,
-  },
-  {
-    id: '5',
-    data: { label: 'node 5' },
-    position,
-    style: nodeStyles,
-  },
-  {
-    id: '6',
-    data: { label: 'node 6' },
-    position,
-    style: nodeStyles,
-  },
-  {
-    id: '7',
-    data: { label: 'node 7' },
-    position,
+    type: 'custom',
     style: nodeStyles,
   },
 ];
 
-export const initialEdges: Edge[] = [
-  {
-    id: 'e45',
-    source: '4',
-    target: '5',
-    type: edgeType,
-    animated: true,
-    style: edgeStyles,
-  },
-  {
-    id: 'e56',
-    source: '5',
-    target: '6',
-    type: edgeType,
-    animated: true,
-    style: edgeStyles,
-  },
-  {
-    id: 'e57',
-    source: '5',
-    target: '7',
-    type: edgeType,
-    animated: true,
-    style: edgeStyles,
-  },
-];
+export const initialEdges: Edge[] = [];

--- a/frontend/src/components/reactFlow/FlowWrapper.tsx
+++ b/frontend/src/components/reactFlow/FlowWrapper.tsx
@@ -24,7 +24,7 @@ import {
   useUpdateNodePending,
   useActiveState,
   useRestoreActiveState,
-} from '@/store/mindMapStore';
+} from '@/store/mindMapStore_deprecated';
 import { useLoadMindMapData } from '@/store/mindmapListStore';
 import { useIsNodeSelectionMode } from '@/store/nodeSelection';
 

--- a/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/AnswerInputNode.tsx
@@ -12,7 +12,7 @@ import {
   useSetNode,
   useUpdateNode,
   useUpdateNodeQuestions,
-} from '@/store/mindMapStore';
+} from '@/store/mindMapStore_deprecated';
 import { SummarizedNodeReq } from '@/types/api/mindmap';
 import { AnswerNodeType } from '@/types/mindMap';
 import { DialogClose } from '@radix-ui/react-dialog';

--- a/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/QuestionListNode.tsx
@@ -1,7 +1,11 @@
 import NodeHandles from '@/components/reactFlow/nodes/ui/NodeHandles';
 import { Skeleton } from '@/components/ui/skeleton';
 import { findParentNode } from '@/lib/mindMap';
-import { useEdges, useNodes, useSetNode } from '@/store/mindMapStore';
+import {
+  useEdges,
+  useNodes,
+  useSetNode,
+} from '@/store/mindMapStore_deprecated';
 import { QuestionNodeType } from '@/types/mindMap';
 import { NodeProps } from '@xyflow/react';
 import { X } from 'lucide-react';

--- a/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
+++ b/frontend/src/components/reactFlow/nodes/ui/SummaryNode.tsx
@@ -6,7 +6,7 @@ import {
   useRemoveSelectedNode,
   useSelectedNodes,
 } from '@/store/nodeSelection';
-import { useNodes, useSetNode } from '@/store/mindMapStore';
+import { useNodes, useSetNode } from '@/store/mindMapStore_deprecated';
 import { SummaryNodeType } from '@/types/mindMap';
 import { NodeProps } from '@xyflow/react';
 import {

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -61,8 +61,8 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background absolute top-4 right-4 rounded-full opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer active:bg-[#E5E5E5] focus:outline-none focus:ring-0 focus:ring-offset-0 p-1">
-          <XIcon />
+        <DialogPrimitive.Close className="ring-offset-background absolute top-4 right-4 rounded-full opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none cursor-pointer active:bg-[#E5E5E5] focus:outline-none focus:ring-0 focus:ring-offset-0 w-10 h-10 bg-blue-2 flex items-center justify-center">
+          <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>
@@ -74,7 +74,10 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn(
+        'flex items-center gap-2 text-center sm:text-left',
+        className,
+      )}
       {...props}
     />
   );
@@ -100,7 +103,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-[28px] leading-none font-semibold', className)}
+      className={cn('text-[24px] leading-none font-semibold', className)}
       {...props}
     />
   );
@@ -113,7 +116,10 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-muted-foreground text-[16px] leading-[140%] font-normal text-[#6E726E]', className)}
+      className={cn(
+        'text-muted-foreground text-[16px] leading-[140%] font-normal text-[#6E726E]',
+        className,
+      )}
       {...props}
     />
   );

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -26,7 +26,7 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-12 rounded-md w-[180px] ',
+        default: 'h-12 rounded-md w-[148px] ',
         sm: 'h-[42px] rounded-md gap-1.5 w-[160px] ',
         lg: 'h-12 rounded-md w-[180px] ',
         icon: 'size-9',

--- a/frontend/src/hooks/queries/mindmap/useGetMindmapDetail.ts
+++ b/frontend/src/hooks/queries/mindmap/useGetMindmapDetail.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { mindmapService } from '@/services/mindmapService';
 import { GetMindmapDetailRes } from '@/types/api/mindmap';
 import { useEffect } from 'react';
-import { useSetInitialData } from '@/store/mindMapStore';
+import { useSetInitialData } from '@/store/mindMapStore_deprecated';
 
 const useGetMindmapDetail = (id: number) => {
   const setInitialData = useSetInitialData();

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,41 +1,9 @@
-import useGetMindmapList from '@/hooks/queries/mindmap/useGetMindmapList';
-import { useNavigate } from 'react-router';
-import { useEffect } from 'react';
+import MindmapWrapper from '@/components/mindmap/MindmapWrapper';
 
 export default function MindmapPage() {
-  const navigate = useNavigate();
-  const { mindmapList, isLoading, error } = useGetMindmapList();
-
-  useEffect(() => {
-    if (isLoading) return;
-
-    if (error) {
-      console.error('마인드맵 목록을 불러오는데 실패했습니다:', error);
-      return;
-    }
-
-    if (!mindmapList || mindmapList.length === 0) {
-      return;
-    }
-
-    // 연결된 마인드맵이 있으면 그걸로 이동
-    const linkedMindMaps = mindmapList.filter((mindmap) => mindmap.linked);
-    if (linkedMindMaps.length > 0) {
-      navigate(`/mindmap/${linkedMindMaps[0].id}`, { replace: true });
-      return;
-    }
-
-    // 없으면 첫 번째 마인드맵으로 이동
-    const freeMindMaps = mindmapList.filter((mindmap) => !mindmap.linked);
-    if (freeMindMaps.length > 0) {
-      navigate(`/mindmap/${freeMindMaps[0].id}`, { replace: true });
-      return;
-    }
-  }, [mindmapList, isLoading, error, navigate]);
-
   return (
-    <div className="h-full">
-      <h1>마인드맵 목록</h1>
+    <div className="relative w-full h-full">
+      <MindmapWrapper />
     </div>
   );
 }

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -15,11 +15,11 @@ export default [
   layout('layouts/DefaultLayout.tsx', [
     index('pages/home.tsx'),
     route('mindmap', 'pages/mindmap.tsx'),
-    route('mindmap/:id', 'pages/mindmapDetail.tsx'),
     route('today', 'pages/today.tsx'),
     route('matrix', 'pages/matrix.tsx'),
     route('pomodoro/:id?', 'pages/pomodoro.tsx'),
     route('list', 'pages/list.tsx'),
     route('dashboard', 'pages/dashboard.tsx'),
+    route('brainstorming', 'pages/brainstorming.tsx'),
   ]),
 ] satisfies RouteConfig;

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -1,240 +1,256 @@
+import { create } from 'zustand';
 import {
-  EdgeChange,
+  Node,
+  Edge,
   NodeChange,
+  EdgeChange,
   applyNodeChanges,
   applyEdgeChanges,
-  XYPosition,
+  Position,
+  ConnectionLineType,
 } from '@xyflow/react';
-import { create } from 'zustand';
-import { MindMapEdge, MindMapNode, MindMapNodeData } from '@/types/mindMap';
-import { filterNodesAndEdges, findChildNodes } from '@/lib/mindMap';
-import { generateStringId } from '@/lib/generateNumericId';
+import dagre from '@dagrejs/dagre';
+import {
+  initialNodes,
+  initialEdges,
+} from '@/components/mindmap/initailElements';
 
-type ActiveState = {
-  nodeId: string;
-  previousNodes: MindMapNode[];
-  previousEdges: MindMapEdge[];
-  previousActiveState: ActiveState | null;
+const NODE_WIDTH = 172;
+const MIN_NODE_HEIGHT = 60;
+const ROOT_NODE_ID = '4';
+
+const nodeHeightMap = new Map<string, number>();
+
+const nodeStyles = {
+  transition: 'all 0.5s ease',
 };
 
-export type RFState = {
-  nodes: MindMapNode[];
-  edges: MindMapEdge[];
-  activeState: ActiveState | null;
+const edgeStyles = {
+  transition: 'all 0.5s ease',
+  strokeWidth: 1.5,
+  stroke: '#0080ff',
+};
+
+initialNodes.forEach((node) => {
+  nodeHeightMap.set(node.id, MIN_NODE_HEIGHT);
+});
+
+/* 레이아웃 계산 함수 */
+const getLayoutedElements = (
+  nodes: Node[],
+  edges: Edge[],
+  direction: 'TB' | 'LR' = 'TB',
+) => {
+  const isHorizontal = direction === 'LR';
+  const dagreGraph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+
+  const rootNode = nodes.find((node) => node.id === ROOT_NODE_ID);
+  const rootPosition = rootNode ? { ...rootNode.position } : { x: 0, y: 0 };
+
+  dagreGraph.setGraph({
+    rankdir: direction,
+    nodesep: isHorizontal ? 60 : 30,
+    ranksep: isHorizontal ? 80 : 120,
+    edgesep: 20,
+    marginx: 20,
+    marginy: 40,
+  });
+
+  nodes.forEach((node) => {
+    const nodeHeight = nodeHeightMap.get(node.id) || MIN_NODE_HEIGHT;
+    dagreGraph.setNode(node.id, {
+      width: NODE_WIDTH,
+      height: nodeHeight,
+    });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const dagreeRootPos = dagreGraph.node(ROOT_NODE_ID);
+  if (!dagreeRootPos) {
+    return { nodes, edges };
+  }
+
+  const diffX = rootPosition.x - (dagreeRootPos.x - NODE_WIDTH / 2);
+  const diffY =
+    rootPosition.y -
+    (dagreeRootPos.y -
+      (nodeHeightMap.get(ROOT_NODE_ID) || MIN_NODE_HEIGHT) / 2);
+
+  const newNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    if (!nodeWithPosition) {
+      return node;
+    }
+
+    const nodeHeight = nodeHeightMap.get(node.id) || MIN_NODE_HEIGHT;
+    const position = {
+      x: nodeWithPosition.x - NODE_WIDTH / 2 + diffX,
+      y: nodeWithPosition.y - nodeHeight / 2 + diffY,
+    };
+
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      position,
+    };
+  });
+
+  return { nodes: newNodes, edges };
+};
+
+const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+  initialNodes.map((node) => ({
+    ...node,
+    type: 'custom',
+    data: {
+      ...node.data,
+      layoutDirection: 'TB',
+    },
+    style: nodeStyles,
+  })),
+  initialEdges.map((edge) => ({
+    ...edge,
+    animated: true,
+    style: edgeStyles,
+  })),
+  'TB',
+);
+
+type MindmapState = {
+  nodes: Node[];
+  edges: Edge[];
+  direction: 'TB' | 'LR';
 
   onNodesChange: (changes: NodeChange[]) => void;
   onEdgesChange: (changes: EdgeChange[]) => void;
-
-  addChildNode: (
-    selectedNode: MindMapNode,
-    position: XYPosition,
-    isPending?: boolean,
-  ) => string;
-  setNode: (nodeId: string, node: MindMapNode) => void;
-  updateNodeQuestions: (nodeId: string, questions: string[]) => void;
-  updateNodePending: (nodeId: string, isPending: boolean) => void;
-  deleteNode: (nodeId: string) => void;
-  updateNode: (nodeId: string, answer: string, summary: string) => void;
-  setInitialData: (nodes: MindMapNode[], edges: MindMapEdge[]) => void;
-  restoreActiveState: () => void;
+  updateNodeLabel: (nodeId: string, newLabel: string) => void;
+  updateNodeHeight: (nodeId: string, height: number) => void;
+  setDirection: (direction: 'TB' | 'LR') => void;
+  addChildNode: (parentNodeId: string) => void;
 };
 
-const initialNodes: MindMapNode[] = [];
-const initialEdges: MindMapEdge[] = [];
+export const useMindmapStore = create<MindmapState>((set, get) => ({
+  nodes: layoutedNodes,
+  edges: layoutedEdges,
+  direction: 'TB',
 
-const useStore = create<RFState>((set, get) => ({
-  nodes: initialNodes,
-  edges: initialEdges,
-  activeState: null,
-
-  onNodesChange: (changes: NodeChange[]) => {
+  onNodesChange: (changes) => {
     set({
-      nodes: applyNodeChanges(changes, get().nodes) as MindMapNode[],
+      nodes: applyNodeChanges(changes, get().nodes),
     });
   },
 
-  onEdgesChange: (changes: EdgeChange[]) => {
+  onEdgesChange: (changes) => {
     set({
       edges: applyEdgeChanges(changes, get().edges),
     });
   },
 
-  addChildNode: (
-    selectedNode: MindMapNode,
-    position: XYPosition,
-    isPending = false,
-  ) => {
-    const parentDepth = (selectedNode.data as MindMapNodeData)?.depth || 0;
-    const newNodeId = generateStringId();
-
-    const newNode: MindMapNode = {
-      id: newNodeId,
-      type: 'QUESTION',
-      data: {
-        question: '다음 질문을 선택해주세요',
-        depth: parentDepth + 1,
-        recommendedQuestions: [],
-        isPending,
-      },
-      position,
-    };
-
-    const newEdge: MindMapEdge = {
-      id: `e${selectedNode.id}-${newNodeId}`,
-      source: selectedNode.id,
-      target: newNodeId,
-      type: 'mindmapEdge',
-    };
-
-    const currentNodes = [...get().nodes];
-    const currentEdges = [...get().edges];
-
+  updateNodeLabel: (nodeId, newLabel) => {
     set((state) => ({
-      nodes: [...state.nodes, newNode],
-      edges: [...state.edges, newEdge],
-      activeState: {
-        nodeId: newNodeId,
-        previousNodes: currentNodes,
-        previousEdges: currentEdges,
-        previousActiveState: state.activeState,
-      },
-    }));
-
-    return newNodeId;
-  },
-
-  setNode: (nodeId, updatedNode) => {
-    const currentNodes = [...get().nodes];
-    const currentEdges = [...get().edges];
-
-    set((state) => ({
-      nodes: state.nodes.map((node) =>
-        node.id === nodeId ? updatedNode : node,
-      ),
-      activeState: {
-        nodeId: nodeId,
-        previousNodes: currentNodes,
-        previousEdges: currentEdges,
-        previousActiveState: state.activeState,
-      },
-    }));
-  },
-
-  updateNodeQuestions: (nodeId, questions) => {
-    set({
-      nodes: get().nodes.map((node) => {
+      nodes: state.nodes.map((node) => {
         if (node.id === nodeId) {
           return {
             ...node,
             data: {
               ...node.data,
-              recommendedQuestions: questions,
+              label: newLabel,
             },
           };
         }
         return node;
       }),
-    });
+    }));
   },
 
-  updateNodePending: (nodeId, isPending) => {
-    set({
-      nodes: get().nodes.map((node) => {
-        if (node.id === nodeId) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              isPending,
-            },
-          };
-        }
-        return node;
-      }),
-    });
-  },
-  deleteNode: (nodeId) => {
-    const { nodes, edges } = get();
+  updateNodeHeight: (nodeId, height) => {
+    const actualHeight = Math.max(height, MIN_NODE_HEIGHT);
 
-    const nodesToDelete = findChildNodes(edges, nodeId, true);
+    if (nodeHeightMap.get(nodeId) !== actualHeight) {
+      nodeHeightMap.set(nodeId, actualHeight);
 
-    const { filteredNodes, filteredEdges } = filterNodesAndEdges(
-      nodes,
-      edges,
-      nodesToDelete,
-    );
+      const { nodes, edges } = getLayoutedElements(
+        get().nodes,
+        get().edges,
+        get().direction,
+      );
 
-    set({
-      nodes: filteredNodes,
-      edges: filteredEdges,
-    });
-  },
-
-  updateNode: (nodeId, answer, summary) => {
-    const { nodes, edges } = get();
-    const nodesToDelete = findChildNodes(edges, nodeId, false);
-
-    const { filteredNodes, filteredEdges } = filterNodesAndEdges(
-      nodes,
-      edges,
-      nodesToDelete,
-    );
-
-    const updatedNodes = filteredNodes.map((node) => {
-      if (node.id === nodeId) {
-        return {
-          ...node,
-          type: 'summary' as const,
-          data: {
-            ...node.data,
-            answer,
-            summary,
-          },
-        };
-      }
-      return node;
-    });
-
-    set({
-      nodes: updatedNodes,
-      edges: filteredEdges,
-    });
-  },
-  setInitialData: (nodes, edges) => {
-    set({
-      nodes: nodes,
-      edges: edges,
-    });
-  },
-
-  restoreActiveState: () => {
-    const { activeState } = get();
-    if (activeState) {
-      set({
-        nodes: activeState.previousNodes,
-        edges: activeState.previousEdges,
-        activeState: activeState.previousActiveState,
-      });
+      set({ nodes, edges });
     }
   },
+
+  setDirection: (direction) => {
+    set((state) => {
+      const nodesWithDirection = state.nodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          layoutDirection: direction,
+        },
+      }));
+
+      const { nodes, edges } = getLayoutedElements(
+        nodesWithDirection,
+        state.edges,
+        direction,
+      );
+
+      return { nodes, edges, direction };
+    });
+  },
+
+  addChildNode: (parentNodeId) => {
+    set((state) => {
+      const randomId = Math.random().toString(36).substring(2, 10);
+      const newNodeId = `node-${randomId}`;
+
+      nodeHeightMap.set(newNodeId, MIN_NODE_HEIGHT);
+
+      const parentNode = state.nodes.find((node) => node.id === parentNodeId);
+      if (!parentNode) return state;
+
+      const newNode: Node = {
+        id: newNodeId,
+        type: 'custom',
+        data: {
+          label: '',
+          layoutDirection: state.direction,
+        },
+        position: {
+          x: parentNode.position.x + 100,
+          y: parentNode.position.y + 100,
+        },
+        targetPosition: state.direction === 'LR' ? Position.Left : Position.Top,
+        sourcePosition:
+          state.direction === 'LR' ? Position.Right : Position.Bottom,
+        style: nodeStyles,
+      };
+
+      const newEdge: Edge = {
+        id: `edge-${parentNodeId}-${newNodeId}`,
+        source: parentNodeId,
+        target: newNodeId,
+        type: ConnectionLineType.Bezier,
+        animated: true,
+        style: edgeStyles,
+      };
+
+      const updatedNodes = [...state.nodes, newNode];
+      const updatedEdges = [...state.edges, newEdge];
+
+      const { nodes, edges } = getLayoutedElements(
+        updatedNodes,
+        updatedEdges,
+        state.direction,
+      );
+
+      return { nodes, edges };
+    });
+  },
 }));
-
-export const useNodes = () => useStore((state) => state.nodes);
-export const useEdges = () => useStore((state) => state.edges);
-export const useNodesChange = () => useStore((state) => state.onNodesChange);
-export const useEdgesChange = () => useStore((state) => state.onEdgesChange);
-export const useAddChildNode = () => useStore((state) => state.addChildNode);
-export const useSetNode = () => useStore((state) => state.setNode);
-export const useUpdateNodeQuestions = () =>
-  useStore((state) => state.updateNodeQuestions);
-export const useUpdateNodePending = () =>
-  useStore((state) => state.updateNodePending);
-export const useDeleteNode = () => useStore((state) => state.deleteNode);
-export const useUpdateNode = () => useStore((state) => state.updateNode);
-export const useSetInitialData = () =>
-  useStore((state) => state.setInitialData);
-export const useActiveState = () => useStore((state) => state.activeState);
-export const useRestoreActiveState = () =>
-  useStore((state) => state.restoreActiveState);
-
-export default useStore;

--- a/frontend/src/store/mindMapStore_deprecated.ts
+++ b/frontend/src/store/mindMapStore_deprecated.ts
@@ -1,0 +1,240 @@
+import {
+  EdgeChange,
+  NodeChange,
+  applyNodeChanges,
+  applyEdgeChanges,
+  XYPosition,
+} from '@xyflow/react';
+import { create } from 'zustand';
+import { MindMapEdge, MindMapNode, MindMapNodeData } from '@/types/mindMap';
+import { filterNodesAndEdges, findChildNodes } from '@/lib/mindMap';
+import { generateStringId } from '@/lib/generateNumericId';
+
+type ActiveState = {
+  nodeId: string;
+  previousNodes: MindMapNode[];
+  previousEdges: MindMapEdge[];
+  previousActiveState: ActiveState | null;
+};
+
+export type RFState = {
+  nodes: MindMapNode[];
+  edges: MindMapEdge[];
+  activeState: ActiveState | null;
+
+  onNodesChange: (changes: NodeChange[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
+
+  addChildNode: (
+    selectedNode: MindMapNode,
+    position: XYPosition,
+    isPending?: boolean,
+  ) => string;
+  setNode: (nodeId: string, node: MindMapNode) => void;
+  updateNodeQuestions: (nodeId: string, questions: string[]) => void;
+  updateNodePending: (nodeId: string, isPending: boolean) => void;
+  deleteNode: (nodeId: string) => void;
+  updateNode: (nodeId: string, answer: string, summary: string) => void;
+  setInitialData: (nodes: MindMapNode[], edges: MindMapEdge[]) => void;
+  restoreActiveState: () => void;
+};
+
+const initialNodes: MindMapNode[] = [];
+const initialEdges: MindMapEdge[] = [];
+
+const useStore = create<RFState>((set, get) => ({
+  nodes: initialNodes,
+  edges: initialEdges,
+  activeState: null,
+
+  onNodesChange: (changes: NodeChange[]) => {
+    set({
+      nodes: applyNodeChanges(changes, get().nodes) as MindMapNode[],
+    });
+  },
+
+  onEdgesChange: (changes: EdgeChange[]) => {
+    set({
+      edges: applyEdgeChanges(changes, get().edges),
+    });
+  },
+
+  addChildNode: (
+    selectedNode: MindMapNode,
+    position: XYPosition,
+    isPending = false,
+  ) => {
+    const parentDepth = (selectedNode.data as MindMapNodeData)?.depth || 0;
+    const newNodeId = generateStringId();
+
+    const newNode: MindMapNode = {
+      id: newNodeId,
+      type: 'QUESTION',
+      data: {
+        question: '다음 질문을 선택해주세요',
+        depth: parentDepth + 1,
+        recommendedQuestions: [],
+        isPending,
+      },
+      position,
+    };
+
+    const newEdge: MindMapEdge = {
+      id: `e${selectedNode.id}-${newNodeId}`,
+      source: selectedNode.id,
+      target: newNodeId,
+      type: 'mindmapEdge',
+    };
+
+    const currentNodes = [...get().nodes];
+    const currentEdges = [...get().edges];
+
+    set((state) => ({
+      nodes: [...state.nodes, newNode],
+      edges: [...state.edges, newEdge],
+      activeState: {
+        nodeId: newNodeId,
+        previousNodes: currentNodes,
+        previousEdges: currentEdges,
+        previousActiveState: state.activeState,
+      },
+    }));
+
+    return newNodeId;
+  },
+
+  setNode: (nodeId, updatedNode) => {
+    const currentNodes = [...get().nodes];
+    const currentEdges = [...get().edges];
+
+    set((state) => ({
+      nodes: state.nodes.map((node) =>
+        node.id === nodeId ? updatedNode : node,
+      ),
+      activeState: {
+        nodeId: nodeId,
+        previousNodes: currentNodes,
+        previousEdges: currentEdges,
+        previousActiveState: state.activeState,
+      },
+    }));
+  },
+
+  updateNodeQuestions: (nodeId, questions) => {
+    set({
+      nodes: get().nodes.map((node) => {
+        if (node.id === nodeId) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              recommendedQuestions: questions,
+            },
+          };
+        }
+        return node;
+      }),
+    });
+  },
+
+  updateNodePending: (nodeId, isPending) => {
+    set({
+      nodes: get().nodes.map((node) => {
+        if (node.id === nodeId) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              isPending,
+            },
+          };
+        }
+        return node;
+      }),
+    });
+  },
+  deleteNode: (nodeId) => {
+    const { nodes, edges } = get();
+
+    const nodesToDelete = findChildNodes(edges, nodeId, true);
+
+    const { filteredNodes, filteredEdges } = filterNodesAndEdges(
+      nodes,
+      edges,
+      nodesToDelete,
+    );
+
+    set({
+      nodes: filteredNodes,
+      edges: filteredEdges,
+    });
+  },
+
+  updateNode: (nodeId, answer, summary) => {
+    const { nodes, edges } = get();
+    const nodesToDelete = findChildNodes(edges, nodeId, false);
+
+    const { filteredNodes, filteredEdges } = filterNodesAndEdges(
+      nodes,
+      edges,
+      nodesToDelete,
+    );
+
+    const updatedNodes = filteredNodes.map((node) => {
+      if (node.id === nodeId) {
+        return {
+          ...node,
+          type: 'summary' as const,
+          data: {
+            ...node.data,
+            answer,
+            summary,
+          },
+        };
+      }
+      return node;
+    });
+
+    set({
+      nodes: updatedNodes,
+      edges: filteredEdges,
+    });
+  },
+  setInitialData: (nodes, edges) => {
+    set({
+      nodes: nodes,
+      edges: edges,
+    });
+  },
+
+  restoreActiveState: () => {
+    const { activeState } = get();
+    if (activeState) {
+      set({
+        nodes: activeState.previousNodes,
+        edges: activeState.previousEdges,
+        activeState: activeState.previousActiveState,
+      });
+    }
+  },
+}));
+
+export const useNodes = () => useStore((state) => state.nodes);
+export const useEdges = () => useStore((state) => state.edges);
+export const useNodesChange = () => useStore((state) => state.onNodesChange);
+export const useEdgesChange = () => useStore((state) => state.onEdgesChange);
+export const useAddChildNode = () => useStore((state) => state.addChildNode);
+export const useSetNode = () => useStore((state) => state.setNode);
+export const useUpdateNodeQuestions = () =>
+  useStore((state) => state.updateNodeQuestions);
+export const useUpdateNodePending = () =>
+  useStore((state) => state.updateNodePending);
+export const useDeleteNode = () => useStore((state) => state.deleteNode);
+export const useUpdateNode = () => useStore((state) => state.updateNode);
+export const useSetInitialData = () =>
+  useStore((state) => state.setInitialData);
+export const useActiveState = () => useStore((state) => state.activeState);
+export const useRestoreActiveState = () =>
+  useStore((state) => state.restoreActiveState);
+
+export default useStore;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -54,8 +54,20 @@
   --color-question-input-hover: rgba(0, 0, 0, 0.02);
   --color-question-input-active: rgba(0, 0, 0, 0.05);
 
-  /* brainstorming 관련 색상 */
-  --color-bg-brainstorming: #e8efff;
+  /* 새로운 기획 색상 변수 */
+  --color-gray-scale-100: #ffffff;
+  --color-gray-scale-200: #f0f0f5;
+  --color-gray-scale-300: #e1e1e8;
+  --color-gray-scale-400: #cdced6;
+  --color-gray-scale-500: #a9abb8;
+  --color-gray-scale-600: #858899;
+  --color-gray-scale-700: #525463;
+  --color-gray-scale-800: #3e404c;
+  --color-gray-scale-900: #2b2d36;
+
+  --color-blue: #7098ff;
+  --color-neon-green: #d3ee17;
+  --color-blue-2: #e8efff;
 }
 
 .scrollbar-hide::-webkit-scrollbar {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,66 +1,69 @@
 @import 'tailwindcss';
 
 @theme {
-    /* 공통 색상 */
-    --color-border-gray: #e3e3e3;
+  /* 공통 색상 */
+  --color-border-gray: #e3e3e3;
 
-    /* button 색상 */
-    --color-button-primary: #ffe277;
-    --color-button-disabled: #e7e7e7;
+  /* button 색상 */
+  --color-button-primary: #ffe277;
+  --color-button-disabled: #e7e7e7;
 
-    /* Gray Colors */
-    --color-gray-100: #fafafa;
-    --color-gray-200: #fafafa;
-    --color-gray-300: #e5e5e5;
-    --color-gray-400: #cecfcd;
-    --color-gray-500: #c8c8c8;
-    --color-gray-600: #aaaaaa;
-    --color-gray-700: #6e726e;
-    --color-gray-800: #3b3d3b;
+  /* Gray Colors */
+  --color-gray-100: #fafafa;
+  --color-gray-200: #fafafa;
+  --color-gray-300: #e5e5e5;
+  --color-gray-400: #cecfcd;
+  --color-gray-500: #c8c8c8;
+  --color-gray-600: #aaaaaa;
+  --color-gray-700: #6e726e;
+  --color-gray-800: #3b3d3b;
 
-    /* Primary Colors */
-    --color-primary-10: rgba(141, 92, 246, 0.1); /* opacity 10 */
-    --color-primary-20: rgba(141, 92, 246, 0.2); /* opacity 20 */
-    --color-primary-50: rgba(141, 92, 246, 0.5); /* opacity 50 */
-    --color-primary-70: rgba(141, 92, 246, 0.7); /* opacity 70 */
-    --color-primary-100: #8d5cf6;
+  /* Primary Colors */
+  --color-primary-10: rgba(141, 92, 246, 0.1); /* opacity 10 */
+  --color-primary-20: rgba(141, 92, 246, 0.2); /* opacity 20 */
+  --color-primary-50: rgba(141, 92, 246, 0.5); /* opacity 50 */
+  --color-primary-70: rgba(141, 92, 246, 0.7); /* opacity 70 */
+  --color-primary-100: #8d5cf6;
 
-    /*category chip bg color*/
-    --color-category-green: rgba(0, 184, 132, 0.2);
-    --color-category-gray: rgba(120, 119, 119, 0.2);
-    --color-category-yellow: rgba(255, 203, 17, 0.2);
-    --color-category-blue: rgba(70, 182, 254, 0.2);
-    --color-category-pink: rgba(255, 139, 195, 0.2);
-    --color-category-red: rgba(255, 30, 0, 0.2);
-    --color-category-orange: rgba(255, 132, 0, 0.2);
-    --color-category-brown: rgba(151, 75, 0, 0.2);
+  /*category chip bg color*/
+  --color-category-green: rgba(0, 184, 132, 0.2);
+  --color-category-gray: rgba(120, 119, 119, 0.2);
+  --color-category-yellow: rgba(255, 203, 17, 0.2);
+  --color-category-blue: rgba(70, 182, 254, 0.2);
+  --color-category-pink: rgba(255, 139, 195, 0.2);
+  --color-category-red: rgba(255, 30, 0, 0.2);
+  --color-category-orange: rgba(255, 132, 0, 0.2);
+  --color-category-brown: rgba(151, 75, 0, 0.2);
 
-    /* Font Sizes */
-    --font-heading-1: 32px;
-    --font-heading-2: 28px;
-    --font-heading-3: 22px;
-    --font-heading-4: 18px;
-    --font-heading-5: 16px;
-    --font-heading-6: 14px;
-    --font-body-1: 16px;
-    --font-body-2: 14px;
-    --font-body-3: 12px;
+  /* Font Sizes */
+  --font-heading-1: 32px;
+  --font-heading-2: 28px;
+  --font-heading-3: 22px;
+  --font-heading-4: 18px;
+  --font-heading-5: 16px;
+  --font-heading-6: 14px;
+  --font-body-1: 16px;
+  --font-body-2: 14px;
+  --font-body-3: 12px;
 
-    /* Font Family */
-    --font-primary: 'Inter', sans-serif;
+  /* Font Family */
+  --font-primary: 'Inter', sans-serif;
 
-    /* mindmap 관련 색상 */
-    --color-root-icon: #ffea9f;
-    --color-question-input-hover: rgba(0, 0, 0, 0.02);
-    --color-question-input-active: rgba(0, 0, 0, 0.05);
+  /* mindmap 관련 색상 */
+  --color-root-icon: #ffea9f;
+  --color-question-input-hover: rgba(0, 0, 0, 0.02);
+  --color-question-input-active: rgba(0, 0, 0, 0.05);
+
+  /* brainstorming 관련 색상 */
+  --color-bg-brainstorming: #e8efff;
 }
 
 .scrollbar-hide::-webkit-scrollbar {
-    display: none;
+  display: none;
 }
 
 body {
-    font-family: 'Inter', sans-serif;
-    color: black;
-    font-weight: 400;
+  font-family: 'Inter', sans-serif;
+  color: black;
+  font-weight: 400;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #173 

## 📝 작업 내용
### 자동 레이아웃 기능이 있는 인터랙티브 마인드맵 구현
@dagrejs/darge 라이브러리를 활용하여 마인드맵의 레이아웃을 자동으로 조절해주는 기능을 개발했습니다.

`mindmapStore.ts`에서 `getLayoutedElements` 함수에 레이아웃 처리하는 코드가 있으니 한 번 봐주시면 좋을 것 같습니다!
해당 라이브러리에 대한 이해가 없이 코드를 보면 이해가 안될 것 같아서 설명 및 요약 적어두겠습니다 😄 

**목적**
👉 React Flow의 노드(`nodes`)와 엣지(`edges`)를 입력받아, dagre 레이아웃 알고리즘을 사용해 자동으로 노드의 좌표(`position`)를 계산하고 반환합니다. 즉, 노드 간의 연결 관계와 레이아웃 방향을 기반으로 각 노드의 좌표(`position`)를 자동 배치해주는 함수입니다.

**설정**
- `isHorizontal` → 방향이 수평(LR)인지 수직(TB)인지 판단
  - 추후에 수평(LR) or 수직(TB) 여부에 따라 레이아웃 배치를 추가로 적용하고 수정하는 기능을 추가할 계획입니다! 그래서 관련 코드가 들어가 있긴한데, 현재는 해당 로직은 배제하고 확인해주시면 됩니다. 
- `dagreGraph` → dagre 라이브러리의 그래프 객체 생성

- `dagreGraph.setGraph` 레이아웃 옵션 
  - `rankdir`: 방향 설정 (TB or LR)
  - `nodesep`: 노드 간 간격
  - `ranksep`: 계층(행) 간 간격
  - `edgesep`: 엣지 간 간격
  - `marginx`, `marginy`: 그래프 전체 여백

그 이후의 실행 방식은 아래와 같은 흐름으로 진행된다고 생각해주시면 됩니다!
- 레이아웃 계싼 -> 루트 노드 위치 기반으로 위치 보정 -> 각 노드 위치 보정 후 좌표(`postion`)으로 변환 및 적용

### 마인드맵 입력에 따른 높이 변화 & 레이아웃 동적 반영
사용자가 노드에 입력을 추가하여 노드의 높이가 동적으로 변할 경우, 해당 높이를 기반으로 레이아웃이 자동 재배치되도록 처리하였습니다.
이를 위해 다음과 같은 과정을 추가적으로 구현하였습니다.

1. 각 노드의 높이는 `nodeHeightMap`이라는 맵(Map) 구조로 관리되며, 노드 ID별로 현재 높이를 저장합니다.
2. 사용자가 노드에 입력을 추가하거나 편집하여 노드의 높이가 변경되면 `updateNodeHeight(nodeId, height)` 메서드가 호출됩니다.
3. 이 메서드는 전달받은 `height`를 최소 높이(`MIN_NODE_HEIGHT`) 이상으로 보정하고, `nodeHeightMap`에 업데이트한 후, 레이아웃 재계산 함수(`getLayoutedElements`)를 호출하여 현재 노드와 엣지를 기반으로 새로운 레이아웃을 계산합니다.



### 새로 추가된 색상 변수 정의
기획에서 변경된 사항에 맞는 색상 변수를 정의했습니다. 아까 다운님께 전달 드렸던대로, 각자 PR에서 공통된 변수로 작업 후 merge 할 때만 인지합시다!!

### 공통 컴포넌트 스타일 일부 수정
마찬가지로 기획에서 변경된 디자인에 따라 약간의 스타일을 수정했습니다.

**Button**
- size === sm 일 때 width 변경: 180px -> 148px

**Dialog**
- 일부 사이즈 수정
- Header와 Description이 한 줄에 배치되도록 수정


## 💬 리뷰 요구사항
아직 UI 수정이 최종적으로 된게 아니라서 1차 버전으로 봐주시면 될듯합니다!
디자인 컨펌 및 @250b 보현님이 작업하신 브레인스토밍 퍼블리싱 작업이 끝나면, 마인드맵과 연결 및 API 연동 작업 진행할 예정입니다!
