### PR TITLE
[BE] feat: 오늘의 할 일 도메인 관련 API 로직 구현

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -83,4 +83,13 @@ public class TodayTaskItemController {
         todayTaskItemService.deleteTaskItem(user.getMemberId(), taskId);
         return ApiResponse.ok();
     }
+
+    @Operation(summary = "어제의 할 일 가져오기", description = "어제 날짜 기준으로 미완료된 할 일을 조회")
+    @GetMapping("/yesterday")
+    public ApiResponse<List<TodayTaskItemResponse>> getYesterdayTaskItems(
+        @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        List<TodayTaskItemResponse> response = todayTaskItemService.getYesterdayTaskItems(user.getMemberId());
+        return ApiResponse.ok(response);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -58,4 +58,15 @@ public class TodayTaskItemController {
         int count = todayTaskItemService.getTaskItemCount(user.getMemberId(), date);
         return ApiResponse.ok(count);
     }
+
+    @Operation(summary = "완료된 할 일 개수 조회", description = "특정 날짜에 완료된 할 일 개수를 반환. 날짜가 없으면 오늘 날짜 기준으로 조회합니다.")
+    @GetMapping("/completed")
+    public ApiResponse<Long> getCompletedTaskItemCount(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        long completedCount = todayTaskItemService.getCompletedTaskItemCount(user.getMemberId(), date);
+        return ApiResponse.ok(completedCount);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -36,4 +36,15 @@ public class TodayTaskItemController {
         List<TodayTaskItemResponse> response = todayTaskItemService.addTaskItem(user.getMemberId(), request);
         return ApiResponse.ok(response);
     }
+
+    @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회. 날짜 디폴트 값은 오늘 날짜(2025-05-07)")
+    @GetMapping
+    public ApiResponse<List<TodayTaskItemResponse>> getTodayTasks(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ){
+        List<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), date);
+        return ApiResponse.ok(response);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -6,6 +6,7 @@ import capstone.backend.domain.todayTask.service.TodayTaskItemService;
 import capstone.backend.global.api.dto.ApiResponse;
 import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -13,7 +14,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -68,5 +71,16 @@ public class TodayTaskItemController {
     ) {
         long completedCount = todayTaskItemService.getCompletedTaskItemCount(user.getMemberId(), date);
         return ApiResponse.ok(completedCount);
+    }
+
+    @Operation(summary = "오늘의 할 일 삭제", description = "오늘의 할 일 목록에서 특정 할 일을 삭제")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteTodayTask(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @Parameter(name = "taskId", description="삭제할 오늘의 할 일 ID", example = "1", required = true)
+        @PathVariable("id") Long taskId
+    ) {
+        todayTaskItemService.deleteTaskItem(user.getMemberId(), taskId);
+        return ApiResponse.ok();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -53,12 +53,12 @@ public class TodayTaskItemController {
 
     @Operation(summary = "특정 날짜의 할 일 개수 조회", description = "특정 날짜에 등록된 할 일 개수를 반환. 날짜가 없으면 오늘 날짜 기준으로 조회합니다.")
     @GetMapping("/count")
-    public ApiResponse<Integer> getTaskItemCount(
+    public ApiResponse<Long> getTaskItemCount(
         @AuthenticationPrincipal CustomOAuth2User user,
         @RequestParam(value = "date", required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        int count = todayTaskItemService.getTaskItemCount(user.getMemberId(), date);
+        long count = todayTaskItemService.getTaskItemCount(user.getMemberId(), date);
         return ApiResponse.ok(count);
     }
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -1,0 +1,39 @@
+package capstone.backend.domain.todayTask.controller;
+
+import capstone.backend.domain.todayTask.dto.request.TodayTaskItemCreateRequest;
+import capstone.backend.domain.todayTask.dto.response.TodayTaskItemResponse;
+import capstone.backend.domain.todayTask.service.TodayTaskItemService;
+import capstone.backend.global.api.dto.ApiResponse;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/today-task")
+@Tag(name="오늘의 할 일", description = "오늘의 할 일 관련 API")
+public class TodayTaskItemController {
+    private final TodayTaskItemService todayTaskItemService;
+
+    @Operation(summary = "오늘의 할 일 추가", description = "여러 개의 아이젠하워 할 일을 오늘의 할 일 목록에 추가")
+    @PostMapping
+    public ApiResponse<List<TodayTaskItemResponse>> addTodayTask(
+        @RequestBody @Valid TodayTaskItemCreateRequest request,
+        @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        List<TodayTaskItemResponse> response = todayTaskItemService.addTaskItem(user.getMemberId(), request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -83,10 +83,11 @@ public class TodayTaskItemController {
 
     @Operation(summary = "어제의 할 일 가져오기", description = "어제 날짜 기준으로 미완료된 할 일을 조회")
     @GetMapping("/yesterday")
-    public ApiResponse<List<TodayTaskItemResponse>> getYesterdayTaskItems(
-        @AuthenticationPrincipal CustomOAuth2User user
+    public ApiResponse<Page<TodayTaskItemResponse>> getYesterdayTaskItems(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @ParameterObject Pageable pageable
     ) {
-        List<TodayTaskItemResponse> response = todayTaskItemService.getYesterdayTaskItems(user.getMemberId());
+        Page<TodayTaskItemResponse> response = todayTaskItemService.getYesterdayTaskItems(user.getMemberId(), pageable);
         return ApiResponse.ok(response);
     }
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -9,13 +9,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -36,37 +36,31 @@ public class TodayTaskItemController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회. 날짜 디폴트 값은 오늘 날짜(yyyy-mm-dd)")
+    @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회")
     @GetMapping
     public ApiResponse<Page<TodayTaskItemResponse>> getTodayTasks(
         @AuthenticationPrincipal CustomOAuth2User user,
-        @RequestParam(value = "date", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
         @ParameterObject Pageable pageable
     ){
-        Page<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), date, pageable);
+        Page<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), pageable);
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "특정 날짜의 할 일 개수 조회", description = "특정 날짜에 등록된 할 일 개수를 반환. 날짜가 없으면 오늘 날짜 기준으로 조회합니다.")
+    @Operation(summary = "오늘 날짜의 할 일 개수 조회", description = "오늘 날짜에 등록된 할 일 개수를 반환")
     @GetMapping("/count")
     public ApiResponse<Long> getTaskItemCount(
-        @AuthenticationPrincipal CustomOAuth2User user,
-        @RequestParam(value = "date", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+        @AuthenticationPrincipal CustomOAuth2User user
     ) {
-        long count = todayTaskItemService.getTaskItemCount(user.getMemberId(), date);
+        long count = todayTaskItemService.getTaskItemCount(user.getMemberId());
         return ApiResponse.ok(count);
     }
 
-    @Operation(summary = "완료된 할 일 개수 조회", description = "특정 날짜에 완료된 할 일 개수를 반환. 날짜가 없으면 오늘 날짜 기준으로 조회합니다.")
+    @Operation(summary = "완료된 할 일 개수 조회")
     @GetMapping("/completed")
     public ApiResponse<Long> getCompletedTaskItemCount(
-        @AuthenticationPrincipal CustomOAuth2User user,
-        @RequestParam(value = "date", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+        @AuthenticationPrincipal CustomOAuth2User user
     ) {
-        long completedCount = todayTaskItemService.getCompletedTaskItemCount(user.getMemberId(), date);
+        long completedCount = todayTaskItemService.getCompletedTaskItemCount(user.getMemberId());
         return ApiResponse.ok(completedCount);
     }
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -92,4 +92,24 @@ public class TodayTaskItemController {
         List<TodayTaskItemResponse> response = todayTaskItemService.getYesterdayTaskItems(user.getMemberId());
         return ApiResponse.ok(response);
     }
+
+    @Operation(summary = "어제 일을 오늘 날짜로 변경", description = "특정 할 일을 오늘 날짜로 변경")
+    @PostMapping("/move-today/{id}")
+    public ApiResponse<TodayTaskItemResponse> updateTaskDateToToday(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @PathVariable("id") Long taskId
+    ){
+        TodayTaskItemResponse response = todayTaskItemService.updateTaskDateToToday(user.getMemberId(), taskId);
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "오늘의 할 일을 어제 날짜로 변경", description = "특정 할 일을 어제 날짜로 이동. 테스트 할 때만 사용")
+    @PostMapping("/yesterday/{id}")
+    public ApiResponse<TodayTaskItemResponse> updateTaskDateToYesterday(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @PathVariable("id") Long taskId
+    ) {
+        TodayTaskItemResponse response = todayTaskItemService.updateTaskDateToYesterday(user.getMemberId(), taskId);
+        return ApiResponse.ok(response);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -40,7 +40,7 @@ public class TodayTaskItemController {
         return ApiResponse.ok(response);
     }
 
-    @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회. 날짜 디폴트 값은 오늘 날짜(2025-05-07)")
+    @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회. 날짜 디폴트 값은 오늘 날짜(yyyy-mm-dd)")
     @GetMapping
     public ApiResponse<List<TodayTaskItemResponse>> getTodayTasks(
         @AuthenticationPrincipal CustomOAuth2User user,
@@ -74,11 +74,11 @@ public class TodayTaskItemController {
     }
 
     @Operation(summary = "오늘의 할 일 삭제", description = "오늘의 할 일 목록에서 특정 할 일을 삭제")
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{taskId}")
     public ApiResponse<Void> deleteTodayTask(
         @AuthenticationPrincipal CustomOAuth2User user,
         @Parameter(name = "taskId", description="삭제할 오늘의 할 일 ID", example = "1", required = true)
-        @PathVariable("id") Long taskId
+        @PathVariable Long taskId
     ) {
         todayTaskItemService.deleteTaskItem(user.getMemberId(), taskId);
         return ApiResponse.ok();
@@ -94,20 +94,22 @@ public class TodayTaskItemController {
     }
 
     @Operation(summary = "어제 일을 오늘 날짜로 변경", description = "특정 할 일을 오늘 날짜로 변경")
-    @PostMapping("/move-today/{id}")
+    @PostMapping("/move-today/{taskId}")
     public ApiResponse<TodayTaskItemResponse> updateTaskDateToToday(
         @AuthenticationPrincipal CustomOAuth2User user,
-        @PathVariable("id") Long taskId
+        @Parameter(name = "taskId", description = "변경할 오늘의 할 일 ID", example = "1", required = true)
+        @PathVariable Long taskId
     ){
         TodayTaskItemResponse response = todayTaskItemService.updateTaskDateToToday(user.getMemberId(), taskId);
         return ApiResponse.ok(response);
     }
 
     @Operation(summary = "오늘의 할 일을 어제 날짜로 변경", description = "특정 할 일을 어제 날짜로 이동. 테스트 할 때만 사용")
-    @PostMapping("/yesterday/{id}")
+    @PostMapping("/yesterday/{taskId}")
     public ApiResponse<TodayTaskItemResponse> updateTaskDateToYesterday(
         @AuthenticationPrincipal CustomOAuth2User user,
-        @PathVariable("id") Long taskId
+        @Parameter(name = "taskId", description = "어제로 변경할 오늘의 할 일 ID (테스트 할 때 사용)", example = "1", required = true)
+        @PathVariable Long taskId
     ) {
         TodayTaskItemResponse response = todayTaskItemService.updateTaskDateToYesterday(user.getMemberId(), taskId);
         return ApiResponse.ok(response);

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -47,4 +47,15 @@ public class TodayTaskItemController {
         List<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), date);
         return ApiResponse.ok(response);
     }
+
+    @Operation(summary = "특정 날짜의 할 일 개수 조회", description = "특정 날짜에 등록된 할 일 개수를 반환. 날짜가 없으면 오늘 날짜 기준으로 조회합니다.")
+    @GetMapping("/count")
+    public ApiResponse<Integer> getTaskItemCount(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @RequestParam(value = "date", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        int count = todayTaskItemService.getTaskItemCount(user.getMemberId(), date);
+        return ApiResponse.ok(count);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -12,16 +12,12 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,12 +38,13 @@ public class TodayTaskItemController {
 
     @Operation(summary = "오늘의 할 일 조회", description = "오늘의 할 일 조회. 날짜 디폴트 값은 오늘 날짜(yyyy-mm-dd)")
     @GetMapping
-    public ApiResponse<List<TodayTaskItemResponse>> getTodayTasks(
+    public ApiResponse<Page<TodayTaskItemResponse>> getTodayTasks(
         @AuthenticationPrincipal CustomOAuth2User user,
         @RequestParam(value = "date", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+        @ParameterObject Pageable pageable
     ){
-        List<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), date);
+        Page<TodayTaskItemResponse> response = todayTaskItemService.getTodayTasks(user.getMemberId(), date, pageable);
         return ApiResponse.ok(response);
     }
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
@@ -2,7 +2,6 @@ package capstone.backend.domain.todayTask.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 
 public record TodayTaskItemCreateRequest(
-    @NotNull
     @NotEmpty
     @Schema(description = "오늘의 할 일에 추가할 아이젠하워 ID 목록", example = "[1, 2, 3]")
     List<Long> eisenhowerItemIds

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
@@ -1,0 +1,14 @@
+package capstone.backend.domain.todayTask.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+
+public record TodayTaskItemCreateRequest(
+    @NotNull
+    @NotEmpty
+    @Schema(description = "오늘의 할 일에 추가할 아이젠하워 ID 목록", example = "[1, 2, 3]")
+    List<Long> eisenhowerItemIds
+){}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskItemResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskItemResponse.java
@@ -1,0 +1,26 @@
+package capstone.backend.domain.todayTask.dto.response;
+
+import capstone.backend.domain.todayTask.entity.TodayTaskItem;
+import java.time.LocalDate;
+
+public record TodayTaskItemResponse(
+    Long id,
+    String title,
+    Long category_id,
+    String memo,
+    LocalDate dueDate,
+    LocalDate taskDate,
+    boolean isCompleted
+) {
+    public static TodayTaskItemResponse from(TodayTaskItem todayTaskItem) {
+        return new TodayTaskItemResponse(
+            todayTaskItem.getId(),
+            todayTaskItem.getEisenhowerItem().getTitle(),
+            todayTaskItem.getEisenhowerItem().getCategory() != null ? todayTaskItem.getEisenhowerItem().getCategory().getId() : null ,
+            todayTaskItem.getEisenhowerItem().getMemo(),
+            todayTaskItem.getEisenhowerItem().getDueDate(),
+            todayTaskItem.getTaskDate(),
+            todayTaskItem.getEisenhowerItem().getIsCompleted()
+        );
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
@@ -46,4 +46,8 @@ public class TodayTaskItem {
             .taskDate(LocalDate.now())
             .build();
     }
+
+    public void updateTaskDate(LocalDate newTaskDate) {
+        this.taskDate = newTaskDate;
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
@@ -1,0 +1,49 @@
+package capstone.backend.domain.todayTask.entity;
+
+import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
+import capstone.backend.domain.member.scheme.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TodayTaskItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "today_task_item_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "eisenhower_item_id", nullable = false)
+    private EisenhowerItem eisenhowerItem;
+
+    @Column(name = "task_date", nullable = false)
+    private LocalDate taskDate;
+
+    public static TodayTaskItem from(Member member, EisenhowerItem eisenhowerItem) {
+        return TodayTaskItem.builder()
+            .member(member)
+            .eisenhowerItem(eisenhowerItem)
+            .taskDate(LocalDate.now())
+            .build();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/exception/TodayTaskNotFoundException.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/exception/TodayTaskNotFoundException.java
@@ -1,0 +1,8 @@
+package capstone.backend.domain.todayTask.exception;
+
+import capstone.backend.global.api.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class TodayTaskNotFoundException extends ApiException {
+    public TodayTaskNotFoundException() {super(HttpStatus.NOT_FOUND, "오늘의 할 일을 찾을 수 없습니다.");}
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/exception/TodayTaskNotFoundException.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/exception/TodayTaskNotFoundException.java
@@ -4,5 +4,7 @@ import capstone.backend.global.api.exception.ApiException;
 import org.springframework.http.HttpStatus;
 
 public class TodayTaskNotFoundException extends ApiException {
-    public TodayTaskNotFoundException() {super(HttpStatus.NOT_FOUND, "오늘의 할 일을 찾을 수 없습니다.");}
+    public TodayTaskNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "오늘의 할 일을 찾을 수 없습니다.");
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
     List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     int countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
+    int countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -4,10 +4,12 @@ import capstone.backend.domain.todayTask.entity.TodayTaskItem;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
-    List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
+    Page<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate, Pageable pageable);
     Long countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     Long countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -3,10 +3,12 @@ package capstone.backend.domain.todayTask.repository;
 import capstone.backend.domain.todayTask.entity.TodayTaskItem;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
     List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     int countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     int countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
+    Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
     List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
-    int countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
-    int countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
+    Long countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
+    Long countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
     List<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -2,7 +2,6 @@ package capstone.backend.domain.todayTask.repository;
 
 import capstone.backend.domain.todayTask.entity.TodayTaskItem;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,5 +12,5 @@ public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Lo
     Long countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     Long countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
-    List<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
+    Page<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted, Pageable pageable);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
     List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
+    int countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.todayTask.repository;
+
+import capstone.backend.domain.todayTask.entity.TodayTaskItem;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
+    List<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -11,4 +11,5 @@ public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Lo
     int countByMemberIdAndTaskDate(Long memberId, LocalDate taskDate);
     int countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
+    List<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -14,6 +14,8 @@ import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,11 +46,10 @@ public class TodayTaskItemService {
     }
 
     //오늘의 할 일 조회
-    public List<TodayTaskItemResponse> getTodayTasks(Long memberId, LocalDate date) {
+    public Page<TodayTaskItemResponse> getTodayTasks(Long memberId, LocalDate date, Pageable pageable) {
         LocalDate taskDate = (date != null) ? date : LocalDate.now();
-        return todayTaskItemRepository.findByMemberIdAndTaskDate(memberId, taskDate).stream()
-            .map(TodayTaskItemResponse::from)
-            .toList();
+        Page<TodayTaskItem> todayTasks = todayTaskItemRepository.findByMemberIdAndTaskDate(memberId, taskDate, pageable);
+        return todayTasks.map(TodayTaskItemResponse::from);
     }
 
     //할 일 전체 개수 조회

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -52,13 +52,13 @@ public class TodayTaskItemService {
     }
 
     //할 일 전체 개수 조회
-    public int getTaskItemCount(Long memberId, LocalDate date) {
+    public Long getTaskItemCount(Long memberId, LocalDate date) {
         LocalDate taskDate = (date != null) ? date : LocalDate.now();
         return todayTaskItemRepository.countByMemberIdAndTaskDate(memberId, taskDate);
     }
 
     //완료된 할 일 개수 조회
-    public int getCompletedTaskItemCount(Long memberId, LocalDate date) {
+    public Long getCompletedTaskItemCount(Long memberId, LocalDate date) {
         LocalDate taskDate = (date != null) ? date : LocalDate.now();
         return todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, taskDate, true);
     }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -1,0 +1,44 @@
+package capstone.backend.domain.todayTask.service;
+
+import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
+import capstone.backend.domain.eisenhower.exception.EisenhowerItemNotFoundException;
+import capstone.backend.domain.eisenhower.repository.EisenhowerItemRepository;
+import capstone.backend.domain.member.exception.MemberNotFoundException;
+import capstone.backend.domain.member.repository.MemberRepository;
+import capstone.backend.domain.member.scheme.Member;
+import capstone.backend.domain.todayTask.dto.request.TodayTaskItemCreateRequest;
+import capstone.backend.domain.todayTask.dto.response.TodayTaskItemResponse;
+import capstone.backend.domain.todayTask.entity.TodayTaskItem;
+import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodayTaskItemService {
+    private final TodayTaskItemRepository todayTaskItemRepository;
+    private final MemberRepository memberRepository;
+    private final EisenhowerItemRepository eisenhowerItemRepository;
+
+    //오늘의 할 일 추가
+    @Transactional
+    public List<TodayTaskItemResponse> addTaskItem(Long memberId, TodayTaskItemCreateRequest request) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        return request.eisenhowerItemIds().stream()
+            .map(itemId -> {
+                EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findByIdAndMemberId(itemId, memberId)
+                    .orElseThrow(EisenhowerItemNotFoundException::new);
+
+                TodayTaskItem todayTaskItem = TodayTaskItem.from(member, eisenhowerItem);
+                todayTaskItemRepository.save(todayTaskItem);
+
+                return TodayTaskItemResponse.from(todayTaskItem);
+            })
+            .toList();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -9,6 +9,7 @@ import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.todayTask.dto.request.TodayTaskItemCreateRequest;
 import capstone.backend.domain.todayTask.dto.response.TodayTaskItemResponse;
 import capstone.backend.domain.todayTask.entity.TodayTaskItem;
+import capstone.backend.domain.todayTask.exception.TodayTaskNotFoundException;
 import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -60,5 +61,14 @@ public class TodayTaskItemService {
     public int getCompletedTaskItemCount(Long memberId, LocalDate date) {
         LocalDate taskDate = (date != null) ? date : LocalDate.now();
         return todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, taskDate, true);
+    }
+
+    //오늘의 할 일에서 삭제
+    @Transactional
+    public void deleteTaskItem(Long memberId, Long taskId) {
+        TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
+            .orElseThrow(TodayTaskNotFoundException::new);
+
+        todayTaskItemRepository.delete(todayTaskItem);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -74,14 +74,12 @@ public class TodayTaskItemService {
     }
 
     //어제 할 일 중 완료되지 않은 할 일 가져오기
-    public List<TodayTaskItemResponse> getYesterdayTaskItems(Long memberId){
+    public Page<TodayTaskItemResponse> getYesterdayTaskItems(Long memberId, Pageable pageable){
         LocalDate yesterday = LocalDate.now().minusDays(1);
 
-        List<TodayTaskItem> yesterdayTasks = todayTaskItemRepository.findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, yesterday, false);
+        Page<TodayTaskItem> yesterdayTasks = todayTaskItemRepository.findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, yesterday, false, pageable);
 
-        return yesterdayTasks.stream()
-            .map(TodayTaskItemResponse::from)
-            .toList();
+        return yesterdayTasks.map(TodayTaskItemResponse::from);
     }
 
     //할 일 날짜를 오늘로 변경

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -49,4 +49,10 @@ public class TodayTaskItemService {
             .map(TodayTaskItemResponse::from)
             .toList();
     }
+
+    //할 일 전체 개수 조회
+    public int getTaskItemCount(Long memberId, LocalDate date) {
+        LocalDate taskDate = (date != null) ? date : LocalDate.now();
+        return todayTaskItemRepository.countByMemberIdAndTaskDate(memberId, taskDate);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -82,4 +82,30 @@ public class TodayTaskItemService {
             .map(TodayTaskItemResponse::from)
             .toList();
     }
+
+    //할 일 날짜를 오늘로 변경
+    @Transactional
+    public TodayTaskItemResponse updateTaskDateToToday(Long memberId, Long taskId) {
+        TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
+            .orElseThrow(TodayTaskNotFoundException::new);
+
+        LocalDate today = LocalDate.now();
+        todayTaskItem.updateTaskDate(today);
+
+        todayTaskItemRepository.save(todayTaskItem);
+        return TodayTaskItemResponse.from(todayTaskItem);
+    }
+
+    //오늘의 할 일 날짜를 어제로 변경
+    @Transactional
+    public TodayTaskItemResponse updateTaskDateToYesterday(Long memberId, Long taskId) {
+        TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
+            .orElseThrow(TodayTaskNotFoundException::new);
+
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        todayTaskItem.updateTaskDate(yesterday);
+
+        todayTaskItemRepository.save(todayTaskItem);
+        return TodayTaskItemResponse.from(todayTaskItem);
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -71,4 +71,15 @@ public class TodayTaskItemService {
 
         todayTaskItemRepository.delete(todayTaskItem);
     }
+
+    //어제 할 일 중 완료되지 않은 할 일 가져오기
+    public List<TodayTaskItemResponse> getYesterdayTaskItems(Long memberId){
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        List<TodayTaskItem> yesterdayTasks = todayTaskItemRepository.findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, yesterday, false);
+
+        return yesterdayTasks.stream()
+            .map(TodayTaskItemResponse::from)
+            .toList();
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -49,23 +49,19 @@ public class TodayTaskItemService {
     }
 
     //오늘의 할 일 조회
-    public Page<TodayTaskItemResponse> getTodayTasks(Long memberId, LocalDate date, Pageable pageable) {
-       LocalDate taskDate = getDate(date);
-
-        Page<TodayTaskItem> todayTasks = todayTaskItemRepository.findByMemberIdAndTaskDate(memberId, taskDate, pageable);
+    public Page<TodayTaskItemResponse> getTodayTasks(Long memberId, Pageable pageable) {
+        Page<TodayTaskItem> todayTasks = todayTaskItemRepository.findByMemberIdAndTaskDate(memberId, getDate(), pageable);
         return todayTasks.map(TodayTaskItemResponse::from);
     }
 
     //할 일 전체 개수 조회
-    public Long getTaskItemCount(Long memberId, LocalDate date) {
-        LocalDate taskDate = (date != null) ? date : LocalDate.now();
-        return todayTaskItemRepository.countByMemberIdAndTaskDate(memberId, taskDate);
+    public Long getTaskItemCount(Long memberId) {
+        return todayTaskItemRepository.countByMemberIdAndTaskDate(memberId, getDate());
     }
 
     //완료된 할 일 개수 조회
-    public Long getCompletedTaskItemCount(Long memberId, LocalDate date) {
-        LocalDate taskDate = (date != null) ? date : LocalDate.now();
-        return todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, taskDate, true);
+    public Long getCompletedTaskItemCount(Long memberId) {
+        return todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, getDate(), true);
     }
 
     //오늘의 할 일에서 삭제
@@ -79,9 +75,7 @@ public class TodayTaskItemService {
 
     //어제 할 일 중 완료되지 않은 할 일 가져오기
     public Page<TodayTaskItemResponse> getYesterdayTaskItems(Long memberId, Pageable pageable){
-        LocalDate taskDate = getDate(LocalDate.now());
-
-        Page<TodayTaskItem> yesterdayTasks = todayTaskItemRepository.findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, taskDate, false, pageable);
+        Page<TodayTaskItem> yesterdayTasks = todayTaskItemRepository.findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, getDate(), false, pageable);
 
         return yesterdayTasks.map(TodayTaskItemResponse::from);
     }
@@ -113,9 +107,7 @@ public class TodayTaskItemService {
     }
 
     //오전 6시 기준 날짜 가져오기
-    private LocalDate getDate(LocalDate date) {
-        if(date != null) return date;
-
+    private LocalDate getDate() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime sixAM = now.with(LocalTime.of(6, 0));
         return now.isBefore(sixAM) ? LocalDate.now().minusDays(1) : LocalDate.now();

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -41,4 +41,12 @@ public class TodayTaskItemService {
             })
             .toList();
     }
+
+    //오늘의 할 일 조회
+    public List<TodayTaskItemResponse> getTodayTasks(Long memberId, LocalDate date) {
+        LocalDate taskDate = (date != null) ? date : LocalDate.now();
+        return todayTaskItemRepository.findByMemberIdAndTaskDate(memberId, taskDate).stream()
+            .map(TodayTaskItemResponse::from)
+            .toList();
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -86,8 +86,7 @@ public class TodayTaskItemService {
         TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
             .orElseThrow(TodayTaskNotFoundException::new);
 
-        LocalDate today = LocalDate.now();
-        todayTaskItem.updateTaskDate(today);
+        todayTaskItem.updateTaskDate(LocalDate.now());
 
         todayTaskItemRepository.save(todayTaskItem);
         return TodayTaskItemResponse.from(todayTaskItem);
@@ -99,8 +98,7 @@ public class TodayTaskItemService {
         TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
             .orElseThrow(TodayTaskNotFoundException::new);
 
-        LocalDate yesterday = LocalDate.now().minusDays(1);
-        todayTaskItem.updateTaskDate(yesterday);
+        todayTaskItem.updateTaskDate(LocalDate.now().minusDays(1));
 
         todayTaskItemRepository.save(todayTaskItem);
         return TodayTaskItemResponse.from(todayTaskItem);

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -55,4 +55,10 @@ public class TodayTaskItemService {
         LocalDate taskDate = (date != null) ? date : LocalDate.now();
         return todayTaskItemRepository.countByMemberIdAndTaskDate(memberId, taskDate);
     }
+
+    //완료된 할 일 개수 조회
+    public int getCompletedTaskItemCount(Long memberId, LocalDate date) {
+        LocalDate taskDate = (date != null) ? date : LocalDate.now();
+        return todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, taskDate, true);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #182 

## 📝 작업 내용

- 전체 조회 API
- 삭제 API 
- 생성 API
- 오늘 해야 할 일 총 개수
- 오늘 해야 할 일 중 완료한 개수
- 어제 해야 할 일 조회
- 어제 일 오늘로 날짜 변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 해야 할 일은 항상 오늘 날짜로 생성됩니다. 테스트를 위해 어제 날짜꺼로 변경할 수 있도록 구현해놨습니다. 프론트에서도 쓸 것 같아서 놔뒀는데 삭제하는게 나을까요??
