### PR TITLE
[BE] refactor: 아이젠하워 관련 기능 수정 사항 반영

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerCategoryController.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerCategoryController.java
@@ -22,9 +22,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "아이젠하워 카테고리", description = "아이젠하워 카테고리 관련 API")
+@Tag(name = "아이젠하워 카테고리 V1", description = "아이젠하워 카테고리 관련 API")
 @RestController
-@RequestMapping("/api/eisenhower/category")
+@RequestMapping("/api/v1/eisenhower/category")
 @RequiredArgsConstructor
 public class EisenhowerCategoryController {
 

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerItemController.java
@@ -27,9 +27,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "아이젠하워 작업", description = "아이젠하워 작업 관련 API")
+@Tag(name = "아이젠하워 작업 V1", description = "아이젠하워 작업 관련 API")
 @RestController
-@RequestMapping("/api/eisenhower")
+@RequestMapping("/api/v1/eisenhower")
 @RequiredArgsConstructor
 public class EisenhowerItemController {
 

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerNotificationController.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/controller/EisenhowerNotificationController.java
@@ -13,9 +13,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "아이젠하워 알림", description = "아이젠하워 알림 관련 API")
+@Tag(name = "아이젠하워 알림 V1", description = "아이젠하워 알림 관련 API")
 @RestController
-@RequestMapping("/api/eisenhower/notification")
+@RequestMapping("/api/v1/eisenhower/notification")
 @RequiredArgsConstructor
 public class EisenhowerNotificationController {
 

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemCreateRequest.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.eisenhower.dto.request;
 
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.entity.EisenhowerQuadrant;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -21,10 +20,6 @@ public record EisenhowerItemCreateRequest(
         @NotNull(message = "사분면(quadrant)은 필수입니다.")
         @Schema(description = "아이젠하워 사분면", example = "Q1")
         EisenhowerQuadrant quadrant,
-
-        @NotNull(message = "작업 타입(type)은 필수입니다.")
-        @Schema(description = "작업 타입", example = "TODO")
-        TaskType type,
 
         @NotNull(message = "정렬 순서(order)는 필수입니다.")
         @Schema(description = "정렬 순서 (작은 값일수록 우선)", example = "1")

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemFilterRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemFilterRequest.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.eisenhower.dto.request;
 
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.entity.EisenhowerQuadrant;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -14,8 +13,6 @@ public record EisenhowerItemFilterRequest(
 
         @Schema(description = "카테고리 ID 필터")
         Long categoryId,
-
-        TaskType type,
 
         EisenhowerQuadrant quadrant
 ) {

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemUpdateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/dto/request/EisenhowerItemUpdateRequest.java
@@ -2,16 +2,12 @@ package capstone.backend.domain.eisenhower.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
-import capstone.backend.domain.common.entity.TaskType;
 import java.time.LocalDate;
 
 public record EisenhowerItemUpdateRequest(
         @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다.")
         @Schema(description = "할 일 제목", example = "운동하기")
         String title,
-
-        @Schema(description = "작업 타입", example = "TODO")
-        TaskType type,
 
         @Schema(description = "카테고리 ID (null이면 변경 없음)", example = "3")
         Long categoryId,

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/dto/response/EisenhowerItemResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/dto/response/EisenhowerItemResponse.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.eisenhower.dto.response;
 
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
 import capstone.backend.domain.eisenhower.entity.EisenhowerQuadrant;
 import java.time.LocalDate;
@@ -13,13 +12,10 @@ public record EisenhowerItemResponse(
         String memo,
         Long category_id,
         EisenhowerQuadrant quadrant,
-        TaskType type,
         LocalDate dueDate,
         Long order,
         Boolean isCompleted,
-        LocalDateTime createdAt,
-        Long mindMapId,
-        Long pomodoroId
+        LocalDateTime createdAt
 ) {
     public static EisenhowerItemResponse from(EisenhowerItem item) {
         return new EisenhowerItemResponse(
@@ -28,13 +24,10 @@ public record EisenhowerItemResponse(
                 item.getMemo(),
                 item.getCategory() != null ? item.getCategory().getId() : null,
                 item.getQuadrant(),
-                item.getType(),
                 item.getDueDate(),
                 item.getOrder(),
                 item.getIsCompleted(),
-                item.getCreatedAt(),
-                item.getMindMap() != null ? item.getMindMap().getId() : null,
-                item.getPomodoro() != null ? item.getPomodoro().getId() : null
+                item.getCreatedAt()
         );
     }
 

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
@@ -5,6 +5,7 @@ import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemUpdateReques
 import capstone.backend.domain.member.scheme.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -21,12 +22,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class EisenhowerItem {
 
     @Id
@@ -55,6 +59,7 @@ public class EisenhowerItem {
     @Column(nullable = false)
     private Boolean isCompleted;
 
+    @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
@@ -73,7 +78,6 @@ public class EisenhowerItem {
                 .quadrant(request.quadrant())
                 .order(request.order())
                 .isCompleted(false)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
@@ -1,11 +1,8 @@
 package capstone.backend.domain.eisenhower.entity;
 
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemCreateRequest;
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemUpdateRequest;
 import capstone.backend.domain.member.scheme.Member;
-import capstone.backend.domain.mindmap.entity.MindMap;
-import capstone.backend.domain.pomodoro.schema.Pomodoro;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -32,7 +29,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class EisenhowerItem {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, name = "eisenhower_item_id")
     private Long id;
 
@@ -51,10 +49,6 @@ public class EisenhowerItem {
     @Column(nullable = false)
     private EisenhowerQuadrant quadrant;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private TaskType type;
-
     @Column(nullable = false, name = "task_order")
     private Long order;
 
@@ -69,14 +63,6 @@ public class EisenhowerItem {
 
     private LocalDate dueDate;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mind_map_id")
-    private MindMap mindMap;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pomodoro_id")
-    private Pomodoro pomodoro;
-
 
     public static EisenhowerItem from(EisenhowerItemCreateRequest request, Member member, EisenhowerCategory category) {
         return EisenhowerItem.builder()
@@ -85,7 +71,6 @@ public class EisenhowerItem {
                 .category(category)
                 .dueDate(request.dueDate())
                 .quadrant(request.quadrant())
-                .type(request.type())
                 .order(request.order())
                 .isCompleted(false)
                 .createdAt(LocalDateTime.now())
@@ -93,10 +78,15 @@ public class EisenhowerItem {
     }
 
     public void update(EisenhowerItemUpdateRequest request, EisenhowerCategory category) {
-        if (request.title() != null) this.title = request.title();
-        if (request.memo() != null) this.memo = request.memo();
-        if (request.type() != null) this.type = request.type();
-        if (request.isCompleted() != null) this.isCompleted = request.isCompleted();
+        if (request.title() != null) {
+            this.title = request.title();
+        }
+        if (request.memo() != null) {
+            this.memo = request.memo();
+        }
+        if (request.isCompleted() != null) {
+            this.isCompleted = request.isCompleted();
+        }
         if (Boolean.TRUE.equals(request.dueDateExplicitlyNull())) {
             this.dueDate = null;
         } else if (request.dueDate() != null) {
@@ -110,11 +100,4 @@ public class EisenhowerItem {
         this.quadrant = quadrant;
     }
 
-    public void connectPomodoro(Pomodoro pomodoro) {
-        this.pomodoro = pomodoro;
-    }
-
-    public void connectMindMap(MindMap mindMap) {
-        this.mindMap = mindMap;
-    }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
@@ -15,5 +15,4 @@ public interface EisenhowerItemRepository extends JpaRepository<EisenhowerItem, 
 
     List<EisenhowerItem> findAllByDueDateAndIsCompleted(LocalDate today, boolean isCompleted);
 
-    Optional<EisenhowerItem> findByMemberIdAndMindMapId(Long memberId, Long mindMapId);
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepositoryImpl.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepositoryImpl.java
@@ -2,18 +2,16 @@ package capstone.backend.domain.eisenhower.repository;
 
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerItemFilterRequest;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
-import capstone.backend.domain.eisenhower.entity.QEisenhowerItem;
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.entity.EisenhowerQuadrant;
+import capstone.backend.domain.eisenhower.entity.QEisenhowerItem;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RequiredArgsConstructor
 public class EisenhowerItemRepositoryImpl implements EisenhowerItemRepositoryCustom {
@@ -31,7 +29,6 @@ public class EisenhowerItemRepositoryImpl implements EisenhowerItemRepositoryCus
                         eqCompleted(filter.completed(), item),
                         eqCategory(filter.categoryId(), item),
                         eqDueDate(filter.dueDate(), item),
-                        eqType(filter.type(), item),
                         eqQuadrant(filter.quadrant(), item)
                 )
                 .offset(pageable.getOffset())
@@ -47,7 +44,6 @@ public class EisenhowerItemRepositoryImpl implements EisenhowerItemRepositoryCus
                         eqCompleted(filter.completed(), item),
                         eqCategory(filter.categoryId(), item),
                         eqDueDate(filter.dueDate(), item),
-                        eqType(filter.type(), item),
                         eqQuadrant(filter.quadrant(), item)
                 )
                 .fetchOne();
@@ -65,10 +61,6 @@ public class EisenhowerItemRepositoryImpl implements EisenhowerItemRepositoryCus
 
     private BooleanExpression eqDueDate(LocalDate dueDate, QEisenhowerItem item) {
         return dueDate != null ? item.dueDate.eq(dueDate) : null;
-    }
-
-    private BooleanExpression eqType(TaskType type, QEisenhowerItem item) {
-        return type != null ? item.type.eq(type) : null;
     }
 
     private BooleanExpression eqQuadrant(EisenhowerQuadrant quadrant, QEisenhowerItem item) {

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerItemService.java
@@ -10,7 +10,6 @@ import capstone.backend.domain.eisenhower.entity.EisenhowerCategory;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
 import capstone.backend.domain.eisenhower.exception.CategoryNotFoundException;
 import capstone.backend.domain.eisenhower.exception.EisenhowerItemNotFoundException;
-import capstone.backend.domain.eisenhower.exception.MindMapNotLinkedToEisenhowerException;
 import capstone.backend.domain.eisenhower.repository.EisenhowerCategoryRepository;
 import capstone.backend.domain.eisenhower.repository.EisenhowerItemRepository;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
@@ -104,9 +103,10 @@ public class EisenhowerItemService {
 
     //마인드맵 추출 시, 연관된 아이젠하워 카테고리 조회
     public EisenhowerCategoryResponse getCategoryByMindMapId(Long mindMapId, Long memberId){
-        EisenhowerItem item = eisenhowerItemRepository.findByMemberIdAndMindMapId(memberId, mindMapId)
-            .orElseThrow(MindMapNotLinkedToEisenhowerException::new);
+//        EisenhowerItem item = eisenhowerItemRepository.findByMemberIdAndMindMapId(memberId, mindMapId)
+//            .orElseThrow(MindMapNotLinkedToEisenhowerException::new);
 
-        return EisenhowerCategoryResponse.from(item.getCategory());
+//        return EisenhowerCategoryResponse.from(item.getCategory());
+        return null;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/SidebarMindMapResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/dto/response/SidebarMindMapResponse.java
@@ -34,7 +34,6 @@ record SidebarEisenhowerItemDTO(
     String memo,
     LocalDate dueDate,
     EisenhowerQuadrant quadrant,
-    TaskType type,
     Long order,
     boolean isCompleted,
     LocalDateTime createdAt
@@ -46,7 +45,6 @@ record SidebarEisenhowerItemDTO(
             eisenhowerItem.getMemo(),
             eisenhowerItem.getDueDate(),
             eisenhowerItem.getQuadrant(),
-            eisenhowerItem.getType(),
             eisenhowerItem.getOrder(),
             eisenhowerItem.getIsCompleted(),
             eisenhowerItem.getCreatedAt()

--- a/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/repository/MindMapRepository.java
@@ -1,21 +1,18 @@
 package capstone.backend.domain.mindmap.repository;
 
 import capstone.backend.domain.mindmap.entity.MindMap;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MindMapRepository extends JpaRepository<MindMap, Long> {
     Optional<MindMap> findByIdAndMemberId(Long id, Long memberId);
 
-    @Query("""
-            SELECT m, e
-            FROM MindMap m
-            LEFT JOIN EisenhowerItem e ON e.mindMap.id = m.id
-            WHERE m.member.id = :memberId
-            ORDER BY m.lastModifiedAt DESC
-        """)
-    List<Object[]> findMindMapWithEisenhowerByMemberId(@Param("memberId") Long memberId);
+//    @Query("""
+//            SELECT m, e
+//            FROM MindMap m
+//            LEFT JOIN EisenhowerItem e ON e.mindMap.id = m.id
+//            WHERE m.member.id = :memberId
+//            ORDER BY m.lastModifiedAt DESC
+//        """)
+//    List<Object[]> findMindMapWithEisenhowerByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
+++ b/backend/src/main/java/capstone/backend/domain/mindmap/service/MindMapService.java
@@ -49,7 +49,7 @@ public class MindMapService {
             .ifPresent(eisenhowerId -> {
                 EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findById(eisenhowerId)
                     .orElseThrow(EisenhowerItemNotFoundException::new);
-                eisenhowerItem.connectMindMap(mindMap);
+//                eisenhowerItem.connectMindMap(mindMap);
                 eisenhowerItemRepository.save(eisenhowerItem);
             });
         mindMapRepository.save(mindMap);
@@ -99,13 +99,14 @@ public class MindMapService {
 
     //마인드맵 리스트 조회
     public List<SidebarMindMapResponse> getMindMapList(Long memberId){
-        List<Object[]> results = mindMapRepository.findMindMapWithEisenhowerByMemberId(memberId);
-        return results.stream()
-            .map(row -> {
-                MindMap mindMap = (MindMap) row[0];
-                EisenhowerItem eisenhowerItem = (EisenhowerItem) row[1]; // null 가능
-                return SidebarMindMapResponse.from(mindMap, eisenhowerItem);
-            })
-            .toList();
+//        List<Object[]> results = mindMapRepository.findMindMapWithEisenhowerByMemberId(memberId);
+//        return results.stream()
+//            .map(row -> {
+//                MindMap mindMap = (MindMap) row[0];
+//                EisenhowerItem eisenhowerItem = (EisenhowerItem) row[1]; // null 가능
+//                return SidebarMindMapResponse.from(mindMap, eisenhowerItem);
+//            })
+//            .toList();
+        return null;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/DailyPomodoroSummaryController.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/DailyPomodoroSummaryController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name = "데이터 분석 - 뽀모도로 타이머 V2", description = "뽀모도로 타이머 이용량 관련 API")
 @RestController
-@RequestMapping("/api/data/pomodoro/v2")
+@RequestMapping("/api/v2/data/pomodoro")
 @RequiredArgsConstructor
 public class DailyPomodoroSummaryController {
 

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/PomodoroV2Controller.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/controller/v2/PomodoroV2Controller.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "뽀모도로 타이머 V2", description = "Version 2. 기획 수정 후 뽀모도로 타이머 관련 API")
 @RestController
-@RequestMapping("/api/pomodoro/v2")
+@RequestMapping("/api/v2/pomodoro")
 @RequiredArgsConstructor
 public class PomodoroV2Controller {
 

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/dto/response/SidebarPomodoroResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/dto/response/SidebarPomodoroResponse.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.pomodoro.dto.response;
 
-import capstone.backend.domain.common.entity.TaskType;
 import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
 import capstone.backend.domain.eisenhower.entity.EisenhowerQuadrant;
 import capstone.backend.domain.pomodoro.schema.Pomodoro;
@@ -36,7 +35,6 @@ record SidebarEisenhowerItemDTO(
         String memo,
         LocalDate dueDate,
         EisenhowerQuadrant quadrant,
-        TaskType type,
         Long order,
         boolean isCompleted,
         LocalDateTime createdAt
@@ -48,7 +46,6 @@ record SidebarEisenhowerItemDTO(
                 eisenhowerItem.getMemo(),
                 eisenhowerItem.getDueDate(),
                 eisenhowerItem.getQuadrant(),
-                eisenhowerItem.getType(),
                 eisenhowerItem.getOrder(),
                 eisenhowerItem.getIsCompleted(),
                 eisenhowerItem.getCreatedAt()

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/repository/PomodoroRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/repository/PomodoroRepository.java
@@ -1,22 +1,18 @@
 package capstone.backend.domain.pomodoro.repository;
 
 import capstone.backend.domain.pomodoro.schema.Pomodoro;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PomodoroRepository extends JpaRepository<Pomodoro, Long> {
 
     Optional<Pomodoro> findByIdAndMemberId(Long id, Long memberId);
 
-    @Query("""
-        SELECT p, ei
-        FROM Pomodoro p
-        LEFT JOIN EisenhowerItem ei ON ei.pomodoro.id = p.id
-        WHERE p.member.id = :memberId
-    """)
-    List<Object[]> findPomodoroWithEisenhowerByMemberId(@Param("memberId") Long memberId);
+//    @Query("""
+//        SELECT p, ei
+//        FROM Pomodoro p
+//        LEFT JOIN EisenhowerItem ei ON ei.pomodoro.id = p.id
+//        WHERE p.member.id = :memberId
+//    """)
+//    List<Object[]> findPomodoroWithEisenhowerByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
@@ -1,9 +1,8 @@
 package capstone.backend.domain.pomodoro.service;
 
-import static capstone.backend.domain.pomodoro.util.PomodoroTimeUtils.*;
+import static capstone.backend.domain.pomodoro.util.PomodoroTimeUtils.calculateTotalTimeSummary;
+import static capstone.backend.domain.pomodoro.util.PomodoroTimeUtils.convertSecondsToLocalTime;
 
-import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
-import capstone.backend.domain.eisenhower.exception.EisenhowerItemNotFoundException;
 import capstone.backend.domain.eisenhower.repository.EisenhowerItemRepository;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
@@ -11,7 +10,6 @@ import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.pomodoro.dto.request.CreatePomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.request.RecordPomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.response.PomodoroDTO;
-import capstone.backend.domain.pomodoro.dto.response.SidebarPomodoroResponse;
 import capstone.backend.domain.pomodoro.dto.response.SidebarResponse;
 import capstone.backend.domain.pomodoro.exception.PomodoroNotFoundException;
 import capstone.backend.domain.pomodoro.repository.PomodoroRepository;
@@ -19,9 +17,6 @@ import capstone.backend.domain.pomodoro.schema.Pomodoro;
 import capstone.backend.domain.pomodoro.schema.PomodoroCycle;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,15 +49,15 @@ public class PomodoroService {
                 convertSecondsToLocalTime(times[1])
         );
 
-        // eisenhowerId가 있으면 매핑
-        Optional.ofNullable(request.eisenhowerId())
-                .ifPresent(eisenhowerId -> {
-                    // 한번 더 유효성 검사
-                    EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findById(eisenhowerId)
-                            .orElseThrow(EisenhowerItemNotFoundException::new);
-                    eisenhowerItem.connectPomodoro(pomodoro); // 연관관계 설정
-                    eisenhowerItemRepository.save(eisenhowerItem);
-                });
+//        // eisenhowerId가 있으면 매핑
+//        Optional.ofNullable(request.eisenhowerId())
+//                .ifPresent(eisenhowerId -> {
+//                    // 한번 더 유효성 검사
+//                    EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findById(eisenhowerId)
+//                            .orElseThrow(EisenhowerItemNotFoundException::new);
+//                    eisenhowerItem.connectPomodoro(pomodoro); // 연관관계 설정
+//                    eisenhowerItemRepository.save(eisenhowerItem);
+//                });
 
         Pomodoro save = pomodoroRepository.save(pomodoro);
         return new PomodoroDTO(save.getId());
@@ -70,16 +65,17 @@ public class PomodoroService {
 
     // (언링크 + 링크) 뽀모도로 전체 조회
     public SidebarResponse getAllPomodoros(Long memberId) {
-        List<Object[]> results = pomodoroRepository.findPomodoroWithEisenhowerByMemberId(memberId);
-
-        Map<Boolean, List<SidebarPomodoroResponse>> partitioned = results.stream()
-                .map(row -> new SidebarPomodoroResponse((Pomodoro) row[0], (EisenhowerItem) row[1]))
-                .collect(Collectors.partitioningBy(SidebarPomodoroResponse::isLinked));
-
-        return new SidebarResponse(
-                partitioned.getOrDefault(false, List.of()), // unlinked
-                partitioned.getOrDefault(true, List.of())   // linked
-        );
+//        List<Object[]> results = pomodoroRepository.findPomodoroWithEisenhowerByMemberId(memberId);
+//
+//        Map<Boolean, List<SidebarPomodoroResponse>> partitioned = results.stream()
+//                .map(row -> new SidebarPomodoroResponse((Pomodoro) row[0], (EisenhowerItem) row[1]))
+//                .collect(Collectors.partitioningBy(SidebarPomodoroResponse::isLinked));
+//
+//        return new SidebarResponse(
+//                partitioned.getOrDefault(false, List.of()), // unlinked
+//                partitioned.getOrDefault(true, List.of())   // linked
+//        );
+        return null;
     }
 
     // 특정 뽀모도로 조회
@@ -94,7 +90,7 @@ public class PomodoroService {
         Pomodoro pomodoro = pomodoroRepository.findByIdAndMemberId(pomodoroId, memberId).orElseThrow(PomodoroNotFoundException::new);
 
         // EisenhowerItem에서 연결 끊기 (만약 존재한다면)
-        eisenhowerItemRepository.findById(pomodoroId).ifPresent(eisenhowerItem -> eisenhowerItem.connectPomodoro(null));
+//        eisenhowerItemRepository.findById(pomodoroId).ifPresent(eisenhowerItem -> eisenhowerItem.connectPomodoro(null));
 
         pomodoroRepository.delete(pomodoro);
     }

--- a/backend/src/main/java/capstone/backend/global/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/capstone/backend/global/swagger/SwaggerConfig.java
@@ -16,9 +16,9 @@ import java.util.List;
 @Configuration
 @OpenAPIDefinition(
         info = @Info(
-                title = "AHZ (ADHD Zone)",
+                title = "Bubble-PoP API",
                 version = "1.0.0",
-                description = "흩어진 생각을 정리하고, 일상 흐름을 바로 잡아주는 ADHD 맞춤형 서비스"
+                description = "쏟아지는 생각 속에서, 나만의 흐름을 다시 세우는 서비스"
         ),
         security = @SecurityRequirement(name = "JWT")
 )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #191 

## 📝 작업 내용

- 아이젠하워 엔티티 변경
  - 내TaskType 필드 삭제
  - 마인드맵 연관관계 삭제
  - 뽀모도로 연관관계 삭제
- 엔티티 변경에 따른 코드 주석 처리 및 삭제
- 스웨거 설정 변경 
  - 서비스명 변경
  - 아이젠하워 관련 API 버전 관리를 위한 변경 작업
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
