### PR TITLE
오늘의 할 일 API 연동

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -21,5 +21,6 @@ export const ENDPOINTS = {
   TODAY: {
     LIST: '/api/v2/today-task',
     YESTERDAY_LIST: '/api/v2/today-task/yesterday',
+    GET_COUNT: '/api/v2/today-task/count',
   },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -22,5 +22,6 @@ export const ENDPOINTS = {
     LIST: '/api/v2/today-task',
     YESTERDAY_LIST: '/api/v2/today-task/yesterday',
     GET_COUNT: '/api/v2/today-task/count',
+    COMPLETE_COUNT: '/api/v2/today-task/completed',
   },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -16,4 +16,10 @@ export const ENDPOINTS = {
     ACCESS_TOKEN: '/api/auth/token',
     REFRESH_TOKEN: '/api/auth/reissue',
   },
+
+  /* 오늘의 할 일 관련 엔드포인트 */
+  TODAY: {
+    LIST: '/api/v2/today-task',
+    YESTERDAY_LIST: '/api/v2/today-task/yesterday',
+  },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -23,5 +23,11 @@ export const ENDPOINTS = {
     YESTERDAY_LIST: '/api/v2/today-task/yesterday',
     GET_COUNT: '/api/v2/today-task/count',
     COMPLETE_COUNT: '/api/v2/today-task/completed',
+    MOVE_TODAY: (id: number) => `/api/v2/today-task/move-today/${id}`,
+  },
+
+  /* 카테고리 관련 엔드포인트 */
+  CATEGORY: {
+    LIST: '/api/v1/eisenhower/category',
   },
 };

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -1,5 +1,6 @@
 import useGetTodayTodoList from '@/hooks/queries/today/useGetTodayTodoList';
 import useGetYesterdayTodoList from '@/hooks/queries/today/useGetYesterdayTodoList';
+import useMoveToday from '@/hooks/queries/today/useMoveToday';
 import { cn } from '@/lib/utils';
 import { Calendar, Check } from 'lucide-react';
 
@@ -25,6 +26,11 @@ function formatDateToEnglish(dateString: string): string {
 export default function TodayList() {
   const { todayTodoList } = useGetTodayTodoList();
   const { yesterdayTodoList } = useGetYesterdayTodoList();
+  const { moveTodayMutation, isPending } = useMoveToday();
+
+  const handleMoveToToday = (id: number) => {
+    moveTodayMutation(id);
+  };
 
   return (
     <div className="mt-4 space-y-4">
@@ -63,7 +69,11 @@ export default function TodayList() {
               </p>
             </div>
             <div className="flex justify-end mt-2">
-              <button className="px-4 py-2 rounded-full bg-white text-blue font-semibold">
+              <button
+                className="px-4 py-2 rounded-full bg-white text-blue font-semibold"
+                onClick={() => handleMoveToToday(todo.id)}
+                disabled={isPending}
+              >
                 오늘 일정에 추가하기
               </button>
             </div>

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -1,3 +1,4 @@
+import useGetCategoryList from '@/hooks/queries/category/useGetCategoryList';
 import useGetTodayTodoList from '@/hooks/queries/today/useGetTodayTodoList';
 import useGetYesterdayTodoList from '@/hooks/queries/today/useGetYesterdayTodoList';
 import useMoveToday from '@/hooks/queries/today/useMoveToday';
@@ -26,6 +27,7 @@ function formatDateToEnglish(dateString: string): string {
 export default function TodayList() {
   const { todayTodoList } = useGetTodayTodoList();
   const { yesterdayTodoList } = useGetYesterdayTodoList();
+  const { getCategoryNameById } = useGetCategoryList();
   const { moveTodayMutation, isPending } = useMoveToday();
 
   const handleMoveToToday = (id: number) => {
@@ -42,7 +44,7 @@ export default function TodayList() {
           >
             <div className="flex items-center justify-between mb-2">
               <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
-                {todo.category_id}
+                {getCategoryNameById(todo.category_id)}
               </div>
               <div
                 className={cn(
@@ -88,7 +90,7 @@ export default function TodayList() {
           >
             <div className="flex items-center justify-between mb-2">
               <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
-                {todo.category_id}
+                {getCategoryNameById(todo.category_id)}
               </div>
               <div
                 className={cn(

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -55,7 +55,10 @@ export default function TodayList() {
                 )}
               >
                 <Check
-                  className={cn(todo.isCompleted ? 'text-white' : 'text-blue')}
+                  className={cn(
+                    'cursor-pointer',
+                    todo.isCompleted ? 'text-white' : 'text-blue',
+                  )}
                   size={24}
                 />
               </div>
@@ -72,7 +75,7 @@ export default function TodayList() {
             </div>
             <div className="flex justify-end mt-2">
               <button
-                className="px-4 py-2 rounded-full bg-white text-blue font-semibold"
+                className="px-4 py-2 rounded-full bg-white text-blue font-semibold cursor-pointer"
                 onClick={() => handleMoveToToday(todo.id)}
                 disabled={isPending}
               >
@@ -101,7 +104,10 @@ export default function TodayList() {
                 )}
               >
                 <Check
-                  className={cn(todo.isCompleted ? 'text-white' : 'text-blue')}
+                  className={cn(
+                    'cursor-pointer',
+                    todo.isCompleted ? 'text-white' : 'text-blue',
+                  )}
                   size={24}
                 />
               </div>
@@ -119,7 +125,7 @@ export default function TodayList() {
             <div className="flex justify-end mt-2">
               <button
                 className={cn(
-                  'px-4 py-2 rounded-full text-white font-semibold',
+                  'px-4 py-2 rounded-full text-white font-semibold cursor-pointer',
                   todo.isCompleted
                     ? 'bg-gray-scale-400 text-gray-scale-200'
                     : 'bg-blue text-white',

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -1,0 +1,131 @@
+import useGetTodayTodoList from '@/hooks/queries/today/useGetTodayTodoList';
+import useGetYesterdayTodoList from '@/hooks/queries/today/useGetYesterdayTodoList';
+import { cn } from '@/lib/utils';
+import { Calendar, Check } from 'lucide-react';
+
+function formatDateToEnglish(dateString: string): string {
+  if (typeof dateString === 'string') {
+    const [yearStr, monthStr, dayStr] = dateString.split('-');
+
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    const day = parseInt(dayStr, 10);
+
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  return '';
+}
+
+export default function TodayList() {
+  const { todayTodoList } = useGetTodayTodoList();
+  const { yesterdayTodoList } = useGetYesterdayTodoList();
+
+  return (
+    <div className="mt-4 space-y-4">
+      {yesterdayTodoList &&
+        yesterdayTodoList.map((todo) => (
+          <div
+            key={todo.id}
+            className="p-3 px-6 py-5 rounded-lg bg-gray-scale-200"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
+                {todo.category_id}
+              </div>
+              <div
+                className={cn(
+                  'w-6 h-6 rounded-full flex items-center justify-center p-1',
+                  todo.isCompleted
+                    ? 'bg-blue'
+                    : 'bg-transparent border-2 border-blue',
+                )}
+              >
+                <Check
+                  className={cn(todo.isCompleted ? 'text-white' : 'text-blue')}
+                  size={24}
+                />
+              </div>
+            </div>
+            <p className="text-[20px] text-[#525463] font-semibold">
+              {todo.title}
+            </p>
+            <p className="text-[14px] text-[#858899] my-2">{todo.memo}</p>
+            <div className="flex items-center gap-2">
+              <Calendar size={24} />
+              <p className="text-[14px] text-[#525463]">
+                {formatDateToEnglish(todo.dueDate)}
+              </p>
+            </div>
+            <div className="flex justify-end mt-2">
+              <button className="px-4 py-2 rounded-full bg-white text-blue font-semibold">
+                오늘 일정에 추가하기
+              </button>
+            </div>
+          </div>
+        ))}
+
+      {todayTodoList &&
+        todayTodoList.map((todo) => (
+          <div
+            key={todo.id}
+            className="p-3 px-6 py-5 rounded-lg bg-white border border-blue"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
+                {todo.category_id}
+              </div>
+              <div
+                className={cn(
+                  'w-6 h-6 rounded-full flex items-center justify-center p-1',
+                  todo.isCompleted
+                    ? 'bg-blue'
+                    : 'bg-transparent border-2 border-blue',
+                )}
+              >
+                <Check
+                  className={cn(todo.isCompleted ? 'text-white' : 'text-blue')}
+                  size={24}
+                />
+              </div>
+            </div>
+            <p className="text-[20px] text-[#525463] font-semibold">
+              {todo.title}
+            </p>
+            <p className="text-[14px] text-[#858899] my-2">{todo.memo}</p>
+            <div className="flex items-center gap-2">
+              <Calendar size={24} />
+              <p className="text-[14px] text-[#525463]">
+                {formatDateToEnglish(todo.dueDate)}
+              </p>
+            </div>
+            <div className="flex justify-end mt-2">
+              <button
+                className={cn(
+                  'px-4 py-2 rounded-full text-white font-semibold',
+                  todo.isCompleted
+                    ? 'bg-gray-scale-400 text-gray-scale-200'
+                    : 'bg-blue text-white',
+                )}
+              >
+                뽀모도로 시작하기
+              </button>
+            </div>
+          </div>
+        ))}
+      {todayTodoList && todayTodoList.length === 0 && (
+        <div className="bg-white px-4 py-2 rounded-md">
+          <p className="font-semibold">아직 오늘의 할 일이 없어요</p>
+          <p className="text-[14px] text-[#525463]">
+            오늘의 할 일 추가하기 {'>'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -1,6 +1,7 @@
 import TodayList from '@/components/today/TodayList';
 import { DailyCompletionChart } from '@/components/ui/chart/DailyCompletionChart';
 import { TodayCompleteChart } from '@/components/ui/chart/TodayCompleteChart';
+import useGetTodayTodoCompletedCount from '@/hooks/queries/today/useGetTodayTodoCompletedCount';
 import useGetTodayTodoCount from '@/hooks/queries/today/useGetTodayTodoCount';
 import { Plus } from 'lucide-react';
 
@@ -11,6 +12,7 @@ export default function TodayMainDashborad() {
   const date = today.getDate();
 
   const { todayTodoCount } = useGetTodayTodoCount();
+  const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
 
   return (
     <div className="flex flex-col lg:flex-row w-full">
@@ -37,7 +39,12 @@ export default function TodayMainDashborad() {
           {year}년 {month}월 {date}일
         </div>
 
-        <TodayCompleteChart />
+        {todayTodoCount && todayTodoCompletedCount && (
+          <TodayCompleteChart
+            totalCount={todayTodoCount}
+            completedCount={todayTodoCompletedCount}
+          />
+        )}
 
         {/* 할 일 목록 */}
         <TodayList />

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -14,6 +14,8 @@ export default function TodayMainDashborad() {
   const { todayTodoCount } = useGetTodayTodoCount();
   const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
 
+  console.log(todayTodoCount, todayTodoCompletedCount);
+
   return (
     <div className="flex flex-col lg:flex-row w-full">
       <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 mr-4">
@@ -39,14 +41,11 @@ export default function TodayMainDashborad() {
           {year}년 {month}월 {date}일
         </div>
 
-        {todayTodoCount && todayTodoCompletedCount && (
-          <TodayCompleteChart
-            totalCount={todayTodoCount}
-            completedCount={todayTodoCompletedCount}
-          />
-        )}
+        <TodayCompleteChart
+          totalCount={todayTodoCount ?? 0}
+          completedCount={todayTodoCompletedCount ?? 0}
+        />
 
-        {/* 할 일 목록 */}
         <TodayList />
       </div>
 

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -14,8 +14,6 @@ export default function TodayMainDashborad() {
   const { todayTodoCount } = useGetTodayTodoCount();
   const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
 
-  console.log(todayTodoCount, todayTodoCompletedCount);
-
   return (
     <div className="flex flex-col lg:flex-row w-full">
       <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 mr-4">
@@ -30,7 +28,7 @@ export default function TodayMainDashborad() {
           </div>
           <div className="flex items-center gap-2">
             <p className="font-semibold text-[#A9ABB8]">수정하기</p>
-            <button className="p-2 bg-gray-scale-200 rounded-full">
+            <button className="p-2 bg-gray-scale-200 rounded-full cursor-pointer">
               <Plus size={18} className="text-blue" />
             </button>
           </div>

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -1,0 +1,56 @@
+import TodayList from '@/components/today/TodayList';
+import { DailyCompletionChart } from '@/components/ui/chart/DailyCompletionChart';
+import { TodayCompleteChart } from '@/components/ui/chart/TodayCompleteChart';
+import useGetTodayTodoCount from '@/hooks/queries/today/useGetTodayTodoCount';
+import { Plus } from 'lucide-react';
+
+export default function TodayMainDashborad() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1;
+  const date = today.getDate();
+
+  const { todayTodoCount } = useGetTodayTodoCount();
+
+  return (
+    <div className="flex flex-col lg:flex-row w-full">
+      <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 mr-4">
+        <div className="flex justify-between items-center mb-4">
+          <div className="flex items-center gap-4">
+            <h3 className="text-[20px] text-[#525463] font-semibold">
+              오늘의 할 일
+            </h3>
+            {todayTodoCount && (
+              <p className="text-[#525463]">{todayTodoCount}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <p className="font-semibold text-[#A9ABB8]">수정하기</p>
+            <button className="p-2 bg-gray-scale-200 rounded-full">
+              <Plus size={18} className="text-blue" />
+            </button>
+          </div>
+        </div>
+
+        {/* 여기서 날짜 포맷은 한글 형식으로 유지 */}
+        <div className="my-8 font-semibold">
+          {year}년 {month}월 {date}일
+        </div>
+
+        <TodayCompleteChart />
+
+        {/* 할 일 목록 */}
+        <TodayList />
+      </div>
+
+      <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto md:h-[740px] lg:h-[600px] mt-4 lg:mt-0">
+        <div className="h-1/2 w-full">
+          <DailyCompletionChart title="할 일 완료 분석" />
+        </div>
+        <div className="h-1/2 w-full">
+          <DailyCompletionChart title="뽀모도로 시간 분석" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/chart/DailyCompletionChart.tsx
+++ b/frontend/src/components/ui/chart/DailyCompletionChart.tsx
@@ -2,7 +2,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  LabelList,
   XAxis,
   ResponsiveContainer,
 } from 'recharts';
@@ -14,7 +13,6 @@ import {
   ChartTooltipContent,
 } from '@/components/ui/chart';
 
-// 일별 데이터 (일요일부터 토요일까지)
 const todoChartData = [
   { day: 'SUN', completed: 5 },
   { day: 'MON', completed: 1 },
@@ -38,9 +36,11 @@ type DailyCompletionChartProps = {
 
 export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
   return (
-    <Card className="h-full w-full">
+    <Card className="h-full w-full border-none shadow-none">
       <CardHeader className="pb-2">
-        <CardTitle>{title}</CardTitle>
+        <CardTitle className="text-gray-scale-700 text-[20px] font-semibold">
+          {title}
+        </CardTitle>
       </CardHeader>
       <CardContent className="h-[calc(100%-5rem)]">
         <div className="h-full w-full">
@@ -61,6 +61,7 @@ export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
                   tickLine={false}
                   tickMargin={10}
                   axisLine={false}
+                  className="font-bold text-gray-scale-700"
                 />
                 <ChartTooltip
                   cursor={false}
@@ -71,12 +72,12 @@ export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
                   fill="var(--color-completed)"
                   radius={8}
                 >
-                  <LabelList
+                  {/* <LabelList
                     position="top"
                     offset={12}
                     className="fill-foreground"
                     fontSize={12}
-                  />
+                  /> */}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>

--- a/frontend/src/components/ui/chart/TodayCompleteChart.tsx
+++ b/frontend/src/components/ui/chart/TodayCompleteChart.tsx
@@ -53,9 +53,9 @@ export function TodayCompleteChart() {
         </div>
 
         <div className="w-full md:w-7/12 lg:w-1/3 md:pl-2">
-          <p className="text-[14px] text-gray-scale-900 mb-4 md:mb-6">
+          <p className="text-[14px] text-gray-scale-900 font-semibold mb-4 md:mb-6">
             오늘의 할 일의 <br />
-            <span className="text-[32px] bg-[#CEFF73] text-blue rounded-full p-1">
+            <span className="text-[32px] bg-neon-green text-blue rounded-full px-2 py-1">
               67%
             </span>
             를 완료했어요!

--- a/frontend/src/components/ui/chart/TodayCompleteChart.tsx
+++ b/frontend/src/components/ui/chart/TodayCompleteChart.tsx
@@ -1,28 +1,48 @@
 import { LabelList, Pie, PieChart } from 'recharts';
-
 import { Card, CardContent } from '@/components/ui/card';
 import { ChartConfig, ChartContainer } from '@/components/ui/chart';
 
-const chartData = [
-  { browser: 'safari', visitors: 33, fill: 'var(--color-safari)' },
-  { browser: 'completionRate', visitors: 67, fill: 'hsl(var(--chart-1))' },
-];
+type TodayCompleteChartProps = {
+  totalCount: number;
+  completedCount: number;
+};
 
-const chartConfig = {
-  visitors: {
-    label: 'Visitors',
-  },
-  completionRate: {
-    label: '67%',
-    color: 'hsl(var(--chart-1))',
-  },
-  safari: {
-    label: '',
-    color: 'hsl(var(--chart-2))',
-  },
-} satisfies ChartConfig;
+export function TodayCompleteChart({
+  totalCount,
+  completedCount,
+}: TodayCompleteChartProps) {
+  const completionPercentage =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
 
-export function TodayCompleteChart() {
+  const remainingPercentage = 100 - completionPercentage;
+
+  const chartData = [
+    {
+      type: 'remainRate',
+      visitors: remainingPercentage,
+      fill: '#D9D9D9',
+    },
+    {
+      type: 'completionRate',
+      visitors: completionPercentage,
+      fill: '#7098ff',
+    },
+  ];
+
+  const chartConfig = {
+    visitors: {
+      label: 'Visitors',
+    },
+    completionRate: {
+      label: `${completionPercentage}%`,
+      color: 'hsl(var(--chart-1))',
+    },
+    remainRate: {
+      label: '',
+      color: 'hsl(var(--chart-2))',
+    },
+  } satisfies ChartConfig;
+
   return (
     <Card className="flex flex-col bg-blue-2 border-0 p-0">
       <CardContent className="p-4 flex flex-col md:flex-row gap-4 md:gap-6 lg:gap-12 items-center md:justify-start lg:justify-center">
@@ -39,7 +59,7 @@ export function TodayCompleteChart() {
                 endAngle={-270}
               >
                 <LabelList
-                  dataKey="browser"
+                  dataKey="type"
                   stroke="none"
                   fontSize={24}
                   fill="#CEFF73"
@@ -51,12 +71,11 @@ export function TodayCompleteChart() {
             </PieChart>
           </ChartContainer>
         </div>
-
         <div className="w-full md:w-7/12 lg:w-1/3 md:pl-2">
           <p className="text-[14px] text-gray-scale-900 font-semibold mb-4 md:mb-6">
             오늘의 할 일의 <br />
             <span className="text-[32px] bg-neon-green text-blue rounded-full px-2 py-1">
-              67%
+              {completionPercentage}%
             </span>
             를 완료했어요!
           </p>

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -25,7 +25,7 @@ const navItems: NavItem[] = [
     id: 'today-todo',
     activeIcon: TodayTodoIcon,
     defaultIcon: TodayTodoHWIcon,
-    label: '매트릭스',
+    label: '오늘의 할 일',
     route: '/today',
   },
   {

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -201,7 +201,7 @@ export default function Sidebar() {
               </div>
               <button
                 onClick={() => toggleSidebar(false)}
-                className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-gray-100 mr-4 transition-all"
+                className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-gray-100 mr-4 transition-all cursor-pointer"
               >
                 <ChevronLeft size={18} />
               </button>
@@ -209,7 +209,7 @@ export default function Sidebar() {
           ) : (
             <button
               onClick={() => toggleSidebar(true)}
-              className="flex items-center justify-center w-full h-full transition-all"
+              className="flex items-center justify-center w-full h-full transition-all cursor-pointer"
             >
               <div className="w-6 h-6 flex items-center justify-center bg-gray-scale-200 rounded-full">
                 <ChevronRight size={40} className="text-blue" />

--- a/frontend/src/hooks/queries/category/useGetCategoryList.ts
+++ b/frontend/src/hooks/queries/category/useGetCategoryList.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { CategoryListRes } from '@/types/api/category';
+import { categoryService } from '@/services/categoryService';
+
+const useGetCategoryList = () => {
+  const { data, isLoading, error, isPending } = useQuery<CategoryListRes>({
+    queryKey: ['CategoryList'],
+    queryFn: () => categoryService.getList(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+    staleTime: 1000 * 60 * 30,
+  });
+
+  const getCategoryNameById = (id: number | string) => {
+    if (!data?.content || data.content.length === 0) {
+      return '기타';
+    }
+
+    const category = data.content.find(
+      (cat) => cat.id === id || cat.id === Number(id),
+    );
+    return category ? category.title : '기타';
+  };
+
+  const getCategoryColorById = (id: number | string) => {
+    if (!data?.content || data.content.length === 0) {
+      return '#e2e8f0'; // 기본 색상
+    }
+
+    const category = data.content.find(
+      (cat) => cat.id === id || cat.id === Number(id),
+    );
+    return category?.color || '#e2e8f0';
+  };
+
+  return {
+    categoryList: data?.content,
+    isLoading,
+    error,
+    isPending,
+    getCategoryNameById,
+    getCategoryColorById,
+  };
+};
+
+export default useGetCategoryList;

--- a/frontend/src/hooks/queries/today/useGetTodayTodoCompletedCount.ts
+++ b/frontend/src/hooks/queries/today/useGetTodayTodoCompletedCount.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTodayCountRes } from '@/types/api/today/response';
+import { todayService } from '@/services/todayService';
+
+const useGetTodayTodoCompletedCount = () => {
+  const { data, isLoading, error, isPending } = useQuery<GetTodayCountRes>({
+    queryKey: ['todayTodoCompletedCount'],
+    queryFn: () => todayService.getCompletedCount(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {
+    todayTodoCompletedCount: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetTodayTodoCompletedCount;

--- a/frontend/src/hooks/queries/today/useGetTodayTodoCount.ts
+++ b/frontend/src/hooks/queries/today/useGetTodayTodoCount.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTodayCountRes } from '@/types/api/today/response';
+import { todayService } from '@/services/todayService';
+
+const useGetTodayTodoCount = () => {
+  const { data, isLoading, error, isPending } = useQuery<GetTodayCountRes>({
+    queryKey: ['todayTodoCount'],
+    queryFn: () => todayService.getCount(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {
+    todayTodoCount: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetTodayTodoCount;

--- a/frontend/src/hooks/queries/today/useGetTodayTodoList.ts
+++ b/frontend/src/hooks/queries/today/useGetTodayTodoList.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTodayTodoListRes } from '@/types/api/today/response';
+import { todayService } from '@/services/todayService';
+
+const useGetTodayTodoList = () => {
+  const { data, isLoading, error, isPending } = useQuery<GetTodayTodoListRes>({
+    queryKey: ['todayTodoList'],
+    queryFn: () => todayService.getList(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {
+    todayTodoList: data?.content.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetTodayTodoList;

--- a/frontend/src/hooks/queries/today/useGetYesterdayTodoList.ts
+++ b/frontend/src/hooks/queries/today/useGetYesterdayTodoList.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTodayTodoListRes } from '@/types/api/today/response';
+import { todayService } from '@/services/todayService';
+
+const useGetYesterdayTodoList = () => {
+  const { data, isLoading, error, isPending } = useQuery<GetTodayTodoListRes>({
+    queryKey: ['yesterdayTodoList'],
+    queryFn: () => todayService.getYesterdayList(),
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  return {
+    yesterdayTodoList: data?.content.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetYesterdayTodoList;

--- a/frontend/src/hooks/queries/today/useMoveToday.ts
+++ b/frontend/src/hooks/queries/today/useMoveToday.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { todayService } from '@/services/todayService';
+
+const useMoveToday = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (id: number) => todayService.moveToday(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+    },
+  });
+
+  return {
+    moveTodayMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useMoveToday;

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -16,7 +16,7 @@ export default function DefaultLayout() {
         </div>
 
         <div className="flex-1">
-          <main className="bg-white rounded-lg shadow-md p-6 min-h-[calc(100vh-88px-64px)] lg:min-h-[calc(100vh-88px)] mb-16 lg:mb-0">
+          <main className="min-h-[calc(100vh-88px-64px)] lg:min-h-[calc(100vh-88px)] mb-16 lg:mb-0">
             <Outlet />
           </main>
         </div>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,3 +1,12 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
 export default function HomePage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate('/today');
+  }, [navigate]);
+
   return <div>메인 페이지</div>;
 }

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -3,6 +3,25 @@ import { TodayCompleteChart } from '@/components/ui/chart/TodayCompleteChart';
 import { cn } from '@/lib/utils';
 import { Calendar, Check, Plus } from 'lucide-react';
 
+function formatDateToEnglish(dateString: string): string {
+  if (typeof dateString === 'string') {
+    const [yearStr, monthStr, dayStr] = dateString.split('-');
+
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    const day = parseInt(dayStr, 10);
+
+    const date = new Date(year, month - 1, day);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  return '';
+}
+
 // 리마인더 데이터
 const REMIND_DATA = [
   {
@@ -48,20 +67,21 @@ export default function TodayListPage() {
   const year = today.getFullYear();
   const month = today.getMonth() + 1;
   const date = today.getDate();
+
   return (
-    <div className="p-5 md:p-7 lg:p-10">
+    <div className="px-6">
       <h1 className="block lg:hidden text-[28px] text-[#525463] font-semibold mb-6">
         오늘의 할 일
       </h1>
 
-      <div className="w-full border border-gray-scale-300 px-6 py-4 rounded-lg text-[20px] font-semibold">
-        응원의 한 마디~
+      <div className="w-full bg-white px-6 py-4 rounded-xl text-[20px] text-[#525463] font-semibold">
+        조금씩, 하지만 꾸준히! 오늘도 파이팅 ✨
       </div>
 
       {/* 리마인더 섹션 */}
-      <div className="mt-4 mb-4">
+      <div className="mt-6 mb-4">
         <div className="flex items-center gap-4 mb-2">
-          <h4 className="text-[20px] font-semibold">리마인더</h4>
+          <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
           <p className="text-blue text-[14px]">더보기 {'>'} </p>
         </div>
 
@@ -69,9 +89,11 @@ export default function TodayListPage() {
           {REMIND_DATA.map((remind) => (
             <li
               key={remind.id}
-              className="border border-gray-scale-300 rounded-lg px-6 py-4 min-w-64"
+              className="bg-white rounded-lg px-6 py-4 min-w-64"
             >
-              <h3 className="text-[20px] font-semibold">{remind.title}</h3>
+              <h3 className="text-[20px] text-[#525463] font-semibold">
+                {remind.title}
+              </h3>
               <p className="text-gray-scale-500">{remind.content}</p>
             </li>
           ))}
@@ -80,10 +102,12 @@ export default function TodayListPage() {
 
       {/* 메인 대시보드 레이아웃 */}
       <div className="flex flex-col lg:flex-row w-full">
-        <div className="w-full lg:w-1/2 border border-gray-scale-300 rounded-lg p-4 mr-4">
+        <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 mr-4">
           <div className="flex justify-between items-center mb-4">
             <div className="flex items-center gap-4">
-              <h3 className="text-[20px] font-semibold">오늘의 할 일</h3>
+              <h3 className="text-[20px] text-[#525463] font-semibold">
+                오늘의 할 일
+              </h3>
               <p className="text-[#525463]">{REMIND_DATA.length}</p>
             </div>
             <div className="flex items-center gap-2">
@@ -94,6 +118,7 @@ export default function TodayListPage() {
             </div>
           </div>
 
+          {/* 여기서 날짜 포맷은 한글 형식으로 유지 */}
           <div className="my-8 font-semibold">
             {year}년 {month}월 {date}일
           </div>
@@ -113,7 +138,7 @@ export default function TodayListPage() {
                 )}
               >
                 <div className="flex items-center justify-between mb-2">
-                  <div className="px-3 py-[6px] bg-blue-2 inline-block rounded-full">
+                  <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
                     {todo.category}
                   </div>
                   <div
@@ -132,13 +157,18 @@ export default function TodayListPage() {
                     />
                   </div>
                 </div>
-                <p className="text-[20px] font-semibold">{todo.title}</p>
+                <p className="text-[20px] text-[#525463] font-semibold">
+                  {todo.title}
+                </p>
                 <p className="text-[14px] text-[#858899] my-2">
                   {todo.content}
                 </p>
+                {/* 여기서 날짜 포맷만 영문 형식(Jan 20, 2022)으로 변경 */}
                 <div className="flex items-center gap-2">
                   <Calendar size={24} />
-                  <p className="text-[14px] text-[#525463]">{todo.dueDate}</p>
+                  <p className="text-[14px] text-[#525463]">
+                    {formatDateToEnglish(todo.dueDate)}
+                  </p>
                 </div>
                 <div className="flex justify-end mt-2">
                   {todo.reminder ? (
@@ -150,7 +180,7 @@ export default function TodayListPage() {
                       className={cn(
                         'px-4 py-2 rounded-full  text-white font-semibold',
                         todo.completed
-                          ? 'bg-blue-2 text-blue'
+                          ? 'bg-gray-scale-400 text-gray-scale-200'
                           : 'bg-blue text-white',
                       )}
                     >

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -55,14 +55,14 @@ export default function TodayListPage() {
       <div className="mt-6 mb-4">
         <div className="flex items-center gap-4 mb-2">
           <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
-          <p className="text-blue text-[14px]">더보기 {'>'} </p>
+          <p className="text-blue text-[14px] cursor-pointer">더보기 {'>'} </p>
         </div>
 
         <ul className="flex gap-4 overflow-x-auto pb-2">
           {REMIND_DATA.map((remind) => (
             <li
               key={remind.id}
-              className="bg-white rounded-lg px-6 py-4 min-w-64"
+              className="bg-white rounded-lg px-6 py-4 min-w-64 cursor-pointer"
             >
               <h3 className="text-[20px] text-[#525463] font-semibold">
                 {remind.title}

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -1,26 +1,7 @@
+import TodayList from '@/components/today/TodayList';
 import { DailyCompletionChart } from '@/components/ui/chart/DailyCompletionChart';
 import { TodayCompleteChart } from '@/components/ui/chart/TodayCompleteChart';
-import { cn } from '@/lib/utils';
-import { Calendar, Check, Plus } from 'lucide-react';
-
-function formatDateToEnglish(dateString: string): string {
-  if (typeof dateString === 'string') {
-    const [yearStr, monthStr, dayStr] = dateString.split('-');
-
-    const year = parseInt(yearStr, 10);
-    const month = parseInt(monthStr, 10);
-    const day = parseInt(dayStr, 10);
-
-    const date = new Date(year, month - 1, day);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  }
-
-  return '';
-}
+import { Plus } from 'lucide-react';
 
 // 리마인더 데이터
 const REMIND_DATA = [
@@ -126,79 +107,7 @@ export default function TodayListPage() {
           <TodayCompleteChart />
 
           {/* 할 일 목록 */}
-          <div className="mt-4 space-y-4">
-            {REMIND_DATA.map((todo) => (
-              <div
-                key={todo.id}
-                className={cn(
-                  'p-3 px-6 py-5 rounded-lg',
-                  todo.reminder
-                    ? 'bg-gray-scale-200'
-                    : 'bg-white border border-blue',
-                )}
-              >
-                <div className="flex items-center justify-between mb-2">
-                  <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
-                    {todo.category}
-                  </div>
-                  <div
-                    className={cn(
-                      'w-6 h-6 rounded-full flex items-center justify-center p-1',
-                      todo.completed
-                        ? 'bg-blue'
-                        : 'bg-transparent border-2 border-blue',
-                    )}
-                  >
-                    <Check
-                      className={cn(
-                        todo.completed ? 'text-white' : 'text-blue',
-                      )}
-                      size={24}
-                    />
-                  </div>
-                </div>
-                <p className="text-[20px] text-[#525463] font-semibold">
-                  {todo.title}
-                </p>
-                <p className="text-[14px] text-[#858899] my-2">
-                  {todo.content}
-                </p>
-                {/* 여기서 날짜 포맷만 영문 형식(Jan 20, 2022)으로 변경 */}
-                <div className="flex items-center gap-2">
-                  <Calendar size={24} />
-                  <p className="text-[14px] text-[#525463]">
-                    {formatDateToEnglish(todo.dueDate)}
-                  </p>
-                </div>
-                <div className="flex justify-end mt-2">
-                  {todo.reminder ? (
-                    <button className="px-4 py-2 rounded-full bg-white text-blue font-semibold">
-                      오늘 일정에 추가하기
-                    </button>
-                  ) : (
-                    <button
-                      className={cn(
-                        'px-4 py-2 rounded-full  text-white font-semibold',
-                        todo.completed
-                          ? 'bg-gray-scale-400 text-gray-scale-200'
-                          : 'bg-blue text-white',
-                      )}
-                    >
-                      뽀모도로 시작하기
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))}
-            {REMIND_DATA.length === 0 && (
-              <div className="bg-white px-4 py-2 rounded-md">
-                <p className="font-semibold">아직 오늘의 할 일이 없어요</p>
-                <p className="text-[14px] text-[#525463]">
-                  오늘의 할 일 추가하기 {'>'}
-                </p>
-              </div>
-            )}
-          </div>
+          <TodayList />
         </div>
 
         <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto md:h-[740px] lg:h-[600px] mt-4 lg:mt-0">

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -1,14 +1,11 @@
-import TodayList from '@/components/today/TodayList';
-import { DailyCompletionChart } from '@/components/ui/chart/DailyCompletionChart';
-import { TodayCompleteChart } from '@/components/ui/chart/TodayCompleteChart';
-import { Plus } from 'lucide-react';
+import TodayMainDashborad from '@/components/today/TodayMainDashborad';
 
 // 리마인더 데이터
 const REMIND_DATA = [
   {
     id: 0,
-    title: '도훈 버블팝 춤 연습하기',
-    content: '버블팝 연습해서 양정민 앞에...',
+    title: '운동하기',
+    content: '등 운동 1시간',
     category: 'category1',
     dueDate: '2022-01-20',
     reminder: true,
@@ -16,8 +13,8 @@ const REMIND_DATA = [
   },
   {
     id: 1,
-    title: '도훈 버블팝 춤 연습하기',
-    content: '버블팝 연습해서 양정민 앞에...',
+    title: '축구하기',
+    content: '일요일 오후 6시 조기축구',
     category: 'category1',
     dueDate: '2022-01-20',
     reminder: false,
@@ -25,8 +22,8 @@ const REMIND_DATA = [
   },
   {
     id: 2,
-    title: '도훈 버블팝 춤 연습하기',
-    content: '버블팝 연습해서 양정민 앞에...',
+    title: '캡스톤 개발',
+    content: '오늘의 할 일 페이지 개발하기',
     category: 'category1',
     dueDate: '2022-01-20',
     reminder: false,
@@ -44,11 +41,6 @@ const REMIND_DATA = [
 ];
 
 export default function TodayListPage() {
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = today.getMonth() + 1;
-  const date = today.getDate();
-
   return (
     <div className="px-6">
       <h1 className="block lg:hidden text-[28px] text-[#525463] font-semibold mb-6">
@@ -82,43 +74,7 @@ export default function TodayListPage() {
       </div>
 
       {/* 메인 대시보드 레이아웃 */}
-      <div className="flex flex-col lg:flex-row w-full">
-        <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 mr-4">
-          <div className="flex justify-between items-center mb-4">
-            <div className="flex items-center gap-4">
-              <h3 className="text-[20px] text-[#525463] font-semibold">
-                오늘의 할 일
-              </h3>
-              <p className="text-[#525463]">{REMIND_DATA.length}</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <p className="font-semibold text-[#A9ABB8]">수정하기</p>
-              <button className="p-2 bg-gray-scale-200 rounded-full">
-                <Plus size={18} className="text-blue" />
-              </button>
-            </div>
-          </div>
-
-          {/* 여기서 날짜 포맷은 한글 형식으로 유지 */}
-          <div className="my-8 font-semibold">
-            {year}년 {month}월 {date}일
-          </div>
-
-          <TodayCompleteChart />
-
-          {/* 할 일 목록 */}
-          <TodayList />
-        </div>
-
-        <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto md:h-[740px] lg:h-[600px] mt-4 lg:mt-0">
-          <div className="h-1/2 w-full">
-            <DailyCompletionChart title="할 일 완료 분석" />
-          </div>
-          <div className="h-1/2 w-full">
-            <DailyCompletionChart title="뽀모도로 시간 분석" />
-          </div>
-        </div>
-      </div>
+      <TodayMainDashborad />
     </div>
   );
 }

--- a/frontend/src/services/categoryService.ts
+++ b/frontend/src/services/categoryService.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/api/client';
+import { ENDPOINTS } from '@/api/endpoints';
+import { CategoryListRes } from '@/types/api/category';
+
+export const categoryService = {
+  getList: async (): Promise<CategoryListRes> => {
+    const response = await apiClient.get<CategoryListRes>(
+      ENDPOINTS.CATEGORY.LIST,
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/api/client';
+import { ENDPOINTS } from '@/api/endpoints';
+import { GetTodayTodoListRes } from '@/types/api/today/response';
+
+export const todayService = {
+  getList: async (): Promise<GetTodayTodoListRes> => {
+    const response = await apiClient.get<GetTodayTodoListRes>(
+      ENDPOINTS.TODAY.LIST,
+    );
+    return response.data;
+  },
+
+  getYesterdayList: async (): Promise<GetTodayTodoListRes> => {
+    const response = await apiClient.get<GetTodayTodoListRes>(
+      ENDPOINTS.TODAY.YESTERDAY_LIST,
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -1,6 +1,9 @@
 import { apiClient } from '@/api/client';
 import { ENDPOINTS } from '@/api/endpoints';
-import { GetTodayTodoListRes } from '@/types/api/today/response';
+import {
+  GetTodayCountRes,
+  GetTodayTodoListRes,
+} from '@/types/api/today/response';
 
 export const todayService = {
   getList: async (): Promise<GetTodayTodoListRes> => {
@@ -13,6 +16,13 @@ export const todayService = {
   getYesterdayList: async (): Promise<GetTodayTodoListRes> => {
     const response = await apiClient.get<GetTodayTodoListRes>(
       ENDPOINTS.TODAY.YESTERDAY_LIST,
+    );
+    return response.data;
+  },
+
+  getCount: async (): Promise<GetTodayCountRes> => {
+    const response = await apiClient.get<GetTodayCountRes>(
+      ENDPOINTS.TODAY.GET_COUNT,
     );
     return response.data;
   },

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -26,4 +26,11 @@ export const todayService = {
     );
     return response.data;
   },
+
+  getCompletedCount: async (): Promise<GetTodayCountRes> => {
+    const response = await apiClient.get<GetTodayCountRes>(
+      ENDPOINTS.TODAY.COMPLETE_COUNT,
+    );
+    return response.data;
+  },
 };

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -3,6 +3,7 @@ import { ENDPOINTS } from '@/api/endpoints';
 import {
   GetTodayCountRes,
   GetTodayTodoListRes,
+  MoveTodayRes,
 } from '@/types/api/today/response';
 
 export const todayService = {
@@ -30,6 +31,13 @@ export const todayService = {
   getCompletedCount: async (): Promise<GetTodayCountRes> => {
     const response = await apiClient.get<GetTodayCountRes>(
       ENDPOINTS.TODAY.COMPLETE_COUNT,
+    );
+    return response.data;
+  },
+
+  moveToday: async (id: number): Promise<MoveTodayRes> => {
+    const response = await apiClient.post<MoveTodayRes>(
+      ENDPOINTS.TODAY.MOVE_TODAY(id),
     );
     return response.data;
   },

--- a/frontend/src/types/api/category/index.ts
+++ b/frontend/src/types/api/category/index.ts
@@ -1,0 +1,2 @@
+export * from './request';
+export * from './response';

--- a/frontend/src/types/api/category/response.ts
+++ b/frontend/src/types/api/category/response.ts
@@ -1,0 +1,7 @@
+import { Category } from '@/types/category';
+
+export type CategoryListRes = {
+  statusCode: number;
+  error: string | null;
+  content: Category[];
+};

--- a/frontend/src/types/api/today/index.ts
+++ b/frontend/src/types/api/today/index.ts
@@ -1,0 +1,2 @@
+export * from './request';
+export * from './response';

--- a/frontend/src/types/api/today/response.ts
+++ b/frontend/src/types/api/today/response.ts
@@ -1,0 +1,9 @@
+import { todayTodo } from '@/types/todayTodo';
+
+export type GetTodayTodoListRes = {
+  statusCode: number;
+  error: string | null;
+  content: {
+    content: todayTodo[];
+  };
+};

--- a/frontend/src/types/api/today/response.ts
+++ b/frontend/src/types/api/today/response.ts
@@ -7,3 +7,9 @@ export type GetTodayTodoListRes = {
     content: todayTodo[];
   };
 };
+
+export type GetTodayCountRes = {
+  statusCode: number;
+  error: string | null;
+  content: number;
+};

--- a/frontend/src/types/api/today/response.ts
+++ b/frontend/src/types/api/today/response.ts
@@ -13,3 +13,17 @@ export type GetTodayCountRes = {
   error: string | null;
   content: number;
 };
+
+export type MoveTodayRes = {
+  statusCode: number;
+  error: string | null;
+  content: {
+    id: number;
+    title: string;
+    category_id: number;
+    meno: string;
+    dueDate: string;
+    taskDate: string;
+    isCompleted: boolean;
+  };
+};

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,6 +1,5 @@
 export interface Category {
   id: number;
   title: string;
-  color: string; // 배경색
-  textColor?: string; // 선택적: 없으면 fallback 처리 가능
+  color: string;
 }

--- a/frontend/src/types/todayTodo.ts
+++ b/frontend/src/types/todayTodo.ts
@@ -1,0 +1,9 @@
+export type todayTodo = {
+  id: number;
+  title: string;
+  category_id: number;
+  memo: string;
+  dueDate: string;
+  taskDate: string;
+  isCompleted: boolean;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #195 

## 📝 작업 내용
오늘의 할 일 관련 API를 연동했습니다. 

해당 PR에서 변경된 디자인 수정 반영 완료했습니다!

### 오늘 / 어제의 할 일 리스트 조회 API 연동
오늘 및 어제의 할 일 리스트 조회 API를 연동하였습니다.
해당 과정 작업 중에 오늘의 할 일 시간 설정으로 인한 API 오류 있었던 부분은 백엔드 팀원 @eraser502 과 소통하여 해결했습니다! 

### 오늘의 할 일 총 / 완료 개수 조회 API 연동 및 그래프 적용
오늘의 할 일의 총개수와 완료개수를 전달받는 API를 활용하여 그래프 데이터에 보여주도록 처리했습니다. 

### 카테고리 조회 API 연동 및 텍스트 변환 기능 개발
category_id 필드로 넘어오는 상황이여서, 카테고리 리스트를 조회하고 텍스트로 변환하는 유틸 함수를 지정하여 처리하였습니다. 

### 어제의 할 일 오늘의 할 일로 변경하는 API 연동
해당 로직은 하루 지났을 때 요청 보내보고 잘 작동하는지 확인해볼 예정입니다! 로직 상에는 문제가 없다고 판단되어 우선 PR 올립니당


++ 응원의 한마디는 임시로 그냥 넣어놨습니다 ㅎㅎ..

<img width="1792" alt="스크린샷 2025-05-09 오전 5 03 04" src="https://github.com/user-attachments/assets/eed6be10-ecc0-4de2-9cbb-3a5c54f906d1" />

## 💬 리뷰 요구사항(선택)
현재 차트 및 리마인더 데이터 관련해서는 백엔드에서 개발이 안된 상황이라, 임시 더미데이터로 처리해놨습니다!
