### PR TITLE
마인드맵 - 브레인스토밍 연결

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -35,4 +35,11 @@ export const ENDPOINTS = {
   CATEGORY: {
     LIST: '/api/v1/eisenhower/category',
   },
+
+  /* GPT API 관련 엔드포인트 */
+  GPT: {
+    BRAINSTORMING: {
+      ANALYZE: '/api/brainstorming/analyze/chunk',
+    },
+  },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -40,6 +40,7 @@ export const ENDPOINTS = {
   GPT: {
     BRAINSTORMING: {
       ANALYZE: '/api/brainstorming/analyze/chunk',
+      REWRITE: '/api/brainstorming/rewrite/chunk',
     },
   },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
     DELETE_BUBBLE: (id: number) => `/api/v2/bubble/${id}`,
     GET_BUBBLES: '/api/v2/bubble',
     CREATE_BUBBLE: '/api/v2/bubble/create',
+    PATCH_BUBBLE: (id: number) => `/api/v2/bubble/${id}`,
   },
 
   /* 인증 관련 엔드포인트 */

--- a/frontend/src/components/mindmap/MindmapSkeleton.tsx
+++ b/frontend/src/components/mindmap/MindmapSkeleton.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function MindmapSkeleton() {
+  return (
+    <div className="w-full h-[calc(100vh-88px)] flex flex-col items-center justify-center p-4 bg-gradient-to-b from-blue-50 to-[#F0F0F5]">
+      <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg p-12 relative overflow-hidden border border-blue-100">
+        <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400"></div>
+        <div className="absolute -top-20 -left-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
+        <div className="absolute -bottom-20 -right-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
+        <div className="absolute top-[15%] left-[8%] z-0 transform rotate-1">
+          <Skeleton className="w-[130px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute top-[28%] right-[12%] z-0 transform -rotate-1">
+          <Skeleton className="w-[180px] h-[40px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute bottom-[28%] left-[15%] z-0 transform rotate-1">
+          <Skeleton className="w-[160px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute bottom-[18%] right-[10%] z-0 transform -rotate-1">
+          <Skeleton className="w-[140px] h-[36px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute top-[55%] left-[25%] z-0 transform rotate-1">
+          <Skeleton className="w-[150px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute top-[45%] right-[28%] z-0 transform -rotate-1">
+          <Skeleton className="w-[120px] h-[34px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+        <div className="absolute top-[75%] right-[25%] z-0 transform rotate-1">
+          <Skeleton className="w-[140px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+        </div>
+
+        <div className="flex flex-col items-center justify-center z-10 relative py-20">
+          <div className="text-xl text-blue-600 font-medium mb-8">
+            마인드맵을 생성하는 중...
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse"></div>
+            <div
+              className="w-3 h-3 bg-blue-400 rounded-full animate-pulse"
+              style={{ animationDelay: '300ms' }}
+            ></div>
+            <div
+              className="w-3 h-3 bg-blue-300 rounded-full animate-pulse"
+              style={{ animationDelay: '600ms' }}
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/queries/brainstorming/usePatchBubble.ts
+++ b/frontend/src/hooks/queries/brainstorming/usePatchBubble.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { brainstormingService } from '@/services/brainstormingService';
+import { PatchBubbleReq } from '@/types/api/brainstorming';
+
+const usePatchBubble = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: PatchBubbleReq }) =>
+      brainstormingService.patchBubble(id, data),
+  });
+
+  return {
+    patchBrainStormingMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default usePatchBubble;

--- a/frontend/src/hooks/queries/gpt/useBrainStormingAnalyze.ts
+++ b/frontend/src/hooks/queries/gpt/useBrainStormingAnalyze.ts
@@ -5,7 +5,7 @@ import { BrainStormingAnalyzeReq } from '@/types/api/gpt';
 const useBrainStormingAnalyze = () => {
   const { mutate, isPending, isError, error, data, reset } = useMutation({
     mutationFn: (data: BrainStormingAnalyzeReq) =>
-      gptService.generateSchedule(data),
+      gptService.analyzeBrainStorming(data),
   });
 
   return {

--- a/frontend/src/hooks/queries/gpt/useBrainStormingAnalyze.ts
+++ b/frontend/src/hooks/queries/gpt/useBrainStormingAnalyze.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { gptService } from '@/services/gptService';
+import { BrainStormingAnalyzeReq } from '@/types/api/gpt';
+
+const useBrainStormingAnalyze = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (data: BrainStormingAnalyzeReq) =>
+      gptService.generateSchedule(data),
+  });
+
+  return {
+    analzeBrainStormingMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useBrainStormingAnalyze;

--- a/frontend/src/hooks/queries/gpt/useBrainStormingRewrite.ts
+++ b/frontend/src/hooks/queries/gpt/useBrainStormingRewrite.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { gptService } from '@/services/gptService';
+import { BrainStormingRewriteReq } from '@/types/api/gpt';
+
+const useBrainStormingRewrite = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (data: BrainStormingRewriteReq) =>
+      gptService.rewriteBrainStorming(data),
+  });
+
+  return {
+    rewriteBrainStormingMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useBrainStormingRewrite;

--- a/frontend/src/pages/brainstorming.tsx
+++ b/frontend/src/pages/brainstorming.tsx
@@ -14,6 +14,7 @@ import useGetBubbles from '@/hooks/queries/brainstorming/useGetBubbles.ts';
 import useDeleteBubble from '@/hooks/queries/brainstorming/useDeleteBubble.ts';
 import useCreateBubble from '@/hooks/queries/brainstorming/useCreateBubble.ts';
 import { Loader2 } from 'lucide-react';
+import { useNavigate } from 'react-router';
 
 export default function Brainstorming() {
   const isMobile = useIsMobile();
@@ -21,11 +22,13 @@ export default function Brainstorming() {
   const scrollRef = useRef(null);
   const { bubbleList } = useGetBubbles();
   const { deleteBrainstormingMutation } = useDeleteBubble();
-  const { createBubbleMutation,isPending } = useCreateBubble();
+  const { createBubbleMutation, isPending } = useCreateBubble();
   const [bubbles, setBubbles] = useState<BubbleNodeType[]>([]);
   const [inputText, setInputText] = useState('');
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
   const bubblesRef = useRef<BubbleNodeType[]>([]);
+
+  const navigate = useNavigate();
 
   // bubbleList가 변경되면 bubbles 상태를 업데이트
   useEffect(() => {
@@ -225,9 +228,14 @@ export default function Brainstorming() {
     });
   };
 
-  const moveToMindmap = () => {};
+  const moveToMindmap = (id: number, title: string) => {
+    const encodedBubbleText = encodeURIComponent(title);
+    navigate(`/mindmap/${id}?text=${encodedBubbleText}`);
+  };
+
   const createMatrix = () => {};
   const saveBubble = () => {};
+
   return (
     <div
       ref={containerRef}
@@ -269,7 +277,9 @@ export default function Brainstorming() {
                     'w-[89px] h-[33px] pl-[9px] rounded-[8px] text-[16px] text-start text-gray-900 hover:bg-gray-200 py-2 cursor-pointer',
                     isMobile ? 'text-[14px]' : 'text-[16px]',
                   )}
-                  onClick={moveToMindmap}
+                  onClick={() => {
+                    moveToMindmap(bubble.id, bubble.title);
+                  }}
                 >
                   마인드맵
                 </button>
@@ -318,7 +328,7 @@ export default function Brainstorming() {
         />
         {isMobile ? (
           <button
-              disabled={isPending}
+            disabled={isPending}
             onClick={addBubble}
             className="rounded-[48px] w-[30px] h-[30px] bg-blue text-white font-semibold text-[16px] font-pretendard flex justify-center items-center cursor-pointer"
           >
@@ -332,14 +342,12 @@ export default function Brainstorming() {
           </button>
         ) : (
           <button
-              disabled={isPending}
+            disabled={isPending}
             onClick={addBubble}
             className="rounded-[48px] p-2 h-[40px] bg-blue text-white font-semibold text-[16px] font-pretendard w-[140px] cursor-pointer items-center justify-center"
           >
             {isPending ? (
-
-                <Loader2 className="animate-spin mx-12" />
-
+              <Loader2 className="animate-spin mx-12" />
             ) : (
               '버블 생성하기'
             )}

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,8 +1,48 @@
 import MindmapWrapper from '@/components/mindmap/MindmapWrapper';
+import useBrainStormingAnalyze from '@/hooks/queries/gpt/useBrainStormingAnalyze';
+import { BrainStormingAnalyzeReq } from '@/types/api/gpt';
+import { useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router';
+import { useMindmapStore } from '@/store/mindMapStore';
+import { MindmapSkeleton } from '@/components/mindmap/MindmapSkeleton';
 
 export default function MindmapPage() {
+  const { id } = useParams();
+  const [searchParams] = useSearchParams();
+  const bubbleText = searchParams.get('text') || '';
+
+  const initializeWithQuestions = useMindmapStore(
+    (state) => state.initializeWithQuestions,
+  );
+
+  const { analzeBrainStormingMutation, isPending } = useBrainStormingAnalyze();
+
+  useEffect(() => {
+    if (bubbleText) {
+      const requestData: BrainStormingAnalyzeReq = {
+        chunk: bubbleText,
+      };
+
+      analzeBrainStormingMutation(requestData, {
+        onSuccess: (data) => {
+          const questions = data.clarifying_questions || [];
+
+          initializeWithQuestions(bubbleText, questions);
+        },
+        onError: (err) => {
+          console.error('API 오류:', err);
+        },
+      });
+    }
+  }, [bubbleText, analzeBrainStormingMutation, initializeWithQuestions]);
+
+  // 로딩 상태 표시
+  if (isPending) {
+    return <MindmapSkeleton />;
+  }
+
   return (
-    <div className="relative w-full h-full">
+    <div className="relative w-full h-[calc(100vh-88px)]">
       <MindmapWrapper />
     </div>
   );

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -2,12 +2,11 @@ import MindmapWrapper from '@/components/mindmap/MindmapWrapper';
 import useBrainStormingAnalyze from '@/hooks/queries/gpt/useBrainStormingAnalyze';
 import { BrainStormingAnalyzeReq } from '@/types/api/gpt';
 import { useEffect } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 import { useMindmapStore } from '@/store/mindMapStore';
 import { MindmapSkeleton } from '@/components/mindmap/MindmapSkeleton';
 
 export default function MindmapPage() {
-  const { id } = useParams();
   const [searchParams] = useSearchParams();
   const bubbleText = searchParams.get('text') || '';
 
@@ -36,7 +35,6 @@ export default function MindmapPage() {
     }
   }, [bubbleText, analzeBrainStormingMutation, initializeWithQuestions]);
 
-  // 로딩 상태 표시
   if (isPending) {
     return <MindmapSkeleton />;
   }

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -14,7 +14,7 @@ export default [
 
   layout('layouts/DefaultLayout.tsx', [
     index('pages/home.tsx'),
-    route('mindmap', 'pages/mindmap.tsx'),
+    route('mindmap/:id', 'pages/mindmap.tsx'),
     route('today', 'pages/today.tsx'),
     route('matrix', 'pages/matrix.tsx'),
     route('pomodoro/:id?', 'pages/pomodoro.tsx'),

--- a/frontend/src/services/brainstormingService.ts
+++ b/frontend/src/services/brainstormingService.ts
@@ -1,6 +1,10 @@
-import { apiClient, gptClient } from '@/api/client';
+import { apiClient } from '@/api/client';
 import { ENDPOINTS } from '@/api/endpoints';
-import { CreateBubbleReq, CreatedBubblesRes } from '@/types/api/brainstorming';
+import {
+  CreateBubbleReq,
+  CreatedBubblesRes,
+  PatchBubbleReq,
+} from '@/types/api/brainstorming';
 
 export const brainstormingService = {
   getBubbles: async (): Promise<CreatedBubblesRes> => {
@@ -20,6 +24,13 @@ export const brainstormingService = {
   deleteBubble: async (id: number): Promise<void> => {
     const response = await apiClient.delete(
       ENDPOINTS.BRAINSTORMING.DELETE_BUBBLE(id),
+    );
+    return response.data;
+  },
+  patchBubble: async (id: number, data: PatchBubbleReq): Promise<void> => {
+    const response = await apiClient.patch(
+      ENDPOINTS.BRAINSTORMING.PATCH_BUBBLE(id),
+      data,
     );
     return response.data;
   },

--- a/frontend/src/services/gptService.ts
+++ b/frontend/src/services/gptService.ts
@@ -1,0 +1,18 @@
+import { gptClient } from '@/api/client';
+import { ENDPOINTS } from '@/api/endpoints';
+import {
+  BrainStormingAnalyzeReq,
+  BrainStormingAnalyzeRes,
+} from '@/types/api/gpt';
+
+export const gptService = {
+  generateSchedule: async (
+    data: BrainStormingAnalyzeReq,
+  ): Promise<BrainStormingAnalyzeRes> => {
+    const response = await gptClient.post<BrainStormingAnalyzeRes>(
+      ENDPOINTS.GPT.BRAINSTORMING.ANALYZE,
+      data,
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/services/gptService.ts
+++ b/frontend/src/services/gptService.ts
@@ -3,14 +3,26 @@ import { ENDPOINTS } from '@/api/endpoints';
 import {
   BrainStormingAnalyzeReq,
   BrainStormingAnalyzeRes,
+  BrainStormingRewriteReq,
+  BrainStormingRewriteRes,
 } from '@/types/api/gpt';
 
 export const gptService = {
-  generateSchedule: async (
+  analyzeBrainStorming: async (
     data: BrainStormingAnalyzeReq,
   ): Promise<BrainStormingAnalyzeRes> => {
     const response = await gptClient.post<BrainStormingAnalyzeRes>(
       ENDPOINTS.GPT.BRAINSTORMING.ANALYZE,
+      data,
+    );
+    return response.data;
+  },
+
+  rewriteBrainStorming: async (
+    data: BrainStormingRewriteReq,
+  ): Promise<BrainStormingRewriteRes> => {
+    const response = await gptClient.post<BrainStormingRewriteRes>(
+      ENDPOINTS.GPT.BRAINSTORMING.REWRITE,
       data,
     );
     return response.data;

--- a/frontend/src/store/mindMapStore.ts
+++ b/frontend/src/store/mindMapStore.ts
@@ -257,7 +257,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
 
   initializeWithQuestions: (rootText: string, questions: string[]) => {
     set((state) => {
-      // 모든 노드와 엣지를 지우고 새로 시작
       const rootNode: Node = {
         id: ROOT_NODE_ID,
         type: 'custom',
@@ -265,29 +264,24 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
           label: rootText,
           layoutDirection: state.direction,
         },
-        position: { x: 0, y: 0 }, // 레이아웃이 나중에 이 위치를 조정
+        position: { x: 0, y: 0 },
         targetPosition: state.direction === 'LR' ? Position.Left : Position.Top,
         sourcePosition:
           state.direction === 'LR' ? Position.Right : Position.Bottom,
         style: nodeStyles,
       };
 
-      // 새로운 노드와 엣지 배열 시작
       const newNodes: Node[] = [rootNode];
       const newEdges: Edge[] = [];
 
-      // nodeHeightMap 초기화 (루트 노드)
       nodeHeightMap.clear();
       nodeHeightMap.set(ROOT_NODE_ID, MIN_NODE_HEIGHT);
 
-      // 각 질문에 대한 자식 노드 생성
       questions.forEach((question, index) => {
         const nodeId = `node-${index + 1}`;
 
-        // 노드 높이 맵에 추가
         nodeHeightMap.set(nodeId, MIN_NODE_HEIGHT);
 
-        // 자식 노드 생성
         const childNode: Node = {
           id: nodeId,
           type: 'custom',
@@ -295,7 +289,7 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
             label: question,
             layoutDirection: state.direction,
           },
-          position: { x: 100, y: 100 * (index + 1) }, // 임시 위치
+          position: { x: 100, y: 100 * (index + 1) },
           targetPosition:
             state.direction === 'LR' ? Position.Left : Position.Top,
           sourcePosition:
@@ -303,7 +297,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
           style: nodeStyles,
         };
 
-        // 루트와 자식 노드 연결 엣지 생성
         const edge: Edge = {
           id: `edge-${ROOT_NODE_ID}-${nodeId}`,
           source: ROOT_NODE_ID,
@@ -317,7 +310,6 @@ export const useMindmapStore = create<MindmapState>((set, get) => ({
         newEdges.push(edge);
       });
 
-      // dagre 레이아웃 적용
       const { nodes, edges } = getLayoutedElements(
         newNodes,
         newEdges,

--- a/frontend/src/types/api/gpt/index.ts
+++ b/frontend/src/types/api/gpt/index.ts
@@ -1,0 +1,2 @@
+export * from './request';
+export * from './response';

--- a/frontend/src/types/api/gpt/request.ts
+++ b/frontend/src/types/api/gpt/request.ts
@@ -1,3 +1,12 @@
 export type BrainStormingAnalyzeReq = {
   chunk: string;
 };
+
+type MindmapDataItem = {
+  context: string;
+};
+
+export type BrainStormingRewriteReq = {
+  existing_chunk: string;
+  mindmap_data: MindmapDataItem[];
+};

--- a/frontend/src/types/api/gpt/request.ts
+++ b/frontend/src/types/api/gpt/request.ts
@@ -1,0 +1,3 @@
+export type BrainStormingAnalyzeReq = {
+  chunk: string;
+};

--- a/frontend/src/types/api/gpt/response.ts
+++ b/frontend/src/types/api/gpt/response.ts
@@ -1,0 +1,3 @@
+export type BrainStormingAnalyzeRes = {
+  clarifying_questions: string[];
+};

--- a/frontend/src/types/api/gpt/response.ts
+++ b/frontend/src/types/api/gpt/response.ts
@@ -1,3 +1,7 @@
 export type BrainStormingAnalyzeRes = {
   clarifying_questions: string[];
 };
+
+export type BrainStormingRewriteRes = {
+  new_chunk: string;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #210 

## 📝 작업 내용
마인드맵과 브레인스토밍을 연결하면서 필요한 API 작업을 연동했습니다.

### 버블 텍스트를 기반으로 마인드맵 추천 노드를 뽑아내서 적용
url parameter 관련으로 관련 데이터를 넘겨주고, 마인드맵 페이지에서 추천 노드를 뽑아내는 API를 호출합니다.

이때 Pending 상태일 때의 UI를 아래와 같이 컴포넌트로 제작했습니다. 
<img width="1457" alt="스크린샷 2025-05-09 오전 7 43 05" src="https://github.com/user-attachments/assets/0f834983-cd3c-4f39-b5a6-5a5440af3981" />

뭔가 더 좋은 사용자 경험을 제공하기 위해, 실제 마인드맵 노드의 형태에 Skeleton UI를 적용하고자 하는 목표가 있습니다...!! 추후에 발전시킬 계획입니다 😄 

API 호출이 완료된 해당 정보를 바탕으로 초기 마인드맵 데이터를 세팅해줍니다. (아래 사진과 같이)
<img width="1324" alt="스크린샷 2025-05-09 오전 7 44 26" src="https://github.com/user-attachments/assets/c8fbc7a3-6aca-4c4b-bd73-d3def3f111c0" />

### 마인드맵 노드 데이터 기반으로 버블 한 줄 요약 뽑아내기
마인드맵 데이터를 가공하여 한 줄 요약을 뽑아내는 API를 호출합니다.
이때 로딩 상태를 완료 버튼에 Loading Spinner를 적용하였습니다. 

요약을 뽑아내면 모달로 요약된 한 줄의 데이터를 보여줍니다. 
<img width="1373" alt="스크린샷 2025-05-09 오전 7 46 04" src="https://github.com/user-attachments/assets/441bc2e5-a52b-41a9-8baa-94aece230835" />

### 요약된 텍스트를 바탕으로 버블 텍스트 수정 적용하기
위 모달 사진에서 적용하기 버튼을 누르면 버블 텍스트를 수정하는 API를 호출합니다. 
위의 예시에서 적용을 누르면 브레인스토밍 페이지로 이동하고 아래와 같이 버블의 텍스트가 업데이트됩니다!
<img width="781" alt="스크린샷 2025-05-09 오전 7 47 14" src="https://github.com/user-attachments/assets/dc7a9614-ccab-4d0a-92d0-6869fdaa37e6" />

## 💬 리뷰 요구사항
내일 급하게 1차적으로 교수님께 시연 + 배포해야하는 사정으로 코드 구조와 사용자 경험 측면에서 좀 더 나은 방향이 있을 것 같은 아쉬움이 있는 상황입니다! 
해당 사항들은 다음주 내로 더 발전시켜 수정하도록 하겠습니다 😄 