### PR TITLE
[BE] feat: 오늘의 할 일 및 분석 구현

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/eisenhower/batch/NotificationJobConfig.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/batch/NotificationJobConfig.java
@@ -22,7 +22,7 @@ public class NotificationJobConfig {
     private final DeleteOldNotificationsTasklet deleteOldNotificationTasklet;
 
     // 알림 생성 및 삭제 Job
-    @Bean
+    @Bean(name = "notificationJob")
     public Job notificationJob() {
         return new JobBuilder("notificationJob", jobRepository)
                 .start(generateNotificationStep())

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
@@ -104,4 +104,12 @@ public class EisenhowerItem {
         this.quadrant = quadrant;
     }
 
+    //오늘의 할 일에서 완료 처리
+    public void setCompletedStatus(boolean isCompleted){
+        if (this.isCompleted == isCompleted) {
+            return;
+        }
+
+        this.isCompleted = isCompleted;
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
@@ -106,10 +106,6 @@ public class EisenhowerItem {
 
     //오늘의 할 일에서 완료 처리
     public void setCompletedStatus(boolean isCompleted){
-        if (this.isCompleted == isCompleted) {
-            return;
-        }
-
         this.isCompleted = isCompleted;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/batch/SaveTodayTaskAnalysisTasklet.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/batch/SaveTodayTaskAnalysisTasklet.java
@@ -1,0 +1,26 @@
+package capstone.backend.domain.todayTask.batch;
+
+import capstone.backend.domain.todayTask.service.TodayTaskAnalysisService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SaveTodayTaskAnalysisTasklet implements Tasklet {
+
+    private final TodayTaskAnalysisService todayTaskAnalysisService;
+
+    @Override
+    public RepeatStatus execute(@NonNull StepContribution contribution, @NonNull ChunkContext chunkContext) {
+        todayTaskAnalysisService.saveTodayTask();
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/batch/TodayTaskAnalysisJobConfig.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/batch/TodayTaskAnalysisJobConfig.java
@@ -1,0 +1,33 @@
+package capstone.backend.domain.todayTask.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class TodayTaskAnalysisJobConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final SaveTodayTaskAnalysisTasklet saveTodayTaskAnalysisTasklet;
+
+    @Bean(name = "todayTaskAnalysisJob")
+    public Job todayTaskAnalysisJob() {
+        return new JobBuilder("todayTaskAnalysisJob", jobRepository)
+            .start(saveTodayTaskAnalysisStep())
+            .build();
+    }
+
+    @Bean
+    public Step saveTodayTaskAnalysisStep() {
+        return new StepBuilder("saveTodayTaskAnalysisStep", jobRepository)
+            .tasklet(saveTodayTaskAnalysisTasklet, transactionManager)
+            .build();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskAnalysisController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskAnalysisController.java
@@ -1,0 +1,31 @@
+package capstone.backend.domain.todayTask.controller;
+
+import capstone.backend.domain.todayTask.dto.response.TodayTaskAnalysisResponse;
+import capstone.backend.domain.todayTask.service.TodayTaskAnalysisService;
+import capstone.backend.global.api.dto.ApiResponse;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "오늘의 할 일 분석", description = "일주일 간 오늘의 할 일 분석 API")
+@RestController
+@RequestMapping("/api/v2/today-task/analysis")
+@RequiredArgsConstructor
+public class TodayTaskAnalysisController {
+    private final TodayTaskAnalysisService todayTaskAnalysisService;
+
+    @Operation(summary = "일주일 간 분석 조회", description = "오늘부터 7일전까지의 오늘의 할 일 분석 결과 조회")
+    @GetMapping
+    public ApiResponse<List<TodayTaskAnalysisResponse>> getWeeklyAnalysis(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        List<TodayTaskAnalysisResponse> analysis = todayTaskAnalysisService.getWeeklyAnalysis(user.getMemberId());
+        return ApiResponse.ok(analysis);
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -1,6 +1,7 @@
 package capstone.backend.domain.todayTask.controller;
 
 import capstone.backend.domain.todayTask.dto.request.TodayTaskItemCreateRequest;
+import capstone.backend.domain.todayTask.dto.request.TodayTaskUpdateRequest;
 import capstone.backend.domain.todayTask.dto.response.TodayTaskItemResponse;
 import capstone.backend.domain.todayTask.service.TodayTaskItemService;
 import capstone.backend.global.api.dto.ApiResponse;
@@ -103,5 +104,16 @@ public class TodayTaskItemController {
     ) {
         TodayTaskItemResponse response = todayTaskItemService.updateTaskDateToYesterday(user.getMemberId(), taskId);
         return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "오늘의 할 일 상태 변경", description = "할 일의 체크 상태 변경")
+    @PatchMapping("/status/{taskId}")
+    public ApiResponse<TodayTaskItemResponse> updateTaskStatus(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @Parameter(name = "taskId", description = "완료할 할 일 ID", example = "1", required = true)
+        @PathVariable Long taskId,
+        @RequestBody @Valid TodayTaskUpdateRequest request
+    ) {
+        return ApiResponse.ok(todayTaskItemService.updateTaskStatus(user.getMemberId(), taskId, request.isCompleted()));
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/controller/TodayTaskItemController.java
@@ -25,13 +25,14 @@ import org.springframework.web.bind.annotation.*;
 public class TodayTaskItemController {
     private final TodayTaskItemService todayTaskItemService;
 
-    @Operation(summary = "오늘의 할 일 추가", description = "여러 개의 아이젠하워 할 일을 오늘의 할 일 목록에 추가")
-    @PostMapping
-    public ApiResponse<List<TodayTaskItemResponse>> addTodayTask(
-        @RequestBody @Valid TodayTaskItemCreateRequest request,
-        @AuthenticationPrincipal CustomOAuth2User user
+    @Operation(summary = "오늘의 할 일 추가", description = "아이젠하워 할 일을 오늘의 할 일 목록에 추가")
+    @PostMapping("/{eisenhowerId}")
+    public ApiResponse<TodayTaskItemResponse> addTodayTask(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @Parameter(name = "eisenhowerId", description="추가할 아이젠하워 ID", example = "1", required = true)
+        @PathVariable Long eisenhowerId
     ) {
-        List<TodayTaskItemResponse> response = todayTaskItemService.addTaskItem(user.getMemberId(), request);
+        TodayTaskItemResponse response = todayTaskItemService.addTaskItem(user.getMemberId(), eisenhowerId);
         return ApiResponse.ok(response);
     }
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskItemCreateRequest.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public record TodayTaskItemCreateRequest(
     @NotEmpty
-    @Schema(description = "오늘의 할 일에 추가할 아이젠하워 ID 목록", example = "[1, 2, 3]")
-    List<Long> eisenhowerItemIds
+    @Schema(description = "오늘의 할 일에 추가할 아이젠하워 ID", example = "1")
+    Long eisenhowerItemId
 ){}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskUpdateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/request/TodayTaskUpdateRequest.java
@@ -1,0 +1,11 @@
+package capstone.backend.domain.todayTask.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record TodayTaskUpdateRequest(
+    @NotNull
+    @Schema(description = "할 일 완료 여부", example = "true")
+    Boolean isCompleted
+) {
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
@@ -8,12 +8,14 @@ import java.util.stream.Collectors;
 public record TodayTaskAnalysisResponse(
     Long id,
     LocalDate taskDate,
+    String dayOfWeek,
     Long completedNum
 ) {
     public static TodayTaskAnalysisResponse from(TodayTaskAnalysis todayTaskAnalysis) {
         return new TodayTaskAnalysisResponse(
             todayTaskAnalysis.getId(),
             todayTaskAnalysis.getDate(),
+            todayTaskAnalysis.getDayOfWeek(),
             todayTaskAnalysis.getCompletedNum()
         );
     }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
@@ -1,0 +1,26 @@
+package capstone.backend.domain.todayTask.dto.response;
+
+import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record TodayTaskAnalysisResponse(
+    Long id,
+    LocalDate taskDate,
+    Long completedNum
+) {
+    public static TodayTaskAnalysisResponse from(TodayTaskAnalysis todayTaskAnalysis) {
+        return new TodayTaskAnalysisResponse(
+            todayTaskAnalysis.getId(),
+            todayTaskAnalysis.getDate(),
+            todayTaskAnalysis.getCompletedNum()
+        );
+    }
+
+    public static List<TodayTaskAnalysisResponse> fromList(List<TodayTaskAnalysis> todayTaskAnalysisList){
+        return todayTaskAnalysisList.stream()
+            .map(TodayTaskAnalysisResponse::from)
+            .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/dto/response/TodayTaskAnalysisResponse.java
@@ -1,5 +1,6 @@
 package capstone.backend.domain.todayTask.dto.response;
 
+import capstone.backend.domain.todayTask.entity.DayOfWeekEnum;
 import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
 import java.time.LocalDate;
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.stream.Collectors;
 public record TodayTaskAnalysisResponse(
     Long id,
     LocalDate taskDate,
-    String dayOfWeek,
+    DayOfWeekEnum dayOfWeek,
     Long completedNum
 ) {
     public static TodayTaskAnalysisResponse from(TodayTaskAnalysis todayTaskAnalysis) {

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/DayOfWeekEnum.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/DayOfWeekEnum.java
@@ -1,0 +1,25 @@
+package capstone.backend.domain.todayTask.entity;
+
+import java.time.DayOfWeek;
+
+public enum DayOfWeekEnum {
+    MON,
+    SUN,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT;
+
+    public static DayOfWeekEnum from(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> MON;
+            case TUESDAY -> TUE;
+            case WEDNESDAY -> WED;
+            case THURSDAY -> THU;
+            case FRIDAY -> FRI;
+            case SATURDAY -> SAT;
+            case SUNDAY -> SUN;
+        };
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
@@ -1,0 +1,36 @@
+package capstone.backend.domain.todayTask.entity;
+
+import capstone.backend.domain.member.scheme.Member;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TodayTaskAnalysis {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "daily_today_task_summary_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private long completedNum;
+
+    public static TodayTaskAnalysis from(Member member, LocalDate date, long completedNum) {
+        return TodayTaskAnalysis.builder()
+            .member(member)
+            .date(date)
+            .completedNum(completedNum)
+            .build();
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
@@ -13,7 +13,7 @@ import lombok.*;
 public class TodayTaskAnalysis {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "daily_today_task_summary_id")
+    @Column(name = "today_task_analysis_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -23,8 +23,9 @@ public class TodayTaskAnalysis {
     @Column(nullable = false)
     private LocalDate date;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String dayOfWeek;
+    private DayOfWeekEnum dayOfWeek;
 
     @Column(nullable = false)
     private long completedNum;
@@ -33,7 +34,7 @@ public class TodayTaskAnalysis {
         return TodayTaskAnalysis.builder()
             .member(member)
             .date(date)
-            .dayOfWeek(date.getDayOfWeek().toString())
+            .dayOfWeek(DayOfWeekEnum.from(date.getDayOfWeek()))
             .completedNum(completedNum)
             .build();
     }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskAnalysis.java
@@ -24,12 +24,16 @@ public class TodayTaskAnalysis {
     private LocalDate date;
 
     @Column(nullable = false)
+    private String dayOfWeek;
+
+    @Column(nullable = false)
     private long completedNum;
 
     public static TodayTaskAnalysis from(Member member, LocalDate date, long completedNum) {
         return TodayTaskAnalysis.builder()
             .member(member)
             .date(date)
+            .dayOfWeek(date.getDayOfWeek().toString())
             .completedNum(completedNum)
             .build();
     }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/entity/TodayTaskItem.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,6 +20,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+    name = "today_task_item",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "eisenhower_item_id", "task_date"})}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/backend/src/main/java/capstone/backend/domain/todayTask/exception/DuplicateTaskException.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/exception/DuplicateTaskException.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.todayTask.exception;
+
+import capstone.backend.global.api.exception.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateTaskException extends ApiException {
+    public DuplicateTaskException() {
+        super(HttpStatus.CONFLICT, "이미 오늘의 할 일에 등록된 아이젠하워입니다.");
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskAnalysisRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskAnalysisRepository.java
@@ -1,0 +1,10 @@
+package capstone.backend.domain.todayTask.repository;
+
+import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodayTaskAnalysisRepository extends JpaRepository<TodayTaskAnalysis, Long> {
+    List<TodayTaskAnalysis> findByMemberIdAndDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskAnalysisRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskAnalysisRepository.java
@@ -3,8 +3,10 @@ package capstone.backend.domain.todayTask.repository;
 import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TodayTaskAnalysisRepository extends JpaRepository<TodayTaskAnalysis, Long> {
     List<TodayTaskAnalysis> findByMemberIdAndDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+    Optional<TodayTaskAnalysis> findByMemberIdAndDate(Long memberId, LocalDate date);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -2,10 +2,13 @@ package capstone.backend.domain.todayTask.repository;
 
 import capstone.backend.domain.todayTask.entity.TodayTaskItem;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Long> {
     Page<TodayTaskItem> findByMemberIdAndTaskDate(Long memberId, LocalDate taskDate, Pageable pageable);
@@ -13,4 +16,7 @@ public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Lo
     Long countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
     Page<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted, Pageable pageable);
+
+    @Query("SELECT DISTINCT t.member.id FROM TodayTaskItem t WHERE t.taskDate = :date")
+    List<Long> findDistinctMemberIdsByTaskDate(@Param("date") LocalDate date);
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/repository/TodayTaskItemRepository.java
@@ -16,6 +16,7 @@ public interface TodayTaskItemRepository extends JpaRepository<TodayTaskItem, Lo
     Long countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted);
     Optional<TodayTaskItem> findByIdAndMemberId(Long id, Long memberId);
     Page<TodayTaskItem> findByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(Long memberId, LocalDate taskDate, boolean isCompleted, Pageable pageable);
+    boolean existsByMemberIdAndEisenhowerItemIdAndTaskDate(Long memberId, Long eisenhowerItemId, LocalDate taskDate);
 
     @Query("SELECT DISTINCT t.member.id FROM TodayTaskItem t WHERE t.taskDate = :date")
     List<Long> findDistinctMemberIdsByTaskDate(@Param("date") LocalDate date);

--- a/backend/src/main/java/capstone/backend/domain/todayTask/scheduler/TodayTaskAnalysisScheduler.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/scheduler/TodayTaskAnalysisScheduler.java
@@ -1,0 +1,26 @@
+package capstone.backend.domain.todayTask.scheduler;
+
+import capstone.backend.domain.todayTask.service.TodayTaskAnalysisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TodayTaskAnalysisScheduler {
+
+    private TodayTaskAnalysisService todayTaskAnalysisService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void saveTodayTaskAnalysis() throws Exception {
+        log.info("Starting daily task analysis at midnight");
+        try {
+            todayTaskAnalysisService.saveTodayTask();
+            log.info("Successfully completed daily task analysis");
+        } catch (Exception e) {
+            log.error("Error during daily task analysis: ", e);
+        }
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
@@ -46,6 +46,7 @@ public class TodayTaskAnalysisService {
                 .orElse(TodayTaskAnalysis.builder()
                     .member(member)
                     .date(yesterday)
+                    .dayOfWeek(yesterday.getDayOfWeek().toString())
                     .completedNum(completedNum)
                     .build());
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
@@ -1,25 +1,55 @@
 package capstone.backend.domain.todayTask.service;
 
+import capstone.backend.domain.member.exception.MemberNotFoundException;
+import capstone.backend.domain.member.repository.MemberRepository;
+import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.todayTask.dto.response.TodayTaskAnalysisResponse;
 import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
 import capstone.backend.domain.todayTask.repository.TodayTaskAnalysisRepository;
+import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TodayTaskAnalysisService {
 
+    private final MemberRepository memberRepository;
     private final TodayTaskAnalysisRepository todayTaskAnalysisRepository;
+    private final TodayTaskItemRepository todayTaskItemRepository;
 
     public List<TodayTaskAnalysisResponse> getWeeklyAnalysis(Long memberId) {
         LocalDate endDate = LocalDate.now().minusDays(1);
         LocalDate startDate = endDate.minusDays(6);
         List<TodayTaskAnalysis> analysisList = todayTaskAnalysisRepository.findByMemberIdAndDateBetween(memberId, startDate, endDate);
         return TodayTaskAnalysisResponse.fromList(analysisList);
+    }
+
+    @Transactional
+    public void saveTodayTask() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        // 어제 할 일을 추가한 멤버 ID 목록 조회
+        List<Long> memberIds = todayTaskItemRepository.findDistinctMemberIdsByTaskDate(yesterday);
+
+        for (Long memberId : memberIds) {
+            Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+            long completedNum = todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, yesterday, true);
+
+            TodayTaskAnalysis analysis = todayTaskAnalysisRepository.findByMemberIdAndDate(memberId, yesterday)
+                .orElse(TodayTaskAnalysis.builder()
+                    .member(member)
+                    .date(yesterday)
+                    .completedNum(completedNum)
+                    .build());
+
+            todayTaskAnalysisRepository.save(analysis);
+        }
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
@@ -1,0 +1,25 @@
+package capstone.backend.domain.todayTask.service;
+
+import capstone.backend.domain.todayTask.dto.response.TodayTaskAnalysisResponse;
+import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
+import capstone.backend.domain.todayTask.repository.TodayTaskAnalysisRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodayTaskAnalysisService {
+
+    private final TodayTaskAnalysisRepository todayTaskAnalysisRepository;
+
+    public List<TodayTaskAnalysisResponse> getWeeklyAnalysis(Long memberId) {
+        LocalDate endDate = LocalDate.now().minusDays(1);
+        LocalDate startDate = endDate.minusDays(6);
+        List<TodayTaskAnalysis> analysisList = todayTaskAnalysisRepository.findByMemberIdAndDateBetween(memberId, startDate, endDate);
+        return TodayTaskAnalysisResponse.fromList(analysisList);
+    }
+}

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskAnalysisService.java
@@ -4,6 +4,7 @@ import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.todayTask.dto.response.TodayTaskAnalysisResponse;
+import capstone.backend.domain.todayTask.entity.DayOfWeekEnum;
 import capstone.backend.domain.todayTask.entity.TodayTaskAnalysis;
 import capstone.backend.domain.todayTask.repository.TodayTaskAnalysisRepository;
 import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
@@ -41,12 +42,13 @@ public class TodayTaskAnalysisService {
         for (Long memberId : memberIds) {
             Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
             long completedNum = todayTaskItemRepository.countByMemberIdAndTaskDateAndEisenhowerItemIsCompleted(memberId, yesterday, true);
+            DayOfWeekEnum dayOfWeekEnum = DayOfWeekEnum.from(yesterday.getDayOfWeek());
 
             TodayTaskAnalysis analysis = todayTaskAnalysisRepository.findByMemberIdAndDate(memberId, yesterday)
                 .orElse(TodayTaskAnalysis.builder()
                     .member(member)
                     .date(yesterday)
-                    .dayOfWeek(yesterday.getDayOfWeek().toString())
+                    .dayOfWeek(dayOfWeekEnum)
                     .completedNum(completedNum)
                     .build());
 

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -31,28 +31,24 @@ public class TodayTaskItemService {
 
     //오늘의 할 일 추가
     @Transactional
-    public List<TodayTaskItemResponse> addTaskItem(Long memberId, TodayTaskItemCreateRequest request) {
+    public TodayTaskItemResponse addTaskItem(Long memberId, Long eisenhowerId) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        return request.eisenhowerItemIds().stream()
-            .map(itemId -> {
-                // 중복 여부 확인
-                boolean exists = todayTaskItemRepository.existsByMemberIdAndEisenhowerItemIdAndTaskDate(
-                    memberId, itemId, LocalDate.now());
+        // 중복 여부 확인
+        boolean exists = todayTaskItemRepository.existsByMemberIdAndEisenhowerItemIdAndTaskDate(
+            memberId, eisenhowerId, LocalDate.now());
 
-                if (exists) {
-                    throw (new DuplicateTaskException());
-                }
+        if (exists) {
+            throw (new DuplicateTaskException());
+        }
 
-                EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findByIdAndMemberId(itemId, memberId)
-                    .orElseThrow(EisenhowerItemNotFoundException::new);
+        EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findByIdAndMemberId(eisenhowerId, memberId)
+            .orElseThrow(EisenhowerItemNotFoundException::new);
 
-                TodayTaskItem todayTaskItem = TodayTaskItem.from(member, eisenhowerItem);
-                todayTaskItemRepository.save(todayTaskItem);
+        TodayTaskItem todayTaskItem = TodayTaskItem.from(member, eisenhowerItem);
+        todayTaskItemRepository.save(todayTaskItem);
 
-                return TodayTaskItemResponse.from(todayTaskItem);
-            })
-            .toList();
+        return TodayTaskItemResponse.from(todayTaskItem);
     }
 
     //오늘의 할 일 조회

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -102,6 +102,18 @@ public class TodayTaskItemService {
         return TodayTaskItemResponse.from(todayTaskItem);
     }
 
+    //할 일 완료 처리
+    @Transactional
+    public TodayTaskItemResponse updateTaskStatus(Long memberId, Long taskId, Boolean isCompleted) {
+        TodayTaskItem todayTaskItem = todayTaskItemRepository.findByIdAndMemberId(taskId, memberId)
+            .orElseThrow(TodayTaskNotFoundException::new);
+
+        todayTaskItem.getEisenhowerItem().setCompletedStatus(isCompleted);
+        todayTaskItemRepository.save(todayTaskItem);
+        
+        return TodayTaskItemResponse.from(todayTaskItem);
+    }
+
     //00시 기준 날짜 가져오기
     private LocalDate getDate() {
 //        LocalDateTime now = LocalDateTime.now();

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -110,15 +110,12 @@ public class TodayTaskItemService {
 
         todayTaskItem.getEisenhowerItem().setCompletedStatus(isCompleted);
         todayTaskItemRepository.save(todayTaskItem);
-        
+
         return TodayTaskItemResponse.from(todayTaskItem);
     }
 
     //00시 기준 날짜 가져오기
     private LocalDate getDate() {
-//        LocalDateTime now = LocalDateTime.now();
-//        LocalDateTime sixAM = now.with(LocalTime.of(6, 0));
-//        return now.isBefore(sixAM) ? LocalDate.now().minusDays(1) : LocalDate.now();
         return LocalDate.now();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/todayTask/service/TodayTaskItemService.java
@@ -10,6 +10,7 @@ import capstone.backend.domain.todayTask.dto.request.TodayTaskItemCreateRequest;
 import capstone.backend.domain.todayTask.dto.response.TodayTaskItemResponse;
 import capstone.backend.domain.todayTask.entity.TodayTaskItem;
 import capstone.backend.domain.todayTask.exception.TodayTaskNotFoundException;
+import capstone.backend.domain.todayTask.exception.DuplicateTaskException;
 import capstone.backend.domain.todayTask.repository.TodayTaskItemRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -35,6 +36,14 @@ public class TodayTaskItemService {
 
         return request.eisenhowerItemIds().stream()
             .map(itemId -> {
+                // 중복 여부 확인
+                boolean exists = todayTaskItemRepository.existsByMemberIdAndEisenhowerItemIdAndTaskDate(
+                    memberId, itemId, LocalDate.now());
+
+                if (exists) {
+                    throw (new DuplicateTaskException());
+                }
+
                 EisenhowerItem eisenhowerItem = eisenhowerItemRepository.findByIdAndMemberId(itemId, memberId)
                     .orElseThrow(EisenhowerItemNotFoundException::new);
 

--- a/backend/src/main/java/capstone/backend/global/batch/runner/MultiJobLauncher.java
+++ b/backend/src/main/java/capstone/backend/global/batch/runner/MultiJobLauncher.java
@@ -1,0 +1,30 @@
+package capstone.backend.global.batch.runner;
+
+import capstone.backend.global.batch.service.MultiJobExecutionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MultiJobLauncher implements ApplicationRunner {
+
+    private final MultiJobExecutionService multiJobExecutionService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("MultiJobLauncher started");
+
+        String[] jobNames = {"notificationJob", "todayTaskAnalysisJob"};
+
+        for (String jobName : jobNames) {
+            log.info("Running job {}", jobName);
+            multiJobExecutionService.execute(jobName);
+        }
+
+        log.info("MultiJobLauncher finished");
+    }
+}

--- a/backend/src/main/java/capstone/backend/global/batch/service/MultiJobExecutionService.java
+++ b/backend/src/main/java/capstone/backend/global/batch/service/MultiJobExecutionService.java
@@ -1,0 +1,39 @@
+package capstone.backend.global.batch.service;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MultiJobExecutionService {
+    private final JobLauncher jobLauncher;
+    private final Map<String, Job> jobMap;
+
+    public void execute(String jobName){
+        try{
+            Job job = jobMap.get(jobName);
+            if(job == null){
+                log.warn("Job {} not found", jobName);
+                return;
+            }
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+            JobExecution jobExecution = jobLauncher.run(job, jobParameters);
+            log.info("Job {} started with status: {}", jobName, jobExecution.getStatus());
+
+        } catch (Exception e){
+            log.error("Job {} failed", jobName, e);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #216 

## 📝 작업 내용

오늘의 할 일
- 오늘의 할 일 페이지에서 체크버튼 누를 경우 상태 변경 구현
- 자정 기준으로 날짜 조회 변경, 예전 코드 삭제
- 할 일 추가 시 기존 리스트로 여러개 추가에서 한개씩 추가로 변경
- 같은 날짜에 동일 사용자가 같은 아이젠하워 아이템을 추가할 수 없도록 제약 조건 설정

오늘의 할 일 분석 
  - 오늘 기준으로 어제부터 7일간 데이터 가져오도록 조회 API 구현
  - 자정에 분석 데이터 저장 스케줄러 구현
 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 오늘의 할 일 분석에서 자정에 데이터 분석 저장 시 배치 처리
