### PR TITLE
로그아웃 관련 로직 수정

### DIFF
--- a/frontend/src/components/ui/header/Header.tsx
+++ b/frontend/src/components/ui/header/Header.tsx
@@ -4,15 +4,17 @@ import { useNavigate } from 'react-router';
 import TmpLogo from '@/assets/tmp-logo.svg';
 import { usePomodoroStore } from '@/store/pomodoro';
 import usePomodoroControl from '@/hooks/usePomodoroControl';
+import { authService } from '@/services/authService.ts';
 
 export default function Header() {
-  const { isAuthenticated, setToken } = useAuthStore();
+  const { isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
   usePomodoroControl();
 
   const handleAuthAction = () => {
     if (isAuthenticated) {
-      setToken(null);
+      // setToken(null);
+      authService.logout();
     } else {
       navigate('/login');
     }
@@ -36,7 +38,7 @@ export default function Header() {
         <div></div>
         {currentId && (
           <div className="text-[#7098FF] font-medium bg-blue-2 border rounded-4xl border-blue px-4 py-[6px] text-[20px] h-9 w-[87px] flex justify-center items-center">
-             {format(remaining)}
+            {format(remaining)}
           </div>
         )}
 

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -4,9 +4,10 @@ import Header from '@/components/ui/header/Header';
 import BottomBar from '@/components/ui/sidebar/BottomBar';
 import clsx from 'clsx';
 import { useIsMobile } from '@/hooks/use-mobile.ts';
+import { useAuthRedirect } from '@/hooks/useAuthRedirect.ts';
 
 export default function DefaultLayout() {
-
+  useAuthRedirect();
   const isMobile = useIsMobile();
   return (
     <div className="min-h-screen bg-[#F0F0F5] flex flex-col">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #202

## 📝 작업 내용

- 토큰이 사라지면 login 으로 이동하도록 `useAuthRedirect` 를 사용하였습니다.
- 로그아웃 버튼 클릭 시 `authService` 의 logout 을 사용하도록 수정하였고 이후 login 페이지로 이동하도록 했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- refreshToken 로직의 경우, 건 님과 조금 더 테스트 해보는 게 좋을 것 같아 추후 더 반영하도록 하겠습니다.
