### PR TITLE
[BE] fix: 뽀모도로 완료 기록 로직 수정

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/pomodoro/dto/request/RecordPomodoroRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/dto/request/RecordPomodoroRequest.java
@@ -2,11 +2,13 @@ package capstone.backend.domain.pomodoro.dto.request;
 
 import capstone.backend.domain.pomodoro.schema.PomodoroCycle;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record RecordPomodoroRequest(
+        @Valid
         @NotEmpty(message = "실제 실행 기록을 입력해주세요.")
         @Schema(description = "실제 실행 기간 별 초 단위 기록")
         List<PomodoroCycle> executedCycles

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/schema/PomodoroCycle.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/schema/PomodoroCycle.java
@@ -1,6 +1,7 @@
 package capstone.backend.domain.pomodoro.schema;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,9 +12,11 @@ import lombok.Setter;
 public class PomodoroCycle {
     @NotNull(message = "작업 시간(workDuration)은 필수입니다.")
     @Min(value = 0, message = "작업 시간(workDuration)은 0 이상이어야 합니다.")
+    @Schema(description = "작업 시간 (초 단위)", example = "1500")
     private Integer workDuration; // 초단위
 
     @NotNull(message = "휴식 시간(breakDuration)은 필수입니다.")
     @Min(value = 0, message = "휴식 시간(breakDuration)은 0 이상이어야 합니다.")
+    @Schema(description = "휴식 시간 (초 단위)", example = "300")
     private Integer breakDuration; // 초단위
 }

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/schema/PomodoroCycle.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/schema/PomodoroCycle.java
@@ -1,12 +1,19 @@
 package capstone.backend.domain.pomodoro.schema;
 
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class PomodoroCycle {
+    @NotNull(message = "작업 시간(workDuration)은 필수입니다.")
+    @Min(value = 0, message = "작업 시간(workDuration)은 0 이상이어야 합니다.")
     private Integer workDuration; // 초단위
+
+    @NotNull(message = "휴식 시간(breakDuration)은 필수입니다.")
+    @Min(value = 0, message = "휴식 시간(breakDuration)은 0 이상이어야 합니다.")
     private Integer breakDuration; // 초단위
 }

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
@@ -107,7 +107,7 @@ public class PomodoroService {
         int totalExecutedSeconds = times[2];
         // TODO 에러로 낼 지, 아니면 0보다 클 때만 기록을 저장하게 조건 제어로 할지 논의 필요
         // 0이면 기록을 저장하지 않고 에러 발생
-        if (totalExecutedSeconds <= 0) {
+        if (totalExecutedSeconds <= 59) {
             throw new PomodoroDurationException();
         }
 

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
@@ -11,6 +11,7 @@ import capstone.backend.domain.pomodoro.dto.request.CreatePomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.request.RecordPomodoroRequest;
 import capstone.backend.domain.pomodoro.dto.response.PomodoroDTO;
 import capstone.backend.domain.pomodoro.dto.response.SidebarResponse;
+import capstone.backend.domain.pomodoro.exception.PomodoroDurationException;
 import capstone.backend.domain.pomodoro.exception.PomodoroNotFoundException;
 import capstone.backend.domain.pomodoro.repository.PomodoroRepository;
 import capstone.backend.domain.pomodoro.schema.Pomodoro;
@@ -103,7 +104,14 @@ public class PomodoroService {
         // 최적화된 시간 계산
         int[] times = calculateTotalTimeSummary(executedCycles);
 
+        int totalExecutedSeconds = times[2];
+        // TODO 에러로 낼 지, 아니면 0보다 클 때만 기록을 저장하게 조건 제어로 할지 논의 필요
+        // 0이면 기록을 저장하지 않고 에러 발생
+        if (totalExecutedSeconds <= 0) {
+            throw new PomodoroDurationException();
+        }
+
         // 일일 뽀모도로 총 시간 업데이트
-        dailyPomodoroSummaryService.updateDailyPomodoroSummary(memberId, times[2]);
+        dailyPomodoroSummaryService.updateDailyPomodoroSummary(memberId, totalExecutedSeconds);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/util/PomodoroTimeUtils.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/util/PomodoroTimeUtils.java
@@ -17,10 +17,11 @@ public class PomodoroTimeUtils {
         int totalBreakSeconds = 0;
 
         for (PomodoroCycle cycle : cycles) {
-            totalWorkingSeconds += Optional.ofNullable(cycle.getWorkDuration()).orElse(0) * 60;
-            totalBreakSeconds += Optional.ofNullable(cycle.getBreakDuration()).orElse(0) * 60;
+            totalWorkingSeconds += Optional.ofNullable(cycle.getWorkDuration()).orElse(0);
+            totalBreakSeconds += Optional.ofNullable(cycle.getBreakDuration()).orElse(0);
         }
 
+        // 전부 초단위로 변경
         return new int[]{
                 totalWorkingSeconds,
                 totalBreakSeconds,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #235 

## 📝 작업 내용
FE의 요청사항에 따라, 뽀모도로 기록 완료 시 분 단위 처리 로직에서 초 단위 처리 로직으로 변경.

(DB 상에서는 nano second로 저장되기 때문에 65초 = 65,000,000,000로 저장됩니다!)

### 스크린샷 (선택)
- 실행 1분, 휴식 5초 2번 진행 시 
<img width="587" alt="image" src="https://github.com/user-attachments/assets/1bb2fd15-322e-4b95-8178-d9b26c99539f" />
<img width="638" alt="image" src="https://github.com/user-attachments/assets/afa529f4-dfe1-459d-8026-a4e8ac8a5cd5" />


## 💬 리뷰 요구사항(선택)

현재 1분 미만의 초단위 데이터는 기록하지 않도록 요구사항을 만족하고자 합니다.
이에 따라, **59초 이하 기록이 들어올 때 에러를 낼지, 아니면 if문을 활용하여 60초 이상인 경우에만 DB에 save할 지** 논의해봐야 할 것 같습니다!
