### PR TITLE
[FE]: 브레인스토밍 <-> 보관함 <-> 오늘의 할 일 관련 작업 처리

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slider": "^1.2.3",
         "@radix-ui/react-slot": "^1.2.0",
+        "@radix-ui/react-switch": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@react-router/fs-routes": "^7.2.0",
@@ -4292,6 +4293,110 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.4.tgz",
+      "integrity": "sha512-yZCky6XZFnR7pcGonJkr9VyNRu46KcYAbyg1v/gVVCZUr8UJ4x+RpncC27hHtiZ15jC+3WS8Yg/JSgyIHnYYsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.2.tgz",
+      "integrity": "sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.4.tgz",
@@ -4378,6 +4483,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slider": "^1.2.3",
     "@radix-ui/react-slot": "^1.2.0",
+    "@radix-ui/react-switch": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@react-router/fs-routes": "^7.2.0",

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -81,6 +81,7 @@ export const ENDPOINTS = {
       MOVE_FOLDER: (id: number) => `/api/v2/inventory/move/${id}`,
       DELETE: (id: number) => `/api/v2/inventory/item/${id}`,
       RECENT: '/api/v2/inventory/recent',
+      CREATE_ITEM: '/api/v2/inventory',
     },
   },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -49,6 +49,7 @@ export const ENDPOINTS = {
     COMPLETE_COUNT: '/api/v2/today-task/completed',
     MOVE_TODAY: (id: number) => `/api/v2/today-task/move-today/${id}`,
     UPDATE_STATUS: (id: number) => `/api/v2/today-task/status/${id}`,
+    DELETE: (id: number) => `/api/v2/today-task/${id}`,
   },
   POMODORO: {
     PATCH_POMODORO: '/api/v2/pomodoro',

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -74,6 +74,7 @@ export const ENDPOINTS = {
       CREATE: '/api/v2/inventory/folder',
       DELETE: (id: number) => `/api/v2/inventory/folder/${id}`,
       DETAIL: (id: number) => `/api/v2/inventory/folder/${id}`,
+      UPDATE_NAME: (id: number) => `/api/v2/inventory/folder/${id}`,
     },
     ITEM: {
       LIST: (id: number) => `/api/v2/inventory/${id}`,

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -78,6 +78,7 @@ export const ENDPOINTS = {
       UPDATE_ITEM: (id: number) => `/api/v2/inventory/item/${id}`,
       MOVE_FOLDER: (id: number) => `/api/v2/inventory/move/${id}`,
       DELETE: (id: number) => `/api/v2/inventory/item/${id}`,
+      RECENT: '/api/v2/inventory/recent',
     },
   },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -85,4 +85,9 @@ export const ENDPOINTS = {
       CREATE_ITEM: '/api/v2/inventory',
     },
   },
+
+  /* 분석 관련 API */
+  ANALYSIS: {
+    TODAY_TASK: '/api/v2/today-task/analysis',
+  },
 };

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -48,6 +48,7 @@ export const ENDPOINTS = {
     GET_COUNT: '/api/v2/today-task/count',
     COMPLETE_COUNT: '/api/v2/today-task/completed',
     MOVE_TODAY: (id: number) => `/api/v2/today-task/move-today/${id}`,
+    UPDATE_STATUS: (id: number) => `/api/v2/today-task/status/${id}`,
   },
   POMODORO: {
     PATCH_POMODORO: '/api/v2/pomodoro',

--- a/frontend/src/components/inventory/InventoryItemCard.tsx
+++ b/frontend/src/components/inventory/InventoryItemCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trash2, Loader2, FolderInput } from 'lucide-react';
 import {
   Collapsible,
@@ -28,6 +28,7 @@ type InventoryItemCardProps = {
     createdAt: string;
     folderId: number;
   };
+  initiallyOpen?: boolean;
 };
 
 const formatDate = (dateString: string) => {
@@ -47,8 +48,11 @@ const formatDate = (dateString: string) => {
   return `${year}.${month}.${day} (${weekDay})`;
 };
 
-export default function InventoryItemCard({ item }: InventoryItemCardProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function InventoryItemCard({
+  item,
+  initiallyOpen = false,
+}: InventoryItemCardProps) {
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
   const [title, setTitle] = useState(item.title);
   const [memo, setMemo] = useState(item.memo || '');
 
@@ -60,6 +64,10 @@ export default function InventoryItemCard({ item }: InventoryItemCardProps) {
 
   const { deleteInventoryItemMutation, isPending: isDeleting } =
     useDeleteInventoryItem(item.folderId);
+
+  useEffect(() => {
+    setIsOpen(initiallyOpen);
+  }, [initiallyOpen]);
 
   const handleSave = () => {
     const updateData: UpdateInventoryItemReq = {

--- a/frontend/src/components/today/ReminderList.tsx
+++ b/frontend/src/components/today/ReminderList.tsx
@@ -1,0 +1,39 @@
+import useGetRecentInventory from '@/hooks/queries/inventory/item/useGetRecentInventory';
+import { useNavigate } from 'react-router';
+
+export default function ReminderList() {
+  const { inventoryRecentList } = useGetRecentInventory();
+  const navigate = useNavigate();
+
+  const handleClickReminder = (folderId: number, itemId: number) => {
+    navigate(`/inventory/${folderId}?itemId=${itemId}`);
+  };
+
+  return (
+    <div className="w-full mt-6 mb-4">
+      <div className="flex items-center gap-2 mb-2">
+        <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
+        <p className="text-blue text-[14px] cursor-pointer">더보기 {'>'} </p>
+      </div>
+
+      <div className="w-full overflow-x-auto pb-4">
+        <div className="flex gap-4" style={{ width: 'max-content' }}>
+          {inventoryRecentList &&
+            inventoryRecentList.map((remind) => (
+              <div
+                key={remind.id}
+                className="bg-white rounded-lg px-6 py-4 cursor-pointer flex-none"
+                style={{ width: '16rem' }}
+                onClick={() => handleClickReminder(remind.folderId, remind.id)}
+              >
+                <h3 className="text-[20px] text-[#525463] font-semibold">
+                  {remind.title}
+                </h3>
+                <p className="text-gray-500">{remind.memo}</p>
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/today/ReminderList.tsx
+++ b/frontend/src/components/today/ReminderList.tsx
@@ -5,6 +5,10 @@ export default function ReminderList() {
   const { inventoryRecentList } = useGetRecentInventory();
   const navigate = useNavigate();
 
+  const handleRouteToInventory = () => {
+    navigate('/inventory');
+  };
+
   const handleClickReminder = (folderId: number, itemId: number) => {
     navigate(`/inventory/${folderId}?itemId=${itemId}`);
   };
@@ -13,7 +17,12 @@ export default function ReminderList() {
     <div className="w-full mt-6 mb-4">
       <div className="flex items-center gap-2 mb-2">
         <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
-        <p className="text-blue text-[14px] cursor-pointer">더보기 {'>'} </p>
+        <p
+          className="text-blue text-[14px] cursor-pointer"
+          onClick={handleRouteToInventory}
+        >
+          더보기 {'>'}{' '}
+        </p>
       </div>
 
       <div className="w-full overflow-x-auto pb-4">

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -3,11 +3,12 @@ import useGetTodayTodoList from '@/hooks/queries/today/useGetTodayTodoList';
 import useGetYesterdayTodoList from '@/hooks/queries/today/useGetYesterdayTodoList';
 import useMoveToday from '@/hooks/queries/today/useMoveToday';
 import { cn } from '@/lib/utils';
-import { Calendar, Check } from 'lucide-react';
+import { Calendar, Check, Trash2 } from 'lucide-react';
 import { usePomodoroStore } from '@/store/pomodoro';
 import usePatchPomodoro from '@/hooks/queries/pomodoro/usePatchPomodoro.ts';
 import { toast } from 'sonner';
 import useUpdateStatusTodo from '@/hooks/queries/today/useUpdateStatusTodo';
+import useDeleteTodayTodo from '@/hooks/queries/today/useDeleteTodayTodo';
 
 interface TodayListProps {
   hideCompleted?: boolean;
@@ -39,6 +40,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
   const { moveTodayMutation, isPending } = useMoveToday();
   const { patchPomodoroMutation } = usePatchPomodoro();
   const { updateStatusMutation } = useUpdateStatusTodo();
+  const { deleteTodayTodoMutation } = useDeleteTodayTodo();
 
   const handleMoveToToday = (id: number) => {
     moveTodayMutation(id);
@@ -73,6 +75,14 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
         },
       },
     );
+  };
+
+  const handleDeleteTask = (id: number, title: string) => {
+    deleteTodayTodoMutation(id, {
+      onSuccess: () => {
+        toast.success(`"${title}"을 오늘의 할 일에서 삭제했습니다.`);
+      },
+    });
   };
 
   const filteredTodayTodoList = todayTodoList
@@ -144,24 +154,32 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
             <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
               {getCategoryNameById(todo.category_id)}
             </div>
-            <div
-              className={cn(
-                'w-6 h-6 rounded-full flex items-center justify-center p-1',
-                todo.isCompleted
-                  ? 'bg-blue'
-                  : 'bg-transparent border-2 border-blue',
-              )}
-            >
-              <Check
-                className={cn(
-                  'cursor-pointer',
-                  todo.isCompleted ? 'text-white' : 'text-blue',
-                )}
+            <div className="flex items-center gap-2">
+              <Trash2
+                className="cursor-pointer text-gray-400 hover:text-red-500"
                 size={24}
-                onClick={() =>
-                  handleCompleteTask(todo.id, todo.isCompleted, todo.title)
-                }
+                onClick={() => handleDeleteTask(todo.id, todo.title)}
+                color="#7098ff"
               />
+              <div
+                className={cn(
+                  'w-6 h-6 rounded-full flex items-center justify-center p-1',
+                  todo.isCompleted
+                    ? 'bg-blue'
+                    : 'bg-transparent border-2 border-blue',
+                )}
+              >
+                <Check
+                  className={cn(
+                    'cursor-pointer',
+                    todo.isCompleted ? 'text-white' : 'text-blue',
+                  )}
+                  size={24}
+                  onClick={() =>
+                    handleCompleteTask(todo.id, todo.isCompleted, todo.title)
+                  }
+                />
+              </div>
             </div>
           </div>
           <p className="text-[20px] text-[#525463] font-semibold">

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -210,13 +210,13 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
         </div>
       ))}
       {filteredTodayTodoList.length === 0 && (
-        <div className="bg-white px-4 py-2 rounded-md">
+        <div className="bg-white px-4 py-8 rounded-md flex flex-col items-center justify-center text-center min-h-[200px]">
           <p className="font-semibold">
             {hideCompleted && todayTodoList && todayTodoList.length > 0
               ? '완료되지 않은 일이 없어요'
               : '아직 오늘의 할 일이 없어요'}
           </p>
-          <p className="text-[14px] text-[#525463]">
+          <p className="text-[14px] text-[#525463] mt-2 cursor-pointer hover:text-blue">
             오늘의 할 일 추가하기 {'>'}
           </p>
         </div>

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -19,9 +19,7 @@ export default function TodayMainDashborad() {
   const date = today.getDate();
 
   const [hideCompleted, setHideCompleted] = useState(false);
-
   const navigate = useNavigate();
-
   const { todayTodoCount } = useGetTodayTodoCount();
   const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
   const currentId = usePomodoroStore((s) => s.id);
@@ -33,18 +31,19 @@ export default function TodayMainDashborad() {
   return (
     <div className="flex flex-col lg:flex-row w-full gap-4">
       {isMobile && currentId && (
-        <div className=" w-full">
+        <div className="w-full">
           <PomodoroCard />
         </div>
       )}
-      <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 lg:mr-4 h-auto lg:min-h-[616px] overflow-auto">
+
+      <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 lg:mr-4 h-auto lg:h-fit overflow-auto self-start">
         <div className="flex justify-between items-center mb-4">
           <div className="flex items-center gap-4">
-            <h3 className="text-[20px] text-[#525463] font-semibold">
+            <h3 className="text-[20px] text-[`#525463`] font-semibold">
               오늘의 할 일
             </h3>
             {todayTodoCount && (
-              <p className="text-[#525463]">{todayTodoCount}</p>
+              <p className="text-[`#525463`]">{todayTodoCount}</p>
             )}
           </div>
           <div className="flex items-center gap-2">
@@ -79,16 +78,16 @@ export default function TodayMainDashborad() {
         <TodayList hideCompleted={hideCompleted} />
       </div>
 
-      <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto md:h-[740px] lg:h-[600px] mt-4 lg:mt-0">
+      <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto mt-4 lg:mt-0">
         {!isMobile && currentId && (
-          <div className=" w-full">
+          <div className="w-full">
             <PomodoroCard />
           </div>
         )}
-        <div className="h-1/2 w-full">
+        <div className="w-full">
           <DailyCompletionChart title="할 일 완료 분석" />
         </div>
-        <div className="h-1/2 w-full">
+        <div className="w-full">
           <DailyCompletionChart title="뽀모도로 시간 분석" />
         </div>
       </div>

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -9,6 +9,7 @@ import { usePomodoroStore } from '@/store/pomodoro.ts';
 import { useIsMobile } from '@/hooks/use-mobile.ts';
 import { useState } from 'react';
 import { Switch } from '@/components/ui/switch';
+import { useNavigate } from 'react-router';
 
 export default function TodayMainDashborad() {
   const isMobile = useIsMobile();
@@ -19,9 +20,15 @@ export default function TodayMainDashborad() {
 
   const [hideCompleted, setHideCompleted] = useState(false);
 
+  const navigate = useNavigate();
+
   const { todayTodoCount } = useGetTodayTodoCount();
   const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
   const currentId = usePomodoroStore((s) => s.id);
+
+  const handleRouteToEisenhower = () => {
+    navigate('/matrix');
+  };
 
   return (
     <div className="flex flex-col lg:flex-row w-full gap-4">
@@ -41,9 +48,12 @@ export default function TodayMainDashborad() {
             )}
           </div>
           <div className="flex items-center gap-2">
-            <p className="font-semibold text-[#A9ABB8]">수정하기</p>
             <button className="p-2 bg-gray-scale-200 rounded-full cursor-pointer">
-              <Plus size={18} className="text-blue" />
+              <Plus
+                size={18}
+                className="text-blue"
+                onClick={handleRouteToEisenhower}
+              />
             </button>
           </div>
         </div>

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -7,6 +7,8 @@ import useGetTodayTodoCount from '@/hooks/queries/today/useGetTodayTodoCount';
 import { Plus } from 'lucide-react';
 import { usePomodoroStore } from '@/store/pomodoro.ts';
 import { useIsMobile } from '@/hooks/use-mobile.ts';
+import { useState } from 'react';
+import { Switch } from '@/components/ui/switch';
 
 export default function TodayMainDashborad() {
   const isMobile = useIsMobile();
@@ -15,6 +17,8 @@ export default function TodayMainDashborad() {
   const month = today.getMonth() + 1;
   const date = today.getDate();
 
+  const [hideCompleted, setHideCompleted] = useState(false);
+
   const { todayTodoCount } = useGetTodayTodoCount();
   const { todayTodoCompletedCount } = useGetTodayTodoCompletedCount();
   const currentId = usePomodoroStore((s) => s.id);
@@ -22,9 +26,9 @@ export default function TodayMainDashborad() {
   return (
     <div className="flex flex-col lg:flex-row w-full gap-4">
       {isMobile && currentId && (
-          <div className=" w-full">
-            <PomodoroCard />
-          </div>
+        <div className=" w-full">
+          <PomodoroCard />
+        </div>
       )}
       <div className="w-full lg:w-1/2 bg-white rounded-lg p-4 lg:mr-4 h-auto lg:min-h-[616px] overflow-auto">
         <div className="flex justify-between items-center mb-4">
@@ -44,15 +48,25 @@ export default function TodayMainDashborad() {
           </div>
         </div>
 
-        <div className="my-8 font-semibold">
-          {year}년 {month}월 {date}일
+        <div className="flex items-center justify-between">
+          <div className="my-8 font-semibold">
+            {year}년 {month}월 {date}일
+          </div>
+          <div className="flex items-center gap-2">
+            <p className="text-[14px] text-gray-scale-700">완료된 일 숨기기</p>
+            <Switch
+              checked={hideCompleted}
+              onCheckedChange={setHideCompleted}
+              className="data-[state=checked]:bg-blue"
+            />
+          </div>
         </div>
 
         <TodayCompleteChart
           totalCount={todayTodoCount ?? 0}
           completedCount={todayTodoCompletedCount ?? 0}
         />
-        <TodayList />
+        <TodayList hideCompleted={hideCompleted} />
       </div>
 
       <div className="w-full lg:w-1/2 flex flex-col gap-4 h-auto md:h-[740px] lg:h-[600px] mt-4 lg:mt-0">

--- a/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
+++ b/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { Folder, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+import useGetInventoryFolderList from '@/hooks/queries/inventory/folder/useGetInventoryFolderList';
+import useMoveInventoryItem from '@/hooks/queries/inventory/item/useMoveInventoryItem';
+import { toast } from 'sonner';
+
+type MoveToInventoryModalProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  item: {
+    id: number;
+    title: string;
+  };
+};
+
+export default function MoveToInventoryModal({
+  isOpen,
+  onOpenChange,
+  item,
+}: MoveToInventoryModalProps) {
+  const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
+
+  const { inventoryFolderList, isLoading } = useGetInventoryFolderList();
+
+  //   아이젠하워 -> 보관함 할당하는 API 로 수정!!!
+  const { moveInventoryItemMutation, isPending } = useMoveInventoryItem(
+    item.folderId,
+  );
+
+  const handleFolderSelect = (folderId: number) => {
+    setSelectedFolderId(folderId);
+  };
+
+  const handleMove = () => {
+    if (!selectedFolderId) return;
+
+    moveInventoryItemMutation(
+      {
+        id: item.id,
+        data: {
+          folderId: selectedFolderId,
+        },
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setSelectedFolderId(null);
+          toast.success(`"${item.title}" 항목이 성공적으로 이동되었습니다.`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>버블 보관하기</DialogTitle>
+          <DialogDescription>
+            "{item.title}" 버블을 저장할 보관함 폴더를 선택해주세요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4 max-h-[300px] overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="h-8 w-8 animate-spin text-blue" />
+            </div>
+          ) : inventoryFolderList && inventoryFolderList.length > 0 ? (
+            <ul className="space-y-2">
+              {inventoryFolderList.map((folder) => (
+                <li
+                  key={folder.id}
+                  onClick={() => handleFolderSelect(folder.id)}
+                  className={`
+                    p-4 rounded-lg cursor-pointer flex items-center gap-3
+                    ${selectedFolderId === folder.id ? 'bg-blue-2 text-blue' : 'bg-gray-scale-200 hover:bg-gray-scale-300'}
+                  `}
+                >
+                  <Folder size={20} />
+                  <div>
+                    <p className="font-medium">{folder.name}</p>
+                    <p className="text-xs text-gray-500">
+                      항목 {folder.itemCount}개
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-center py-6 text-gray-500">
+              이동 가능한 폴더가 없습니다.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <div className="w-full flex items-center justify-end gap-2">
+            <Button
+              onClick={() => {
+                onOpenChange(false);
+                setSelectedFolderId(null);
+              }}
+              variant="outline"
+            >
+              취소
+            </Button>
+            <Button
+              onClick={handleMove}
+              disabled={isPending || !selectedFolderId}
+              className="bg-blue text-white"
+            >
+              {isPending ? (
+                <div className="flex items-center justify-center">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  이동 중...
+                </div>
+              ) : (
+                '이동하기'
+              )}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
+++ b/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
@@ -10,8 +10,8 @@ import {
 } from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/button';
 import useGetInventoryFolderList from '@/hooks/queries/inventory/folder/useGetInventoryFolderList';
-import useMoveInventoryItem from '@/hooks/queries/inventory/item/useMoveInventoryItem';
 import { toast } from 'sonner';
+import useCreateInventoryItem from '@/hooks/queries/inventory/item/useCreateInventoryItem';
 
 type MoveToInventoryModalProps = {
   isOpen: boolean;
@@ -20,21 +20,20 @@ type MoveToInventoryModalProps = {
     id: number;
     title: string;
   };
+  onSuccess?: () => void;
 };
 
 export default function MoveToInventoryModal({
   isOpen,
   onOpenChange,
   item,
+  onSuccess,
 }: MoveToInventoryModalProps) {
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
 
   const { inventoryFolderList, isLoading } = useGetInventoryFolderList();
 
-  //   아이젠하워 -> 보관함 할당하는 API 로 수정!!!
-  const { moveInventoryItemMutation, isPending } = useMoveInventoryItem(
-    item.folderId,
-  );
+  const { createInventoryItemMutation, isPending } = useCreateInventoryItem();
 
   const handleFolderSelect = (folderId: number) => {
     setSelectedFolderId(folderId);
@@ -43,18 +42,18 @@ export default function MoveToInventoryModal({
   const handleMove = () => {
     if (!selectedFolderId) return;
 
-    moveInventoryItemMutation(
+    createInventoryItemMutation(
       {
-        id: item.id,
-        data: {
-          folderId: selectedFolderId,
-        },
+        folderId: selectedFolderId,
+        title: item.title,
+        memo: '',
       },
       {
         onSuccess: () => {
           onOpenChange(false);
           setSelectedFolderId(null);
           toast.success(`"${item.title}" 항목이 성공적으로 이동되었습니다.`);
+          if (onSuccess) onSuccess();
         },
       },
     );

--- a/frontend/src/components/ui/chart/DailyCompletionChart.tsx
+++ b/frontend/src/components/ui/chart/DailyCompletionChart.tsx
@@ -12,29 +12,57 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
-
-const todoChartData = [
-  { day: 'SUN', completed: 5 },
-  { day: 'MON', completed: 1 },
-  { day: 'TUE', completed: 2 },
-  { day: 'WED', completed: 3 },
-  { day: 'THU', completed: 4 },
-  { day: 'FRI', completed: 5 },
-  { day: 'SAT', completed: 6 },
-];
+import useGetTodayTaskAnalysis from '@/hooks/queries/analysis/useGetTodayTaskAnalysis';
 
 const todoChartConfig = {
-  completed: {
+  completedNum: {
     label: '완료한 일',
     color: '#7098ff',
   },
 } satisfies ChartConfig;
+
+type DayOfWeekMap = {
+  [key in 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN']: string;
+};
+
+const dayOfWeekMapping: DayOfWeekMap = {
+  MON: '월',
+  TUE: '화',
+  WED: '수',
+  THU: '목',
+  FRI: '금',
+  SAT: '토',
+  SUN: '일',
+};
 
 type DailyCompletionChartProps = {
   title: string;
 };
 
 export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
+  const { todayTaskAnalysisList } = useGetTodayTaskAnalysis();
+
+  const defaultChartData = [
+    { day: '일', dayOfWeek: 'SUN', completedNum: 0 },
+    { day: '월', dayOfWeek: 'MON', completedNum: 0 },
+    { day: '화', dayOfWeek: 'TUE', completedNum: 0 },
+    { day: '수', dayOfWeek: 'WED', completedNum: 0 },
+    { day: '목', dayOfWeek: 'THU', completedNum: 0 },
+    { day: '금', dayOfWeek: 'FRI', completedNum: 0 },
+    { day: '토', dayOfWeek: 'SAT', completedNum: 0 },
+  ];
+
+  const chartData = todayTaskAnalysisList?.length
+    ? todayTaskAnalysisList.map((item) => ({
+        day:
+          dayOfWeekMapping[item.dayOfWeek as keyof DayOfWeekMap] ||
+          item.dayOfWeek,
+        dayOfWeek: item.dayOfWeek,
+        completedNum: item.completedNum,
+        taskDate: item.taskDate,
+      }))
+    : defaultChartData;
+
   return (
     <Card className="h-full w-full border-none shadow-none">
       <CardHeader className="pb-2">
@@ -47,7 +75,7 @@ export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
           <ChartContainer config={todoChartConfig} className="h-full w-full">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart
-                data={todoChartData}
+                data={chartData}
                 margin={{
                   top: 10,
                   right: 30,
@@ -68,17 +96,10 @@ export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
                   content={<ChartTooltipContent hideLabel />}
                 />
                 <Bar
-                  dataKey="completed"
+                  dataKey="completedNum"
                   fill="var(--color-completed)"
                   radius={8}
-                >
-                  {/* <LabelList
-                    position="top"
-                    offset={12}
-                    className="fill-foreground"
-                    fontSize={12}
-                  /> */}
-                </Bar>
+                ></Bar>
               </BarChart>
             </ResponsiveContainer>
           </ChartContainer>

--- a/frontend/src/components/ui/sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ type NavItem = {
   defaultIcon: string | React.ReactNode;
   label: string;
   route: string;
+  activePatterns?: string[];
 };
 
 const navItems: NavItem[] = [
@@ -34,6 +35,7 @@ const navItems: NavItem[] = [
     defaultIcon: BrainStormingHWIcon,
     label: '브레인스토밍',
     route: '/brainstorming',
+    activePatterns: ['/mindmap'],
   },
   {
     id: 'matrix',
@@ -43,11 +45,12 @@ const navItems: NavItem[] = [
     route: '/matrix',
   },
   {
-    id: 'store',
+    id: 'inventory',
     activeIcon: StoreIcon,
     defaultIcon: StoreHWIcon,
     label: '보관함',
     route: '/inventory',
+    activePatterns: ['/inventory/'],
   },
 ];
 
@@ -74,17 +77,30 @@ export default function Sidebar() {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const [isTransitioning, setIsTransitioning] = useState<boolean>(false);
 
-  const isActive = (itemRoute: string): boolean => {
-    return location.pathname === itemRoute;
+  const isActive = (item: NavItem): boolean => {
+    if (location.pathname === item.route) {
+      return true;
+    }
+
+    if (item.activePatterns) {
+      return item.activePatterns.some((pattern) => {
+        return location.pathname.startsWith(pattern);
+      });
+    }
+
+    return false;
   };
 
   const handleItemClick = (route: string): void => {
     navigate(route);
   };
 
-  const activeItem: NavItem =
-    [...navItems, ...bottomNavItems].find((item) => isActive(item.route)) ||
-    navItems[0];
+  const findActiveItem = (): NavItem => {
+    const allItems = [...navItems, ...bottomNavItems];
+    return allItems.find((item) => isActive(item)) || navItems[0];
+  };
+
+  const activeItem: NavItem = findActiveItem();
 
   const toggleSidebar = (open: boolean): void => {
     setIsTransitioning(true);
@@ -94,7 +110,8 @@ export default function Sidebar() {
     }, 300);
   };
 
-  const renderNavItem = (item: NavItem, active: boolean) => {
+  const renderNavItem = (item: NavItem) => {
+    const active = isActive(item);
     const isIconComponent = typeof item.activeIcon !== 'string';
 
     return (
@@ -220,19 +237,13 @@ export default function Sidebar() {
 
         <div className="py-[10px] flex-1 ">
           <div className="flex flex-col gap-[18px] px-4">
-            {navItems.map((item) => {
-              const active = isActive(item.route);
-              return renderNavItem(item, active);
-            })}
+            {navItems.map((item) => renderNavItem(item))}
           </div>
         </div>
 
         <div className="py-[10px] mt-auto flex-shrink-0">
           <div className="flex flex-col gap-[18px] px-4 mb-4">
-            {bottomNavItems.map((item) => {
-              const active = isActive(item.route);
-              return renderNavItem(item, active);
-            })}
+            {bottomNavItems.map((item) => renderNavItem(item))}
           </div>
         </div>
       </div>

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+
+import { cn } from '@/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/frontend/src/hooks/queries/analysis/useGetTodayTaskAnalysis.ts
+++ b/frontend/src/hooks/queries/analysis/useGetTodayTaskAnalysis.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetTodayTaskAnalysisRes } from '@/types/api/analysis';
+import { analysisService } from '@/services/analysisService';
+
+const useGetTodayTaskAnalysis = () => {
+  const { data, isLoading, error, isPending } =
+    useQuery<GetTodayTaskAnalysisRes>({
+      queryKey: ['todayTaskAnalysis'],
+      queryFn: () => analysisService.getList(),
+      refetchOnWindowFocus: false,
+      retry: 1,
+    });
+
+  return {
+    todayTaskAnalysisList: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetTodayTaskAnalysis;

--- a/frontend/src/hooks/queries/inventory/folder/useUpdateFolderName.ts
+++ b/frontend/src/hooks/queries/inventory/folder/useUpdateFolderName.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { inventoryFolderService } from '@/services/inventoryFolderService';
+
+const useUpdateFolderName = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: { name: string } }) =>
+      inventoryFolderService.updateName(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['inventoryFolderList'] });
+    },
+  });
+
+  return {
+    updateFolderNameMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useUpdateFolderName;

--- a/frontend/src/hooks/queries/inventory/item/useCreateInventoryItem.ts
+++ b/frontend/src/hooks/queries/inventory/item/useCreateInventoryItem.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { inventoryItemService } from '@/services/inventoryItemService';
+import { CreateInventoryItemReq } from '@/types/api/inventory/item';
+
+const useCreateInventoryItem = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (data: CreateInventoryItemReq) =>
+      inventoryItemService.createItem(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bubbleList'] });
+    },
+  });
+
+  return {
+    createInventoryItemMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useCreateInventoryItem;

--- a/frontend/src/hooks/queries/inventory/item/useGetRecentInventory.ts
+++ b/frontend/src/hooks/queries/inventory/item/useGetRecentInventory.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { inventoryItemService } from '@/services/inventoryItemService';
+import { InventoryRecentListRes } from '@/types/api/inventory/item';
+
+const useGetRecentInventory = () => {
+  const { data, isLoading, error, isPending } =
+    useQuery<InventoryRecentListRes>({
+      queryKey: ['recentInventoryList'],
+      queryFn: () => inventoryItemService.getRecentList(),
+      refetchOnWindowFocus: false,
+      retry: 1,
+    });
+
+  return {
+    inventoryRecentList: data?.content,
+    isLoading,
+    error,
+    isPending,
+  };
+};
+
+export default useGetRecentInventory;

--- a/frontend/src/hooks/queries/today/useDeleteTodayTodo.ts
+++ b/frontend/src/hooks/queries/today/useDeleteTodayTodo.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { todayService } from '@/services/todayService';
+
+const useDeleteTodayTodo = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (id: number) => todayService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+    },
+  });
+
+  return {
+    deleteTodayTodoMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useDeleteTodayTodo;

--- a/frontend/src/hooks/queries/today/useDeleteTodayTodo.ts
+++ b/frontend/src/hooks/queries/today/useDeleteTodayTodo.ts
@@ -9,6 +9,8 @@ const useDeleteTodayTodo = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
       queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCount'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCompletedCount'] });
     },
   });
 

--- a/frontend/src/hooks/queries/today/useUpdateStatusTodo.ts
+++ b/frontend/src/hooks/queries/today/useUpdateStatusTodo.ts
@@ -15,6 +15,8 @@ const useUpdateStatusTodo = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
       queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCount'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCompletedCount'] });
     },
   });
 

--- a/frontend/src/hooks/queries/today/useUpdateStatusTodo.ts
+++ b/frontend/src/hooks/queries/today/useUpdateStatusTodo.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { todayService } from '@/services/todayService';
+
+const useUpdateStatusTodo = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: { isCompleted: boolean };
+    }) => todayService.updateStatus(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+    },
+  });
+
+  return {
+    updateStatusMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useUpdateStatusTodo;

--- a/frontend/src/pages/brainstorming.tsx
+++ b/frontend/src/pages/brainstorming.tsx
@@ -34,6 +34,9 @@ export default function Brainstorming() {
     bubbleId: null,
     title: '',
   });
+  const [toBeSavedBubbleId, setToBeSavedBubbleId] = useState<number | null>(
+    null,
+  );
 
   const [isMoveToInventoryDialogOpen, setIsMoveToInventoryDialogOpen] =
     useState(false);
@@ -250,7 +253,38 @@ export default function Brainstorming() {
   };
 
   const createMatrix = () => {};
-  const saveBubble = () => {};
+
+  const handleSaveBubble = (bubble) => {
+    setSelectedBubble({
+      bubbleId: bubble.bubbleId,
+      title: bubble.title,
+    });
+    setOpenPopoverId(null);
+    setToBeSavedBubbleId(bubble.bubbleId); // 보관할 버블 ID 저장
+    setIsMoveToInventoryDialogOpen(true);
+  };
+
+  // 보관 성공 시 실행할 함수
+  const handleSaveSuccess = () => {
+    if (toBeSavedBubbleId) {
+      // 애니메이션을 위해 isDeleting 상태 설정
+      setBubbles((prev) =>
+        prev.map((bubble) =>
+          bubble.bubbleId === toBeSavedBubbleId
+            ? { ...bubble, isDeleting: true }
+            : bubble,
+        ),
+      );
+
+      // 애니메이션이 끝난 후 버블 제거
+      setTimeout(() => {
+        setBubbles((prev) =>
+          prev.filter((bubble) => bubble.bubbleId !== toBeSavedBubbleId),
+        );
+        setToBeSavedBubbleId(null); // 상태 초기화
+      }, 250);
+    }
+  };
 
   return (
     <div
@@ -339,13 +373,7 @@ export default function Brainstorming() {
                       isMobile ? 'text-[14px]' : 'text-[16px]',
                     )}
                     onClick={() => {
-                      setSelectedBubble({
-                        bubbleId: bubble.bubbleId,
-                        title: bubble.title,
-                      });
-                      saveBubble();
-                      setOpenPopoverId(null);
-                      setIsMoveToInventoryDialogOpen(true);
+                      handleSaveBubble(bubble);
                     }}
                   >
                     보관
@@ -401,14 +429,25 @@ export default function Brainstorming() {
         </div>
       </div>
 
-      <MoveToInventoryModal
-        isOpen={isMoveToInventoryDialogOpen}
-        onOpenChange={setIsMoveToInventoryDialogOpen}
-        item={{
-          id: selectedBubble.bubbleId,
-          title: selectedBubble.title,
-        }}
-      />
+      {selectedBubble.bubbleId && (
+        <MoveToInventoryModal
+          isOpen={isMoveToInventoryDialogOpen}
+          onOpenChange={(open) => {
+            setIsMoveToInventoryDialogOpen(open);
+            if (!open) {
+              if (!toBeSavedBubbleId) {
+                setSelectedBubble({ bubbleId: null, title: '' });
+                setToBeSavedBubbleId(null);
+              }
+            }
+          }}
+          item={{
+            id: selectedBubble.bubbleId,
+            title: selectedBubble.title,
+          }}
+          onSuccess={handleSaveSuccess}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/brainstorming.tsx
+++ b/frontend/src/pages/brainstorming.tsx
@@ -15,6 +15,7 @@ import useDeleteBubble from '@/hooks/queries/brainstorming/useDeleteBubble.ts';
 import useCreateBubble from '@/hooks/queries/brainstorming/useCreateBubble.ts';
 import { Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router';
+import MoveToInventoryModal from '@/components/ui/brainstorming/MoveToInventoryModal';
 
 export default function Brainstorming() {
   const isMobile = useIsMobile();
@@ -29,6 +30,13 @@ export default function Brainstorming() {
   const bubblesRef = useRef<BubbleNodeType[]>([]);
   const textareaRef = useRef(null);
   const [openPopoverId, setOpenPopoverId] = useState<number | null>(null);
+  const [selectedBubble, setSelectedBubble] = useState({
+    bubbleId: null,
+    title: '',
+  });
+
+  const [isMoveToInventoryDialogOpen, setIsMoveToInventoryDialogOpen] =
+    useState(false);
 
   const navigate = useNavigate();
 
@@ -156,7 +164,7 @@ export default function Brainstorming() {
       return;
     }
     const scroll = scrollRef.current;
-    let scrollWidth = scroll.offsetWidth;
+    const scrollWidth = scroll.offsetWidth;
     let scrollHeight = scroll.offsetHeight;
 
     createBubbleMutation(
@@ -255,7 +263,7 @@ export default function Brainstorming() {
       ></div>
       <div className="relative w-full h-full ">
         <div ref={scrollRef} className="relative w-full h-full overflow-auto ">
-          {bubbles.map((bubble, index) => (
+          {bubbles.map((bubble) => (
             <Popover
               key={bubble.bubbleId}
               open={openPopoverId === bubble.bubbleId}
@@ -331,8 +339,13 @@ export default function Brainstorming() {
                       isMobile ? 'text-[14px]' : 'text-[16px]',
                     )}
                     onClick={() => {
+                      setSelectedBubble({
+                        bubbleId: bubble.bubbleId,
+                        title: bubble.title,
+                      });
                       saveBubble();
                       setOpenPopoverId(null);
+                      setIsMoveToInventoryDialogOpen(true);
                     }}
                   >
                     보관
@@ -387,6 +400,15 @@ export default function Brainstorming() {
           )}
         </div>
       </div>
+
+      <MoveToInventoryModal
+        isOpen={isMoveToInventoryDialogOpen}
+        onOpenChange={setIsMoveToInventoryDialogOpen}
+        item={{
+          id: selectedBubble.bubbleId,
+          title: selectedBubble.title,
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/inventory.tsx
+++ b/frontend/src/pages/inventory.tsx
@@ -7,7 +7,7 @@ import useDeleteInventoryFolder from '@/hooks/queries/inventory/folder/useDelete
 import CreateFolderModal from '@/components/inventory/modal/CreateFolderMoal';
 import DeleteFolderModal from '@/components/inventory/modal/DeleteFolderMoal';
 
-export default function StorePage() {
+export default function InventoryPage() {
   const navigate = useNavigate();
   const { inventoryFolderList } = useGetInventoryFolderList();
   const { deleteInventoryFolderMutation, isPending: isDeleting } =

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -1,44 +1,5 @@
+import ReminderList from '@/components/today/ReminderList';
 import TodayMainDashborad from '@/components/today/TodayMainDashborad';
-
-// 리마인더 데이터
-const REMIND_DATA = [
-  {
-    id: 0,
-    title: '운동하기',
-    content: '등 운동 1시간',
-    category: 'category1',
-    dueDate: '2022-01-20',
-    reminder: true,
-    completed: false,
-  },
-  {
-    id: 1,
-    title: '축구하기',
-    content: '일요일 오후 6시 조기축구',
-    category: 'category1',
-    dueDate: '2022-01-20',
-    reminder: false,
-    completed: false,
-  },
-  {
-    id: 2,
-    title: '캡스톤 개발',
-    content: '오늘의 할 일 페이지 개발하기',
-    category: 'category1',
-    dueDate: '2022-01-20',
-    reminder: false,
-    completed: true,
-  },
-  {
-    id: 3,
-    title: '도훈 버블팝 춤 연습하기',
-    content: '버블팝 연습해서 양정민 앞에...',
-    category: 'category1',
-    dueDate: '2022-01-20',
-    reminder: false,
-    completed: false,
-  },
-];
 
 export default function TodayListPage() {
   return (
@@ -51,30 +12,7 @@ export default function TodayListPage() {
         조금씩, 하지만 꾸준히! 오늘도 파이팅 ✨
       </div>
 
-      <div className="w-full mt-6 mb-4">
-        <div className="flex items-center gap-2 mb-2">
-          <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
-          <p className="text-blue text-[14px] cursor-pointer">더보기 {'>'} </p>
-        </div>
-
-        <div className="w-full overflow-x-auto pb-4">
-          <div className="flex gap-4" style={{ width: 'max-content' }}>
-            {REMIND_DATA.map((remind) => (
-              <div
-                key={remind.id}
-                className="bg-white rounded-lg px-6 py-4 cursor-pointer flex-none"
-                style={{ width: '16rem' }}
-              >
-                <h3 className="text-[20px] text-[#525463] font-semibold">
-                  {remind.title}
-                </h3>
-                <p className="text-gray-500">{remind.content}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
+      <ReminderList />
       {/* 메인 대시보드 레이아웃 */}
       <TodayMainDashborad />
     </div>

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -13,7 +13,6 @@ export default function TodayListPage() {
       </div>
 
       <ReminderList />
-      {/* 메인 대시보드 레이아웃 */}
       <TodayMainDashborad />
     </div>
   );

--- a/frontend/src/services/analysisService.ts
+++ b/frontend/src/services/analysisService.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/api/client';
+import { ENDPOINTS } from '@/api/endpoints';
+import { GetTodayTaskAnalysisRes } from '@/types/api/analysis';
+
+export const analysisService = {
+  getList: async (): Promise<GetTodayTaskAnalysisRes> => {
+    const response = await apiClient.get<GetTodayTaskAnalysisRes>(
+      ENDPOINTS.ANALYSIS.TODAY_TASK,
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/services/inventoryFolderService.ts
+++ b/frontend/src/services/inventoryFolderService.ts
@@ -35,4 +35,12 @@ export const inventoryFolderService = {
     );
     return response.data;
   },
+
+  updateName: async (id: number, data: { name: string }) => {
+    const res = await apiClient.patch(
+      ENDPOINTS.INVENTORY.FOLDER.UPDATE_NAME(id),
+      data,
+    );
+    return res.data;
+  },
 };

--- a/frontend/src/services/inventoryItemService.ts
+++ b/frontend/src/services/inventoryItemService.ts
@@ -2,6 +2,7 @@ import { apiClient } from '@/api/client';
 import { ENDPOINTS } from '@/api/endpoints';
 import {
   InventoryItemListRes,
+  InventoryRecentListRes,
   MoveInventoryItemReq,
   UpdateInventoryItemReq,
 } from '@/types/api/inventory/item';
@@ -31,10 +32,18 @@ export const inventoryItemService = {
     );
     return response.data;
   },
+
   moveFolder: async (id: number, data: MoveInventoryItemReq): Promise<void> => {
     const response = await apiClient.patch(
       ENDPOINTS.INVENTORY.ITEM.MOVE_FOLDER(id),
       data,
+    );
+    return response.data;
+  },
+
+  getRecentList: async (): Promise<InventoryRecentListRes> => {
+    const response = await apiClient.get<InventoryRecentListRes>(
+      ENDPOINTS.INVENTORY.ITEM.RECENT,
     );
     return response.data;
   },

--- a/frontend/src/services/inventoryItemService.ts
+++ b/frontend/src/services/inventoryItemService.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/api/client';
 import { ENDPOINTS } from '@/api/endpoints';
 import {
+  CreateInventoryItemReq,
   InventoryItemListRes,
   InventoryRecentListRes,
   MoveInventoryItemReq,
@@ -44,6 +45,16 @@ export const inventoryItemService = {
   getRecentList: async (): Promise<InventoryRecentListRes> => {
     const response = await apiClient.get<InventoryRecentListRes>(
       ENDPOINTS.INVENTORY.ITEM.RECENT,
+    );
+    return response.data;
+  },
+
+  createItem: async (
+    data: CreateInventoryItemReq,
+  ): Promise<MoveInventoryItemReq> => {
+    const response = await apiClient.post(
+      ENDPOINTS.INVENTORY.ITEM.CREATE_ITEM,
+      data,
     );
     return response.data;
   },

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -41,4 +41,15 @@ export const todayService = {
     );
     return response.data;
   },
+
+  updateStatus: async (
+    id: number,
+    data: { isCompleted: boolean },
+  ): Promise<void> => {
+    const response = await apiClient.patch(
+      ENDPOINTS.TODAY.UPDATE_STATUS(id),
+      data,
+    );
+    return response.data;
+  },
 };

--- a/frontend/src/services/todayService.ts
+++ b/frontend/src/services/todayService.ts
@@ -52,4 +52,9 @@ export const todayService = {
     );
     return response.data;
   },
+
+  delete: async (id: number): Promise<void> => {
+    const response = await apiClient.delete(ENDPOINTS.TODAY.DELETE(id));
+    return response.data;
+  },
 };

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -1,0 +1,6 @@
+export type TodayTaskAnalysis = {
+  id: number;
+  taskDate: string;
+  dayOfWeek: string;
+  completedNum: 0;
+};

--- a/frontend/src/types/api/analysis/index.ts
+++ b/frontend/src/types/api/analysis/index.ts
@@ -1,0 +1,2 @@
+export * from './request';
+export * from './response';

--- a/frontend/src/types/api/analysis/response.ts
+++ b/frontend/src/types/api/analysis/response.ts
@@ -1,0 +1,7 @@
+import { TodayTaskAnalysis } from '@/types/analysis';
+
+export type GetTodayTaskAnalysisRes = {
+  statusCode: number;
+  error: string | null;
+  content: TodayTaskAnalysis[];
+};

--- a/frontend/src/types/api/inventory/item/request.ts
+++ b/frontend/src/types/api/inventory/item/request.ts
@@ -6,3 +6,9 @@ export type UpdateInventoryItemReq = {
 export type MoveInventoryItemReq = {
   folderId: number;
 };
+
+export type CreateInventoryItemReq = {
+  folderId: number;
+  title: string;
+  memo: string;
+};

--- a/frontend/src/types/api/inventory/item/response.ts
+++ b/frontend/src/types/api/inventory/item/response.ts
@@ -7,3 +7,9 @@ export type InventoryItemListRes = {
     content: InventoryItem[];
   };
 };
+
+export type InventoryRecentListRes = {
+  statusCode: number;
+  error: string | null;
+  content: InventoryItem[];
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #237 

## 📝 작업 내용
`브레인스토밍 <-> 보관함 <-> 오늘의 할 일`
위 세 단계의 관련 작업들을 처리했습니다. 

### 오늘의 할 일
**1. 리마인더 API 연동**
**2. 할 일 완료 및 삭제 기능 추가**
API 요청 성공 시, toast를 뜨도록 처리했습니다! 
<img width="1499" alt="스크린샷 2025-05-13 오전 4 19 50" src="https://github.com/user-attachments/assets/05eef5fa-3451-4f0b-addf-b9d64cf999d6" />
<img width="1499" alt="스크린샷 2025-05-13 오전 4 20 14" src="https://github.com/user-attachments/assets/6d64e86c-be8a-4772-a4df-1a4793f0bf78" />
<img width="1511" alt="스크린샷 2025-05-13 오전 4 20 27" src="https://github.com/user-attachments/assets/f8817286-a321-402c-8f44-94f6104cad9e" />
**3. 오늘의 할 일 분석 데이터 연동**

이외 레이아웃 관련 CSS 수정 작업도 진행했습니다.

### 브레인스토밍 -> 보관함
브레인스토밍에서 보관함으로 옮기는 기능 개발했습니다. 모달 UI는 이전에 보관함 폴더 이동 기능 때 활용했던 모달을 재활용하여 구현했습니다.
<img width="772" alt="스크린샷 2025-05-13 오전 4 22 49" src="https://github.com/user-attachments/assets/5a356f35-f1c6-43bd-a68e-f1ce4bec54dc" />

그런데 보관함 이동 API 요청 시, 브레인스토밍 리스트에 해당 아이템이 삭제 반영 안 되고 있어서 해당 부분 백엔드에 수정 요청한 상태입니다.

### 보관함
**폴더명 수정 기능 개발**
수정 아이콘 눌렀을 시, 폴더명을 input으로 변경하여 편집모드 UI를 구현하였습니다.
이때 편집 중인 상태면, 다른 리스트를 눌러도 이동은 못하도록 막아놨습니다! 

<img width="1500" alt="스크린샷 2025-05-13 오전 4 24 32" src="https://github.com/user-attachments/assets/8f0bb61c-dcca-4a7c-8630-b2298bf235e3" />


## 💬 추가 사항
현재 뽀모도로 관련 데이터 API가 아직 개발되지 않아서, 해당 부분은 전달 받는대로 바로 적용할 예정입니다!

