### PR TITLE
[BE] hotfix: 보관함 아이템 생성 중복 API 제거

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/inventory/controller/InventoryItemController.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/controller/InventoryItemController.java
@@ -1,6 +1,5 @@
 package capstone.backend.domain.inventory.controller;
 
-import capstone.backend.domain.inventory.request.InventoryItemCreateRequest;
 import capstone.backend.domain.inventory.request.InventoryItemUpdateRequest;
 import capstone.backend.domain.inventory.request.InventoryItemMoveRequest;
 import capstone.backend.domain.inventory.response.InventoryItemResponse;
@@ -33,16 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class InventoryItemController {
 
     private final InventoryItemService inventoryItemService;
-
-    @Operation(summary = "보관함 아이템 생성", description = "보관함 아이템을 생성합니다.")
-    @PostMapping
-    public ApiResponse<InventoryItemResponse> createInventoryItem(
-        @AuthenticationPrincipal CustomOAuth2User user,
-        @RequestBody @Valid InventoryItemCreateRequest request
-    ){
-        InventoryItemResponse response = inventoryItemService.createInventoryItem(request, user.getMemberId());
-        return ApiResponse.ok(response);
-    }
 
     @Operation(summary = "보관함 폴더별 조회", description = "폴더 안에 있는 보관함 아이템들을 조회합니다.")
     @GetMapping("/{folderId}")

--- a/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
+++ b/backend/src/main/java/capstone/backend/domain/pomodoro/service/PomodoroService.java
@@ -105,7 +105,6 @@ public class PomodoroService {
         int[] times = calculateTotalTimeSummary(executedCycles);
 
         int totalExecutedSeconds = times[2];
-        // TODO 에러로 낼 지, 아니면 0보다 클 때만 기록을 저장하게 조건 제어로 할지 논의 필요
         // 0이면 기록을 저장하지 않고 에러 발생
         if (totalExecutedSeconds <= 59) {
             throw new PomodoroDurationException();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #249 

## 📝 작업 내용

- 뽀모도로 완료 및 기록 로직 확정으로 인한 주석 제거
- 보관함 아이템 생성 중복 API 제거

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
