### PR TITLE
[FE] qa: 마인드맵 수정사항 반영

### DIFF
--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -18,6 +18,8 @@ export default function CustomNode({
   const nodeRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const isRootNode = id === '1';
+
   const updateNodeLabel = useMindmapStore((state) => state.updateNodeLabel);
   const updateNodeHeight = useMindmapStore((state) => state.updateNodeHeight);
   const addChildNode = useMindmapStore((state) => state.addChildNode);
@@ -40,12 +42,14 @@ export default function CustomNode({
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (isRootNode) return;
+
       const newValue = e.target.value;
       setLabelText(newValue);
 
       updateNodeLabel(id, newValue);
     },
-    [id, updateNodeLabel],
+    [id, updateNodeLabel, isRootNode],
   );
 
   const handlePlusClick = useCallback(
@@ -59,16 +63,24 @@ export default function CustomNode({
   return (
     <div
       ref={nodeRef}
-      className="px-6 py-4 bg-white border border-[#CDCED6] rounded-md w-[172px] relative"
+      className={`px-6 py-4 bg-white border border-[#CDCED6] rounded-md w-[172px] relative ${
+        isRootNode ? 'bg-blue-50' : ''
+      }`}
     >
-      <textarea
-        ref={textareaRef}
-        value={labelText}
-        onChange={handleChange}
-        placeholder="텍스트를 입력하세요"
-        className="text-[14px] text-center font-semibold w-full outline-none bg-transparent resize-none overflow-hidden min-h-[20px]"
-        rows={1}
-      />
+      {isRootNode ? (
+        <div className="text-[14px] text-center font-semibold w-full min-h-[20px]">
+          {labelText}
+        </div>
+      ) : (
+        <textarea
+          ref={textareaRef}
+          value={labelText}
+          onChange={handleChange}
+          placeholder="텍스트를 입력하세요"
+          className="text-[14px] text-center font-semibold w-full outline-none bg-transparent resize-none overflow-hidden min-h-[20px]"
+          rows={1}
+        />
+      )}
 
       <div
         className="absolute left-1/2 -translate-x-1/2 bottom-0 translate-y-1/2 z-10"

--- a/frontend/src/components/mindmap/CustomNode.tsx
+++ b/frontend/src/components/mindmap/CustomNode.tsx
@@ -1,6 +1,6 @@
 import { useMindmapStore } from '@/store/mindMapStore';
 import { Handle, Node, NodeProps, Position } from '@xyflow/react';
-import { CirclePlus } from 'lucide-react';
+import { CirclePlus, X } from 'lucide-react';
 import { useState, useCallback, useEffect, useRef } from 'react';
 
 type CustomNodeData = {
@@ -23,6 +23,7 @@ export default function CustomNode({
   const updateNodeLabel = useMindmapStore((state) => state.updateNodeLabel);
   const updateNodeHeight = useMindmapStore((state) => state.updateNodeHeight);
   const addChildNode = useMindmapStore((state) => state.addChildNode);
+  const deleteNode = useMindmapStore((state) => state.deleteNode);
 
   useEffect(() => {
     setLabelText(data.label || '');
@@ -60,6 +61,14 @@ export default function CustomNode({
     [id, addChildNode],
   );
 
+  const handleDeleteClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      deleteNode(id);
+    },
+    [id, deleteNode],
+  );
+
   return (
     <div
       ref={nodeRef}
@@ -67,6 +76,15 @@ export default function CustomNode({
         isRootNode ? 'bg-blue-50' : ''
       }`}
     >
+      {!isRootNode && (
+        <div
+          className="absolute -top-2 -right-2 bg-gray-scale-400 text-white rounded-full p-1 cursor-pointer z-20 hover:bg-red-600 transition-colors"
+          onClick={handleDeleteClick}
+        >
+          <X size={14} />
+        </div>
+      )}
+
       {isRootNode ? (
         <div className="text-[14px] text-center font-semibold w-full min-h-[20px]">
           {labelText}

--- a/frontend/src/components/mindmap/MindmapSkeleton.tsx
+++ b/frontend/src/components/mindmap/MindmapSkeleton.tsx
@@ -2,13 +2,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export function MindmapSkeleton() {
   return (
-    <div className="w-full h-[calc(100vh-88px)]">
+    <div className="w-full h-full">
       <div
         className="absolute left-0 top-0 w-screen h-screen
         bg-blue-2"
       ></div>
 
-      <div className="w-full h-[calc(100vh-88px)] flex flex-col items-center justify-center p-4 relative z-10">
+      <div className="w-full h-full flex flex-col items-center justify-center p-4 relative z-10">
         <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg p-12 relative overflow-hidden border border-blue-100">
           <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400"></div>
           <div className="absolute -top-20 -left-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>

--- a/frontend/src/components/mindmap/MindmapSkeleton.tsx
+++ b/frontend/src/components/mindmap/MindmapSkeleton.tsx
@@ -2,48 +2,55 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export function MindmapSkeleton() {
   return (
-    <div className="w-full h-[calc(100vh-88px)] flex flex-col items-center justify-center p-4 bg-gradient-to-b from-blue-50 to-[#F0F0F5]">
-      <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg p-12 relative overflow-hidden border border-blue-100">
-        <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400"></div>
-        <div className="absolute -top-20 -left-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
-        <div className="absolute -bottom-20 -right-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
-        <div className="absolute top-[15%] left-[8%] z-0 transform rotate-1">
-          <Skeleton className="w-[130px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute top-[28%] right-[12%] z-0 transform -rotate-1">
-          <Skeleton className="w-[180px] h-[40px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute bottom-[28%] left-[15%] z-0 transform rotate-1">
-          <Skeleton className="w-[160px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute bottom-[18%] right-[10%] z-0 transform -rotate-1">
-          <Skeleton className="w-[140px] h-[36px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute top-[55%] left-[25%] z-0 transform rotate-1">
-          <Skeleton className="w-[150px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute top-[45%] right-[28%] z-0 transform -rotate-1">
-          <Skeleton className="w-[120px] h-[34px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
-        <div className="absolute top-[75%] right-[25%] z-0 transform rotate-1">
-          <Skeleton className="w-[140px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
-        </div>
+    <div className="w-full h-[calc(100vh-88px)]">
+      <div
+        className="absolute left-0 top-0 w-screen h-screen
+        bg-blue-2"
+      ></div>
 
-        <div className="flex flex-col items-center justify-center z-10 relative py-20">
-          <div className="text-xl text-blue-600 font-medium mb-8">
-            마인드맵을 생성하는 중...
+      <div className="w-full h-[calc(100vh-88px)] flex flex-col items-center justify-center p-4 relative z-10">
+        <div className="w-full max-w-3xl bg-white rounded-2xl shadow-lg p-12 relative overflow-hidden border border-blue-100">
+          <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400"></div>
+          <div className="absolute -top-20 -left-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
+          <div className="absolute -bottom-20 -right-20 w-40 h-40 rounded-full bg-blue-50 opacity-50"></div>
+          <div className="absolute top-[15%] left-[8%] z-0 transform rotate-1">
+            <Skeleton className="w-[130px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute top-[28%] right-[12%] z-0 transform -rotate-1">
+            <Skeleton className="w-[180px] h-[40px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute bottom-[28%] left-[15%] z-0 transform rotate-1">
+            <Skeleton className="w-[160px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute bottom-[18%] right-[10%] z-0 transform -rotate-1">
+            <Skeleton className="w-[140px] h-[36px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute top-[55%] left-[25%] z-0 transform rotate-1">
+            <Skeleton className="w-[150px] h-[38px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute top-[45%] right-[28%] z-0 transform -rotate-1">
+            <Skeleton className="w-[120px] h-[34px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
+          </div>
+          <div className="absolute top-[75%] right-[25%] z-0 transform rotate-1">
+            <Skeleton className="w-[140px] h-[35px] bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg" />
           </div>
 
-          <div className="flex items-center space-x-2">
-            <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse"></div>
-            <div
-              className="w-3 h-3 bg-blue-400 rounded-full animate-pulse"
-              style={{ animationDelay: '300ms' }}
-            ></div>
-            <div
-              className="w-3 h-3 bg-blue-300 rounded-full animate-pulse"
-              style={{ animationDelay: '600ms' }}
-            ></div>
+          <div className="flex flex-col items-center justify-center z-10 relative py-20">
+            <div className="text-xl text-blue-600 font-medium mb-8">
+              마인드맵을 생성하는 중...
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <div className="w-3 h-3 bg-blue-500 rounded-full animate-pulse"></div>
+              <div
+                className="w-3 h-3 bg-blue-400 rounded-full animate-pulse"
+                style={{ animationDelay: '300ms' }}
+              ></div>
+              <div
+                className="w-3 h-3 bg-blue-300 rounded-full animate-pulse"
+                style={{ animationDelay: '600ms' }}
+              ></div>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -27,6 +27,7 @@ import { BrainStormingRewriteReq } from '@/types/api/gpt';
 import { Loader2 } from 'lucide-react';
 import BrainstormingLogo from '@/assets/sidebar/color-brainstorming.svg';
 import usePatchBubble from '@/hooks/queries/brainstorming/usePatchBubble';
+import { toast } from 'sonner';
 
 const nodeTypes: NodeTypes = {
   custom: CustomNode,
@@ -52,6 +53,15 @@ function FlowContent() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleRewriteBrainStorming = () => {
+    const emptyNodes = nodes.filter((node) => {
+      return !node.data.label || (node.data.label as string).trim() === '';
+    });
+
+    if (emptyNodes.length > 0) {
+      toast('🚨비어있는 노드 데이터가 있습니다!');
+      return;
+    }
+
     const mindmapData = nodes.map((node) => ({
       context: String(node.data.label || ''),
     }));

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -102,6 +102,7 @@ function FlowContent() {
       style={flowStyles}
       defaultViewport={{ x: 0, y: 0, zoom: 1 }}
       nodesDraggable={false}
+      deleteKeyCode={null}
     >
       <Controls />
 

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -109,33 +109,13 @@ function FlowContent() {
       <Panel position="bottom-center">
         <div className="mb-12 z-10 bg-[rgba(255,255,255,0.6)] rounded-4xl px-6 py-4 w-auto">
           <div className="flex items-center gap-3">
-            <Modal
-              trigger={
-                <Button
-                  className="w-[139px] h-[48px] text-center rounded-4xl bg-blue-2 text-blue font-semibold"
-                  disabled={isPending}
-                  onClick={() => navigate('/brainstorming')}
-                >
-                  취소
-                </Button>
-              }
-              title="취소"
-              description="마인드맵 작성을 취소하시겠습니까?"
-              footer={
-                <div className="w-full flex items-center justify-end">
-                  <DialogClose asChild>
-                    <Button size="sm" className="bg-blue text-white">
-                      적용하기
-                    </Button>
-                  </DialogClose>
-                </div>
-              }
+            <Button
+              className="w-[139px] h-[48px] text-center rounded-4xl bg-blue-2 text-blue font-semibold"
+              disabled={isPending}
+              onClick={() => navigate('/brainstorming')}
             >
-              <div className="rounded-[7px] px-6 py-[20px] text-[20px] font-semibold bg-blue-2">
-                마인드맵 내용은 저장되지 않으며, 다시 확인할 수 없습니다.
-              </div>
-            </Modal>
-
+              취소
+            </Button>
             <Button
               onClick={handleRewriteBrainStorming}
               className="w-[139px] h-[48px] text-center rounded-4xl bg-blue text-white font-semibold"

--- a/frontend/src/layouts/DefaultLayout.tsx
+++ b/frontend/src/layouts/DefaultLayout.tsx
@@ -2,12 +2,9 @@ import { Outlet } from 'react-router';
 import Sidebar from '@/components/ui/sidebar/Sidebar';
 import Header from '@/components/ui/header/Header';
 import BottomBar from '@/components/ui/sidebar/BottomBar';
-import clsx from 'clsx';
-import { useResponsive } from '@/hooks/use-mobile.ts';
 import { Toaster } from '@/components/ui/sonner';
 
 export default function DefaultLayout() {
-  const isMobile = useResponsive();
   return (
     <div className="min-h-screen bg-[#F0F0F5] flex flex-col">
       <Header />

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -105,7 +105,12 @@ export default function MindmapPage() {
   }
 
   return (
-    <div className="relative w-full h-[calc(100vh-88px)]">
+    <div className="w-full h-[calc(100vh-88px)]">
+      <div
+        className="absolute left-0 top-0 w-screen h-screen
+        bg-blue-2"
+      ></div>
+
       <MindmapWrapper />
 
       <Dialog open={showExitDialog} onOpenChange={setShowExitDialog}>

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -105,10 +105,10 @@ export default function MindmapPage() {
   }
 
   return (
-    <div className="w-full h-[calc(100vh-88px)]">
+    <div className="w-full h-full">
       <div
         className="absolute left-0 top-0 w-screen h-screen
-        bg-blue-2"
+      bg-blue-2"
       ></div>
 
       <MindmapWrapper />

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -1,20 +1,85 @@
 import MindmapWrapper from '@/components/mindmap/MindmapWrapper';
 import useBrainStormingAnalyze from '@/hooks/queries/gpt/useBrainStormingAnalyze';
 import { BrainStormingAnalyzeReq } from '@/types/api/gpt';
-import { useEffect } from 'react';
-import { useSearchParams } from 'react-router';
+import { useEffect, useState, useCallback } from 'react';
+import { useSearchParams, useBlocker } from 'react-router';
 import { useMindmapStore } from '@/store/mindMapStore';
 import { MindmapSkeleton } from '@/components/mindmap/MindmapSkeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button';
+
+type Blocker = {
+  state: 'unblocked' | 'blocked' | 'proceeding';
+  proceed: () => void;
+  reset: () => void;
+};
+
+interface EnhancedBeforeUnloadEvent extends BeforeUnloadEvent {
+  returnValue: string;
+}
 
 export default function MindmapPage() {
   const [searchParams] = useSearchParams();
   const bubbleText = searchParams.get('text') || '';
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [showExitDialog, setShowExitDialog] = useState(false);
 
   const initializeWithQuestions = useMindmapStore(
     (state) => state.initializeWithQuestions,
   );
 
   const { analzeBrainStormingMutation, isPending } = useBrainStormingAnalyze();
+
+  const shouldBlock = useCallback(() => {
+    return isInitialized;
+  }, [isInitialized]);
+
+  const blocker = useBlocker(shouldBlock) as Blocker | undefined;
+
+  useEffect(() => {
+    if (blocker?.state === 'blocked') {
+      console.log('Navigation blocked, showing dialog');
+      setShowExitDialog(true);
+    }
+  }, [blocker]);
+
+  const handleProceed = useCallback(() => {
+    console.log('Proceeding with navigation');
+    setShowExitDialog(false);
+    blocker?.proceed();
+  }, [blocker]);
+
+  const handleCancel = useCallback(() => {
+    console.log('Canceling navigation');
+    setShowExitDialog(false);
+    blocker?.reset();
+  }, [blocker]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isInitialized) {
+        e.preventDefault();
+
+        const message = '현재 페이지를 벗어나면 마인드맵은 저장되지 않습니다.';
+
+        (e as EnhancedBeforeUnloadEvent).returnValue = message;
+
+        return message;
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isInitialized]);
 
   useEffect(() => {
     if (bubbleText) {
@@ -25,8 +90,8 @@ export default function MindmapPage() {
       analzeBrainStormingMutation(requestData, {
         onSuccess: (data) => {
           const questions = data.clarifying_questions || [];
-
           initializeWithQuestions(bubbleText, questions);
+          setIsInitialized(true);
         },
         onError: (err) => {
           console.error('API 오류:', err);
@@ -42,6 +107,33 @@ export default function MindmapPage() {
   return (
     <div className="relative w-full h-[calc(100vh-88px)]">
       <MindmapWrapper />
+
+      <Dialog open={showExitDialog} onOpenChange={setShowExitDialog}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>마인드맵 작성을 취소하시겠습니까?</DialogTitle>
+          </DialogHeader>
+          <div>
+            <div className="rounded-[7px] px-6 py-[20px] text-[20px] font-semibold bg-blue-2">
+              마인드맵 내용은 저장되지 않으며, 다시 확인할 수 없습니다.
+            </div>
+          </div>
+          <DialogFooter>
+            <div className="w-full flex items-center justify-end gap-3">
+              <Button
+                variant="outline"
+                onClick={handleCancel}
+                className="bg-white text-gray-700"
+              >
+                취소
+              </Button>
+              <Button onClick={handleProceed} className="bg-blue text-white">
+                확인
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -209,3 +209,7 @@ body {
 .float {
   animation: float 3s ease-in-out infinite;
 }
+
+.react-flow__attribution {
+  display: none !important;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #270 

## 📝 작업 내용
- 백스페이스하면 날라감
- 오른쪽 맨 위에 노드 내부 → 삭제
- 메인노드 수정+삭제 안되도록
- 마인드맵 페이지 벗어나면 경고창 (현재 페이지를 벗어나면 마인드맵은 저장되지 않는다)
- 브레인스토밍 화면처럼 전체 영역 배경 !!
- 빈 텍스트 있을 때 API 요청 안되도록!
- 오른쪽 아래 React Flow 버튼 안 보이게!!
