### PR TITLE
[BE] hotfix: 보관함 수정사항

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/inventory/dto/request/InventoryItemCreateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/dto/request/InventoryItemCreateRequest.java
@@ -11,7 +11,6 @@ public record InventoryItemCreateRequest(
     Long folderId,
 
     @NotBlank(message = "아이템 제목을 설정해주세요.")
-    @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다.")
     @Schema(description = "보관함 아이템 제목", example = "몸짱 되는 법")
     String title,
 

--- a/backend/src/main/java/capstone/backend/domain/inventory/dto/request/InventoryItemUpdateRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/dto/request/InventoryItemUpdateRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 
 public record InventoryItemUpdateRequest(
     @NotBlank(message = "제목은 비어있으면 안됩니다.")
-    @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다.")
     @Schema(description = "수정할 보관함 아이템 제목", example = "업데이트된 제목")
     String title,
 

--- a/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
@@ -6,12 +6,14 @@ import static lombok.AccessLevel.*;
 import capstone.backend.domain.inventory.dto.request.InventoryFolderRequest;
 import capstone.backend.domain.member.scheme.Member;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
@@ -34,6 +36,9 @@ public class InventoryFolder {
     @Column(nullable = false)
     private boolean isDefault;
 
+    @CreatedDate
+    private LocalDateTime createdAt;
+
     @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<InventoryItem> items = new ArrayList<>();
 
@@ -42,6 +47,7 @@ public class InventoryFolder {
             .member(member)
             .name(inventoryFolderRequest.name())
             .isDefault(isDefault)
+            .createdAt(LocalDateTime.now())
             .build();
     }
 

--- a/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
@@ -13,11 +13,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 public class InventoryFolder {
     @Id
@@ -35,7 +38,7 @@ public class InventoryFolder {
     @Column(nullable = false)
     private boolean isDefault;
 
-    @Column(nullable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -46,7 +49,6 @@ public class InventoryFolder {
             .member(member)
             .name(inventoryFolderRequest.name())
             .isDefault(isDefault)
-            .createdAt(LocalDateTime.now())
             .build();
     }
 

--- a/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryFolder.java
@@ -13,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
@@ -36,7 +35,7 @@ public class InventoryFolder {
     @Column(nullable = false)
     private boolean isDefault;
 
-    @CreatedDate
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryItem.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/entity/InventoryItem.java
@@ -4,6 +4,7 @@ import capstone.backend.domain.inventory.dto.request.InventoryItemCreateRequest;
 import capstone.backend.domain.member.scheme.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,12 +18,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class InventoryItem {
 
     @Id
@@ -52,7 +55,6 @@ public class InventoryItem {
             .folder(folder)
             .title(request.title())
             .memo(request.memo())
-            .createdAt(LocalDateTime.now())
             .build();
     }
 

--- a/backend/src/main/java/capstone/backend/domain/inventory/repository/InventoryFolderRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/repository/InventoryFolderRepository.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InventoryFolderRepository extends JpaRepository<InventoryFolder, Long> {
-    List<InventoryFolder> findAllByMemberId(Long memberId);
+    List<InventoryFolder> findAllByMemberIdOrderByCreatedAt(Long memberId);
     Optional<InventoryFolder> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/backend/src/main/java/capstone/backend/domain/inventory/repository/InventoryItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/repository/InventoryItemRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InventoryItemRepository extends JpaRepository<InventoryItem, Long> {
-    Page<InventoryItemResponse> findByMemberIdAndFolderId(Long memberId, Long folderId, Pageable pageable);
+    Page<InventoryItemResponse> findByMemberIdAndFolderIdOrderByCreatedAt(Long memberId, Long folderId, Pageable pageable);
     InventoryItemResponse findByMemberIdAndId(Long memberId, Long inventoryId);
     Optional<InventoryItem> findByIdAndMemberId(Long inventoryId, Long memberId);
     List<InventoryItemResponse> findTop5ByMemberIdOrderByCreatedAtDesc(Long memberId);

--- a/backend/src/main/java/capstone/backend/domain/inventory/service/InventoryFolderService.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/service/InventoryFolderService.java
@@ -9,6 +9,7 @@ import capstone.backend.domain.inventory.dto.response.InventoryFolderResponse;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,7 @@ public class InventoryFolderService {
 
     //폴더 조회
     public List<InventoryFolderResponse> getInventoryFolders(Long memberId){
-        return inventoryFolderRepository.findAllByMemberId(memberId)
+        return inventoryFolderRepository.findAllByMemberIdOrderByCreatedAt(memberId)
             .stream()
             .map(InventoryFolderResponse::from)
             .toList();
@@ -81,6 +82,7 @@ public class InventoryFolderService {
             .name("기본 폴더")
             .member(member)
             .isDefault(true)
+            .createdAt(LocalDateTime.now())
             .build();
         inventoryFolderRepository.save(defaultFolder);
     }

--- a/backend/src/main/java/capstone/backend/domain/inventory/service/InventoryItemService.java
+++ b/backend/src/main/java/capstone/backend/domain/inventory/service/InventoryItemService.java
@@ -41,7 +41,7 @@ public class InventoryItemService {
 
     //보관함 조회
     public Page<InventoryItemResponse> getInventoryItems(Long folderId, Long memberId, Pageable pageable) {
-        return inventoryItemRepository.findByMemberIdAndFolderId(memberId, folderId, pageable);
+        return inventoryItemRepository.findByMemberIdAndFolderIdOrderByCreatedAt(memberId, folderId, pageable);
     }
 
     //보관함 아이템 상세 조회


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #284 

## 📝 작업 내용

- 보관함 아이템 생성 시 제목의 글자 수 20글자 제한을 걸지 않도록 수정했습니다.
- 보관함 폴더 속, 아이템 조회 시 orderby createdAt 했습니다.
- 보관함 폴더 조회 시 orderby createdAt 했습니다.
