### PR TITLE
[FE] qa 추가 수정 사항

### DIFF
--- a/frontend/src/components/eisenhower/card/TaskCard.tsx
+++ b/frontend/src/components/eisenhower/card/TaskCard.tsx
@@ -141,7 +141,7 @@ export function TaskCard({
         <div className="absolute p-2 top-1 right-1 flex gap-2">
           {variant === 'default' && (
             <div className="opacity-0 group-hover:opacity-100 transition-opacity flex gap-2 items-center">
-              <div onClick={(e) => e.stopPropagation()}>
+              {/* <div onClick={(e) => e.stopPropagation()}>
                 <EisenhowerAi
                   trigger={
                     <div className="text-[#6E726E] hover:text-gray-600 transition-colors">
@@ -150,7 +150,7 @@ export function TaskCard({
                   }
                   linkedEisenhower={task}
                 />
-              </div>
+              </div> */}
 
               <div onClick={(e) => e.stopPropagation()}>
                 <Modal

--- a/frontend/src/components/eisenhower/card/TaskCard.tsx
+++ b/frontend/src/components/eisenhower/card/TaskCard.tsx
@@ -23,7 +23,8 @@ import { Button } from '@/components/ui/button.tsx';
 import { DialogClose } from '@radix-ui/react-dialog';
 import EisenhowerAi from '@/components/ui/Modal/EisenhowerAi.tsx';
 import { todayService } from '@/services/todayService.ts';
-import {showToast} from "@/components/common/Toast.tsx";
+import { showToast } from '@/components/common/Toast.tsx';
+import useCreateTodayTask from '@/hooks/queries/today/useCreateTodayTask';
 
 type TaskCardVariant = 'default' | 'inactive' | 'done';
 
@@ -63,6 +64,8 @@ export function TaskCard({
     isDragging,
   } = useSortable({ id, data: { ...task } });
 
+  const { createTodoTaskMutation } = useCreateTodayTask();
+
   const style = { transform: CSS.Transform.toString(transform), transition };
 
   const handleClick = (e: MouseEvent) => {
@@ -90,11 +93,28 @@ export function TaskCard({
         // toast.success(
         //   wasCompleted ? '완료를 취소했습니다' : '할 일을 완료했습니다',
         // );
-        showToast('success',  wasCompleted ? '완료를 취소했습니다' : '할 일을 완료했습니다');
+        showToast(
+          'success',
+          wasCompleted ? '완료를 취소했습니다' : '할 일을 완료했습니다',
+        );
       } catch (err) {
         console.error('완료 상태 업데이트 실패:', err);
       }
     }
+  };
+
+  const handleCreateTodayTask = (id: number) => {
+    createTodoTaskMutation(id, {
+      onSuccess: (data) => {
+        if (data.statusCode === 500) {
+          showToast('error', `${data.error}`);
+
+          return;
+        }
+
+        showToast('success', '오늘의 할 일에 추가했어요!');
+      },
+    });
   };
 
   return (
@@ -146,15 +166,7 @@ export function TaskCard({
                     <DialogClose asChild>
                       <Button
                         variant="blue"
-                        onClick={async () => {
-                          try {
-                            await todayService.createTodayTask(task.id);
-                            toast.success('오늘의 할 일에 추가했어요!');
-                          } catch (err) {
-                            console.error('오늘의 할 일 추가 실패:', err);
-                            toast.error('추가에 실패했습니다');
-                          }
-                        }}
+                        onClick={() => handleCreateTodayTask(task.id)}
                       >
                         추가하기
                       </Button>

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -10,7 +10,6 @@ import '@xyflow/react/dist/style.css';
 import CustomNode from '@/components/mindmap/CustomNode';
 import { Button } from '@/components/ui/button';
 import { DialogClose } from '@radix-ui/react-dialog';
-import { Modal } from '@/components/common/Modal';
 import {
   Dialog,
   DialogContent,
@@ -37,7 +36,11 @@ const flowStyles = {
   background: '#E8EFFF',
 };
 
-function FlowContent() {
+interface FlowContentProps {
+  onCompletedSuccessfully?: () => void;
+}
+
+function FlowContent({ onCompletedSuccessfully }: FlowContentProps) {
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const bubbleText = searchParams.get('text') || '';
@@ -93,7 +96,12 @@ function FlowContent() {
         },
         {
           onSuccess: () => {
-            navigate('/brainstorming');
+            if (onCompletedSuccessfully) {
+              onCompletedSuccessfully();
+            }
+            setTimeout(() => {
+              navigate('/brainstorming');
+            }, 50);
           },
         },
       );
@@ -173,10 +181,14 @@ function FlowContent() {
   );
 }
 
-function MindmapWrapper() {
+interface MindmapWrapperProps {
+  onCompletedSuccessfully?: () => void;
+}
+
+function MindmapWrapper({ onCompletedSuccessfully }: MindmapWrapperProps) {
   return (
     <ReactFlowProvider>
-      <FlowContent />
+      <FlowContent onCompletedSuccessfully={onCompletedSuccessfully} />
     </ReactFlowProvider>
   );
 }

--- a/frontend/src/components/mindmap/MindmapWrapper.tsx
+++ b/frontend/src/components/mindmap/MindmapWrapper.tsx
@@ -65,7 +65,23 @@ function FlowContent({ onCompletedSuccessfully }: FlowContentProps) {
       return;
     }
 
-    const mindmapData = nodes.map((node) => ({
+    const defaultQuestionNodeIds = ['node-1', 'node-2', 'node-3', 'node-4'];
+
+    const nodesWithChildren = new Set<string>();
+
+    edges.forEach((edge) => {
+      nodesWithChildren.add(edge.source);
+    });
+
+    const filteredNodes = nodes.filter((node) => {
+      if (defaultQuestionNodeIds.includes(node.id)) {
+        return nodesWithChildren.has(node.id);
+      }
+
+      return true;
+    });
+
+    const mindmapData = filteredNodes.map((node) => ({
       context: String(node.data.label || ''),
     }));
 

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -16,7 +16,9 @@ interface TodayListProps {
   hideCompleted?: boolean;
 }
 
-function formatDateToEnglish(dateString: string): string {
+function formatDateToEnglish(dateString: string | null): string {
+  if (!dateString) return '날짜 없음';
+
   if (typeof dateString === 'string') {
     const [yearStr, monthStr, dayStr] = dateString.split('-');
 
@@ -25,6 +27,10 @@ function formatDateToEnglish(dateString: string): string {
     const day = parseInt(dayStr, 10);
 
     const date = new Date(year, month - 1, day);
+    if (isNaN(date.getTime())) {
+      return '날짜 없음';
+    }
+
     return date.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
@@ -32,7 +38,7 @@ function formatDateToEnglish(dateString: string): string {
     });
   }
 
-  return '';
+  return '날짜 없음';
 }
 
 export default function TodayList({ hideCompleted = false }: TodayListProps) {
@@ -110,6 +116,18 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
     );
   };
 
+  // 날짜 표시 함수
+  const renderDate = (dueDate: string | null | undefined) => {
+    return (
+      <div className="px-6 flex items-center gap-2">
+        <Calendar size={24} />
+        <p className="text-[14px] text-[#525463]">
+          {formatDateToEnglish(dueDate || null)}
+        </p>
+      </div>
+    );
+  };
+
   return (
     <div className="mt-4 space-y-4">
       {yesterdayTodoList &&
@@ -126,12 +144,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
               {todo.title}
             </p>
             <p className="px-6 text-[14px] text-[#858899]">{todo.memo}</p>
-            <div className="px-6 flex items-center gap-2">
-              <Calendar size={24} />
-              <p className="text-[14px] text-[#525463]">
-                {formatDateToEnglish(todo.dueDate)}
-              </p>
-            </div>
+            {renderDate(todo.dueDate)}
             <div className="flex justify-end mb-5 px-6">
               <button
                 className="px-4 py-2 rounded-full bg-white text-blue font-semibold cursor-pointer"
@@ -173,12 +186,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
             </p>
             <p className="px-6 text-[14px] text-[#858899]">{todo.memo}</p>
           </div>
-          <div className="px-6 flex items-center gap-2">
-            <Calendar size={24} />
-            <p className="text-[14px] text-[#525463]">
-              {formatDateToEnglish(todo.dueDate)}
-            </p>
-          </div>
+          {renderDate(todo.dueDate)}
           <div className="flex justify-end mb-5 px-6">
             <button
               className={cn(

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -145,7 +145,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
             </p>
             <p className="px-6 text-[14px] text-[#858899]">{todo.memo}</p>
             {renderDate(todo.dueDate)}
-            <div className="flex justify-end mb-5 px-6">
+            <div className="flex justify-end px-6">
               <button
                 className="px-4 py-2 rounded-full bg-white text-blue font-semibold cursor-pointer"
                 onClick={() => handleMoveToToday(todo.id)}
@@ -187,7 +187,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
             <p className="px-6 text-[14px] text-[#858899]">{todo.memo}</p>
           </div>
           {renderDate(todo.dueDate)}
-          <div className="flex justify-end mb-5 px-6">
+          <div className="flex justify-end px-6">
             <button
               className={cn(
                 'px-4 py-2 rounded-full text-white font-semibold cursor-pointer',

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -6,12 +6,11 @@ import { cn } from '@/lib/utils';
 import { Calendar, Trash2 } from 'lucide-react';
 import { usePomodoroStore } from '@/store/pomodoro';
 import usePatchPomodoro from '@/hooks/queries/pomodoro/usePatchPomodoro.ts';
-import { toast } from 'sonner';
 import useUpdateStatusTodo from '@/hooks/queries/today/useUpdateStatusTodo';
 import useDeleteTodayTodo from '@/hooks/queries/today/useDeleteTodayTodo';
 import CheckIcon from '@/assets/check.svg';
 import CheckFillIcon from '@/assets/check-fill.svg';
-import {showToast} from "@/components/common/Toast.tsx";
+import { showToast } from '@/components/common/Toast.tsx';
 
 interface TodayListProps {
   hideCompleted?: boolean;
@@ -73,9 +72,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
         onSuccess: () => {
           if (newCompletedState) {
             showToast('success', `"${title}"을(를) 완료했습니다`);
-            // toast.success(`"${title}"을(를) 완료했습니다`);
           } else {
-            // toast.info(`"${title}"을(를) 미완료 상태로 변경했습니다`);
             showToast('success', `"${title}"을(를) 미완료 상태로 변경했습니다`);
           }
         },
@@ -86,7 +83,6 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
   const handleDeleteTask = (id: number, title: string) => {
     deleteTodayTodoMutation(id, {
       onSuccess: () => {
-        // toast.success(`"${title}"을 오늘의 할 일에서 삭제했습니다.`);
         showToast('success', `"${title}"을 오늘의 할 일에서 삭제했습니다.`);
       },
     });
@@ -98,6 +94,22 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
       : todayTodoList
     : [];
 
+  const renderCategoryBadge = (categoryId: number | string) => {
+    const categoryName = getCategoryNameById(categoryId);
+
+    if (!categoryName) {
+      return (
+        <div className="invisible h-[30px] w-[80px]" aria-hidden="true"></div>
+      );
+    }
+
+    return (
+      <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
+        {categoryName}
+      </div>
+    );
+  };
+
   return (
     <div className="mt-4 space-y-4">
       {yesterdayTodoList &&
@@ -107,9 +119,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
             className="flex flex-col gap-4 py-5 rounded-lg bg-gray-scale-200"
           >
             <div className="px-5 flex items-center justify-between">
-              <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
-                {getCategoryNameById(todo.category_id)}
-              </div>
+              {renderCategoryBadge(todo.category_id)}
               <img src={CheckIcon} className="w-6 h-6 cursor-pointer" />
             </div>
             <p className="px-6 text-[20px] text-[#525463] font-semibold">
@@ -140,9 +150,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
           className="flex flex-col gap-4 py-5 rounded-lg bg-white border border-blue"
         >
           <div className="px-5 flex items-center justify-between">
-            <div className="px-3 py-[6px] bg-blue-2 text-gray-scale-900 inline-block rounded-full">
-              {getCategoryNameById(todo.category_id)}
-            </div>
+            {renderCategoryBadge(todo.category_id)}
             <div className="flex items-center gap-2">
               <Trash2
                 className="cursor-pointer text-gray-400 hover:text-red-500"

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -11,6 +11,7 @@ import useDeleteTodayTodo from '@/hooks/queries/today/useDeleteTodayTodo';
 import CheckIcon from '@/assets/check.svg';
 import CheckFillIcon from '@/assets/check-fill.svg';
 import { showToast } from '@/components/common/Toast.tsx';
+import { useNavigate } from 'react-router';
 
 interface TodayListProps {
   hideCompleted?: boolean;
@@ -50,6 +51,8 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
   const { patchPomodoroMutation } = usePatchPomodoro();
   const { updateStatusMutation } = useUpdateStatusTodo();
   const { deleteTodayTodoMutation } = useDeleteTodayTodo();
+
+  const navigate = useNavigate();
 
   const handleMoveToToday = (id: number) => {
     moveTodayMutation(id);
@@ -92,6 +95,10 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
         showToast('success', `"${title}"을 오늘의 할 일에서 삭제했습니다.`);
       },
     });
+  };
+
+  const handleRouteToEisenhower = () => {
+    navigate('/matrix');
   };
 
   const filteredTodayTodoList = todayTodoList
@@ -211,7 +218,10 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
               ? '완료되지 않은 일이 없어요'
               : '아직 오늘의 할 일이 없어요'}
           </p>
-          <p className="text-[14px] text-[#525463] mt-2 cursor-pointer hover:text-blue">
+          <p
+            className="text-[14px] text-[#525463] mt-2 cursor-pointer hover:text-blue"
+            onClick={handleRouteToEisenhower}
+          >
             오늘의 할 일 추가하기 {'>'}
           </p>
         </div>

--- a/frontend/src/components/today/TodayMainDashborad.tsx
+++ b/frontend/src/components/today/TodayMainDashborad.tsx
@@ -8,7 +8,7 @@ import { usePomodoroStore } from '@/store/pomodoro.ts';
 import { useState } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { useNavigate } from 'react-router';
-import { PomodoroCompletionChart } from '@/components/ui/chart/PomodoroCompletionChar';
+import { PomodoroCompletionChart } from '@/components/ui/chart/PomodoroCompletionChart';
 import PlusIcon from '@/assets/plus.svg';
 
 export default function TodayMainDashborad() {

--- a/frontend/src/components/ui/chart/DailyCompletionChart.tsx
+++ b/frontend/src/components/ui/chart/DailyCompletionChart.tsx
@@ -113,6 +113,17 @@ export function DailyCompletionChart({ title }: DailyCompletionChartProps) {
                 <ChartTooltip
                   cursor={false}
                   content={<ChartTooltipContent hideLabel />}
+                  formatter={(value) => {
+                    return (
+                      <div className="flex items-center gap-2">
+                        <div className="w-2.5 h-2.5 bg-blue" />
+                        <p>
+                          <span className="mr-2 text-gray-700">완료한 일</span>
+                          <span className="font-semibold">{value}개</span>
+                        </p>
+                      </div>
+                    );
+                  }}
                 />
                 <Bar dataKey="completedNum" fill="#7098ff" radius={8}></Bar>
               </BarChart>

--- a/frontend/src/components/ui/chart/PomodoroCompletionChart.tsx
+++ b/frontend/src/components/ui/chart/PomodoroCompletionChart.tsx
@@ -76,7 +76,7 @@ export function PomodoroCompletionChart({
 
     const dataMap = new Map();
     pomodoroAnalysisList.forEach((item) => {
-      dataMap.set(item.dayOfWeek, parseInt(item.totalTime, 10) || 0);
+      dataMap.set(item.dayOfWeek, item.totalTime);
     });
 
     return result.map((item) => {
@@ -89,6 +89,19 @@ export function PomodoroCompletionChart({
       return item;
     });
   }, [pomodoroAnalysisList]);
+
+  const formatTimeFromSeconds = (totalSeconds: number): string => {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    let formattedTime = '';
+    if (hours > 0) formattedTime += `${hours}h `;
+    if (minutes > 0 || hours > 0) formattedTime += `${minutes}m `;
+    if (seconds > 0) formattedTime += `${seconds}s`;
+
+    return formattedTime.trim() || '0s';
+  };
 
   return (
     <Card className="h-full w-full border-none shadow-none rounded-2xl px-6 py-4">
@@ -124,6 +137,21 @@ export function PomodoroCompletionChart({
                 <ChartTooltip
                   cursor={false}
                   content={<ChartTooltipContent hideLabel />}
+                  formatter={(value: number) => {
+                    return (
+                      <div className="flex items-center gap-2">
+                        <div className="w-2.5 h-2.5 bg-blue" />
+                        <p>
+                          <span className="mr-2 text-gray-700">
+                            집중한 시간
+                          </span>
+                          <span className="font-semibold">
+                            {value ? formatTimeFromSeconds(value) : '0s'}
+                          </span>
+                        </p>
+                      </div>
+                    );
+                  }}
                 />
                 <Bar dataKey="totalTime" fill="#7098ff" radius={8}></Bar>
               </BarChart>

--- a/frontend/src/hooks/queries/category/useGetCategoryList.ts
+++ b/frontend/src/hooks/queries/category/useGetCategoryList.ts
@@ -13,24 +13,24 @@ const useGetCategoryList = () => {
 
   const getCategoryNameById = (id: number | string) => {
     if (!data?.content || data.content.length === 0) {
-      return '기타';
+      return null;
     }
 
     const category = data.content.find(
       (cat) => cat.id === id || cat.id === Number(id),
     );
-    return category ? category.title : '기타';
+    return category ? category.title : null;
   };
 
   const getCategoryColorById = (id: number | string) => {
     if (!data?.content || data.content.length === 0) {
-      return '#e2e8f0'; // 기본 색상
+      return null;
     }
 
     const category = data.content.find(
       (cat) => cat.id === id || cat.id === Number(id),
     );
-    return category?.color || '#e2e8f0';
+    return category?.color || null;
   };
 
   return {

--- a/frontend/src/hooks/queries/today/useCreateTodayTask.ts
+++ b/frontend/src/hooks/queries/today/useCreateTodayTask.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { todayService } from '@/services/todayService';
+
+const useCreateTodayTask = () => {
+  const { mutate, isPending, isError, error, data, reset } = useMutation({
+    mutationFn: (id: number) => todayService.createTodayTask(id),
+  });
+
+  return {
+    createTodoTaskMutation: mutate,
+    isPending,
+    isError,
+    error,
+    data,
+    reset,
+  };
+};
+
+export default useCreateTodayTask;

--- a/frontend/src/pages/mindmap.tsx
+++ b/frontend/src/pages/mindmap.tsx
@@ -29,6 +29,7 @@ export default function MindmapPage() {
   const bubbleText = searchParams.get('text') || '';
   const [isInitialized, setIsInitialized] = useState(false);
   const [showExitDialog, setShowExitDialog] = useState(false);
+  const [isCompletedSuccessfully, setIsCompletedSuccessfully] = useState(false);
 
   const initializeWithQuestions = useMindmapStore(
     (state) => state.initializeWithQuestions,
@@ -37,8 +38,8 @@ export default function MindmapPage() {
   const { analzeBrainStormingMutation, isPending } = useBrainStormingAnalyze();
 
   const shouldBlock = useCallback(() => {
-    return isInitialized;
-  }, [isInitialized]);
+    return isInitialized && !isCompletedSuccessfully;
+  }, [isInitialized, isCompletedSuccessfully]);
 
   const blocker = useBlocker(shouldBlock) as Blocker | undefined;
 
@@ -63,7 +64,7 @@ export default function MindmapPage() {
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (isInitialized) {
+      if (isInitialized && !isCompletedSuccessfully) {
         e.preventDefault();
 
         const message = '현재 페이지를 벗어나면 마인드맵은 저장되지 않습니다.';
@@ -79,7 +80,7 @@ export default function MindmapPage() {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [isInitialized]);
+  }, [isInitialized, isCompletedSuccessfully]);
 
   useEffect(() => {
     if (bubbleText) {
@@ -111,7 +112,9 @@ export default function MindmapPage() {
       bg-blue-2"
       ></div>
 
-      <MindmapWrapper />
+      <MindmapWrapper
+        onCompletedSuccessfully={() => setIsCompletedSuccessfully(true)}
+      />
 
       <Dialog open={showExitDialog} onOpenChange={setShowExitDialog}>
         <DialogContent className="sm:max-w-lg">
@@ -125,13 +128,10 @@ export default function MindmapPage() {
           </div>
           <DialogFooter>
             <div className="w-full flex items-center justify-end gap-3">
-              <Button
-                variant="outline"
-                onClick={handleCancel}
-              >
+              <Button variant="outline" onClick={handleCancel}>
                 취소
               </Button>
-              <Button onClick={handleProceed} variant='blue'>
+              <Button onClick={handleProceed} variant="blue">
                 확인
               </Button>
             </div>

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -8,5 +8,6 @@ export type TodayTaskAnalysis = {
 export type PomodoroAnalysis = {
   dailyPomodoroSummaryId: number;
   createdAt: string;
+  dayOfWeek: string;
   totalTime: string;
 };

--- a/frontend/src/types/analysis.ts
+++ b/frontend/src/types/analysis.ts
@@ -9,5 +9,5 @@ export type PomodoroAnalysis = {
   dailyPomodoroSummaryId: number;
   createdAt: string;
   dayOfWeek: string;
-  totalTime: string;
+  totalTime: number;
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #286

## 📝 작업 내용
- [x]  오늘의 할 일 중복으로 추가 안된다고 알려줘야함
- [x]  아이젠하워에서 카테고리 없는 경우에 오늘의 할 일로 추가하면 오늘의 할 일에서는 기타 카테고리라고 뜸
- [x]  오늘의 할 일에서, 마감일 없는 경우에 날짜 없음으로 보여주기
- [x]  오늘의 할 일에서 카드 버튼 밑에 잇는 margin 제거
- [x]  더미데이터로 도표 UI 확인해보기
- [x]  마인드맵 적용하기 클릭하면 나가는 창이 뜸
- [x]  마인드맵 노드 겹침 문제 해결

