### PR TITLE
fix: 아이젠하워 카테고리 삭제 시 연관된 작업의 카테고리 null 처리

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerItem.java
@@ -108,4 +108,8 @@ public class EisenhowerItem {
     public void setCompletedStatus(boolean isCompleted){
         this.isCompleted = isCompleted;
     }
+
+    public void deleteCategory() {
+        this.category = null;
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerItemRepository.java
@@ -15,4 +15,5 @@ public interface EisenhowerItemRepository extends JpaRepository<EisenhowerItem, 
 
     List<EisenhowerItem> findAllByDueDateAndIsCompleted(LocalDate today, boolean isCompleted);
 
+    List<EisenhowerItem> findAllByMemberIdAndCategoryId(Long memberId, Long categoryId);
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerCategoryService.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerCategoryService.java
@@ -4,8 +4,10 @@ import capstone.backend.domain.eisenhower.dto.request.EisenhowerCategoryCreateRe
 import capstone.backend.domain.eisenhower.dto.response.EisenhowerCategoryResponse;
 import capstone.backend.domain.eisenhower.dto.request.EisenhowerCategoryUpdateRequest;
 import capstone.backend.domain.eisenhower.entity.EisenhowerCategory;
+import capstone.backend.domain.eisenhower.entity.EisenhowerItem;
 import capstone.backend.domain.eisenhower.exception.CategoryNotFoundException;
 import capstone.backend.domain.eisenhower.repository.EisenhowerCategoryRepository;
+import capstone.backend.domain.eisenhower.repository.EisenhowerItemRepository;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
@@ -21,6 +23,7 @@ public class EisenhowerCategoryService {
 
     private final EisenhowerCategoryRepository eisenhowerCategoryRepository;
     private final MemberRepository memberRepository;
+    private final EisenhowerItemRepository eisenhowerItemRepository;
 
     public List<EisenhowerCategoryResponse> getEisenhowerCategories(Long memberId) {
         return eisenhowerCategoryRepository.findAllByMemberId(memberId)
@@ -55,6 +58,12 @@ public class EisenhowerCategoryService {
     public void deleteEisenhowerCategory(Long memberId, Long categoryId) {
         EisenhowerCategory eisenhowerCategory = eisenhowerCategoryRepository.findByIdAndMemberId(categoryId, memberId)
                 .orElseThrow(CategoryNotFoundException::new);
+
+        List<EisenhowerItem> items = eisenhowerItemRepository.findAllByMemberIdAndCategoryId(memberId, categoryId);
+
+        for (EisenhowerItem item : items) {
+            item.deleteCategory();
+        }
 
         eisenhowerCategoryRepository.delete(eisenhowerCategory);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #299 

## 📝 작업 내용

- 아이젠하워 카테고리 삭제 시 연관된 작업의 카테고리 null 처리

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
