### PR TITLE
[FE] 추가 QA 사항 처리

### DIFF
--- a/frontend/src/components/eisenhower/card/TaskCard.tsx
+++ b/frontend/src/components/eisenhower/card/TaskCard.tsx
@@ -199,45 +199,47 @@ export function TaskCard({
           </div>
         </div>
 
-        {/* 카테고리 */}
-        {category && (
-          <div className="flex mb-2 flex-wrap">
-            <CategoryBadge label={category.title} bgColor={category.color} />
-          </div>
-        )}
-
-        <div className="flex items-center mb-2 flex-grow">
-          <div
-            className={cn(
-              'text-md font-medium line-clamp-2',
-              variant === 'done' ? 'text-gray-500' : 'text-black',
-            )}
-          >
-            {title}
-          </div>
-        </div>
-
-        {/* 메모 */}
-        <div className="text-xs mb-2 line-clamp-2 text-[#858899] ">
-          {memo ? memo : <>비어 있음</>}
-        </div>
-
-        {/* 마감일 */}
-        <div className="text-xs flex items-center mt-auto text-[#525463] ">
-          {dueDate ? (
-            <div className="flex">
-              <Calendar className="w-4 h-4 mr-1 text-blue" />
-              <span className="text-center pt-[1px] text-xs">
-                {dueDate}
-                {/*{format(new Date(dueDate), 'yyyy.MM.dd')}*/}
-              </span>
-            </div>
-          ) : (
-            <div className="flex">
-              <Calendar className="w-4 h-4 mr-1 text-blue" />
-              <span className="text-center pt-[1px] text-xs">날짜 없음</span>
+        <div className="pr-16">
+          {/* 카테고리 */}
+          {category && (
+            <div className="flex mb-2 flex-wrap">
+              <CategoryBadge label={category.title} bgColor={category.color} />
             </div>
           )}
+
+          <div className="flex items-center mb-2 flex-grow">
+            <div
+              className={cn(
+                'text-md font-medium line-clamp-2',
+                variant === 'done' ? 'text-gray-500' : 'text-black',
+              )}
+            >
+              {title}
+            </div>
+          </div>
+
+          {/* 메모 */}
+          <div className="text-xs mb-2 line-clamp-2 text-[#858899] ">
+            {memo ? memo : <>비어 있음</>}
+          </div>
+
+          {/* 마감일 */}
+          <div className="text-xs flex items-center mt-auto text-[#525463] ">
+            {dueDate ? (
+              <div className="flex">
+                <Calendar className="w-4 h-4 mr-1 text-blue" />
+                <span className="text-center pt-[1px] text-xs">
+                  {dueDate}
+                  {/*{format(new Date(dueDate), 'yyyy.MM.dd')}*/}
+                </span>
+              </div>
+            ) : (
+              <div className="flex">
+                <Calendar className="w-4 h-4 mr-1 text-blue" />
+                <span className="text-center pt-[1px] text-xs">날짜 없음</span>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/inventory/modal/MoveToFolderModal.tsx
+++ b/frontend/src/components/inventory/modal/MoveToFolderModal.tsx
@@ -11,8 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import useGetInventoryFolderList from '@/hooks/queries/inventory/folder/useGetInventoryFolderList';
 import useMoveInventoryItem from '@/hooks/queries/inventory/item/useMoveInventoryItem';
-import { toast } from 'sonner';
-import {showToast} from "@/components/common/Toast.tsx";
+import { showToast } from '@/components/common/Toast.tsx';
 
 type MoveToFolderModalProps = {
   isOpen: boolean;
@@ -55,8 +54,10 @@ export default function MoveToFolderModal({
         onSuccess: () => {
           onOpenChange(false);
           setSelectedFolderId(null);
-          showToast('success',`"${item.title}" 항목이 성공적으로 이동되었습니다.`)
-          // toast.success(`"${item.title}" 항목이 성공적으로 이동되었습니다.`);
+          showToast(
+            'success',
+            `"${item.title}" 항목이 성공적으로 이동되었습니다.`,
+          );
         },
       },
     );

--- a/frontend/src/components/today/ReminderList.tsx
+++ b/frontend/src/components/today/ReminderList.tsx
@@ -20,9 +20,7 @@ export default function ReminderList() {
   return (
     <div className="w-full mb-6 flex flex-col gap-2 md:gap-[17px] ">
       <div className="flex items-center gap-4 mb-2 ml-2  md:ml-2">
-        <h4 className="text-[20px] text-[#525463] font-semibold">
-          리마인더
-        </h4>
+        <h4 className="text-[20px] text-[#525463] font-semibold">리마인더</h4>
         <p
           className="text-blue text-[14px] cursor-pointer"
           onClick={handleRouteToInventory}
@@ -41,10 +39,10 @@ export default function ReminderList() {
                 style={{ width: '16rem' }}
                 onClick={() => handleClickReminder(remind.folderId, remind.id)}
               >
-                <h3 className="text-[16px] md:text-[20px] text-[#525463] font-semibold">
+                <h3 className="text-[16px] md:text-[20px] text-[#525463] font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
                   {remind.title}
                 </h3>
-                <p className="text-[14px] md:text-[16px] text-gray-scale-500">
+                <p className="text-[14px] md:text-[16px] text-gray-scale-500 whitespace-nowrap overflow-hidden text-ellipsis">
                   {remind.memo || '입력된 메모가 없습니다'}
                 </p>
               </div>

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -2,253 +2,249 @@ import useGetCategoryList from '@/hooks/queries/category/useGetCategoryList';
 import useGetTodayTodoList from '@/hooks/queries/today/useGetTodayTodoList';
 import useGetYesterdayTodoList from '@/hooks/queries/today/useGetYesterdayTodoList';
 import useMoveToday from '@/hooks/queries/today/useMoveToday';
-import {cn} from '@/lib/utils';
-import {Calendar, Trash2} from 'lucide-react';
-import {usePomodoroStore} from '@/store/pomodoro';
+import { cn } from '@/lib/utils';
+import { Calendar, Trash2 } from 'lucide-react';
+import { usePomodoroStore } from '@/store/pomodoro';
 import usePatchPomodoro from '@/hooks/queries/pomodoro/usePatchPomodoro.ts';
 import useUpdateStatusTodo from '@/hooks/queries/today/useUpdateStatusTodo';
 import useDeleteTodayTodo from '@/hooks/queries/today/useDeleteTodayTodo';
 import CheckIcon from '@/assets/check.svg';
 import CheckFillIcon from '@/assets/check-fill.svg';
-import {showToast} from '@/components/common/Toast.tsx';
-import {useNavigate} from 'react-router';
+import { showToast } from '@/components/common/Toast.tsx';
+import { useNavigate } from 'react-router';
 
 interface TodayListProps {
-    hideCompleted?: boolean;
+  hideCompleted?: boolean;
 }
 
 function formatDateToEnglish(dateString: string | null): string {
-    if (!dateString) return '날짜 없음';
+  if (!dateString) return '날짜 없음';
 
-    if (typeof dateString === 'string') {
-        const [yearStr, monthStr, dayStr] = dateString.split('-');
+  if (typeof dateString === 'string') {
+    const [yearStr, monthStr, dayStr] = dateString.split('-');
 
-        const year = parseInt(yearStr, 10);
-        const month = parseInt(monthStr, 10);
-        const day = parseInt(dayStr, 10);
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    const day = parseInt(dayStr, 10);
 
-        const date = new Date(year, month - 1, day);
-        if (isNaN(date.getTime())) {
-            return '날짜 없음';
-        }
-
-        return date.toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric',
-        });
+    const date = new Date(year, month - 1, day);
+    if (isNaN(date.getTime())) {
+      return '날짜 없음';
     }
 
-    return '날짜 없음';
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  return '날짜 없음';
 }
 
-export default function TodayList({hideCompleted = false}: TodayListProps) {
-    const {todayTodoList} = useGetTodayTodoList();
-    const {yesterdayTodoList} = useGetYesterdayTodoList();
+export default function TodayList({ hideCompleted = false }: TodayListProps) {
+  const { todayTodoList } = useGetTodayTodoList();
+  const { yesterdayTodoList } = useGetYesterdayTodoList();
 
-    const {getCategoryNameById} = useGetCategoryList();
-    const {moveTodayMutation, isPending} = useMoveToday();
-    const {patchPomodoroMutation} = usePatchPomodoro();
-    const {updateStatusMutation} = useUpdateStatusTodo();
-    const {deleteTodayTodoMutation} = useDeleteTodayTodo();
+  const { getCategoryNameById } = useGetCategoryList();
+  const { moveTodayMutation, isPending } = useMoveToday();
+  const { patchPomodoroMutation } = usePatchPomodoro();
+  const { updateStatusMutation } = useUpdateStatusTodo();
+  const { deleteTodayTodoMutation } = useDeleteTodayTodo();
 
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const handleMoveToToday = (id: number) => {
-        moveTodayMutation(id);
-    };
+  const handleMoveToToday = (id: number) => {
+    moveTodayMutation(id);
+  };
 
-    const setTimer = usePomodoroStore((s) => s.setTimer);
-    const currentId = usePomodoroStore((s) => s.id);
-    const handleDelete = (id: number, title: string) => {
-        if (currentId) {
-            if (currentId === id) {
+  const setTimer = usePomodoroStore((s) => s.setTimer);
+  const currentId = usePomodoroStore((s) => s.id);
+  const handleDelete = (id: number, title: string) => {
+    if (currentId) {
+      if (currentId === id) {
+        return;
+      } else {
+        showToast('error', '이미 진행 중인 뽀모도로가 있습니다.');
+        return;
+      }
+    }
+    setTimer(id, title, patchPomodoroMutation);
+  };
 
-                return;
-            } else {
-                showToast('error', '이미 진행 중인 뽀모도로가 있습니다.');
-                return;
-            }
+  const handleCompleteTask = (
+    id: number,
+    isCompleted: boolean,
+    title: string,
+  ) => {
+    const newCompletedState = !isCompleted;
+
+    updateStatusMutation(
+      {
+        id,
+        data: {
+          isCompleted: newCompletedState,
+        },
+      },
+      {
+        onSuccess: () => {
+          if (newCompletedState) {
+            showToast('success', `"${title}"을(를) 완료했습니다`);
+          } else {
+            showToast('success', `"${title}"을(를) 미완료 상태로 변경했습니다`);
+          }
+        },
+      },
+    );
+  };
+
+  const deleteTimer = usePomodoroStore((s) => s.deleteTimer);
+
+  const handleDeleteTask = (id: number, title: string) => {
+    deleteTodayTodoMutation(id, {
+      onSuccess: () => {
+        showToast('success', `"${title}"을 오늘의 할 일에서 삭제했습니다.`);
+        if (id == currentId) {
+          deleteTimer(patchPomodoroMutation);
         }
-        setTimer(id, title, patchPomodoroMutation);
-    };
+      },
+    });
+  };
 
-    const handleCompleteTask = (
-        id: number,
-        isCompleted: boolean,
-        title: string,
-    ) => {
-        const newCompletedState = !isCompleted;
+  const handleRouteToEisenhower = () => {
+    navigate('/matrix');
+  };
 
-        updateStatusMutation(
-            {
-                id,
-                data: {
-                    isCompleted: newCompletedState,
-                },
-            },
-            {
-                onSuccess: () => {
-                    if (newCompletedState) {
-                        showToast('success', `"${title}"을(를) 완료했습니다`);
-                    } else {
-                        showToast('success', `"${title}"을(를) 미완료 상태로 변경했습니다`);
-                    }
-                },
-            },
-        );
-    };
+  const filteredTodayTodoList = todayTodoList
+    ? hideCompleted
+      ? todayTodoList.filter((todo) => !todo.isCompleted)
+      : todayTodoList
+    : [];
 
-    const deleteTimer = usePomodoroStore((s) => s.deleteTimer);
+  const renderCategoryBadge = (categoryId: number | string) => {
+    const categoryName = getCategoryNameById(categoryId);
 
-
-    const handleDeleteTask = (id: number, title: string) => {
-        deleteTodayTodoMutation(id, {
-            onSuccess: () => {
-                showToast('success', `"${title}"을 오늘의 할 일에서 삭제했습니다.`)
-                if(id==currentId){
-                    deleteTimer(patchPomodoroMutation);
-                }
-            },
-        });
-    };
-
-    const handleRouteToEisenhower = () => {
-        navigate('/matrix');
-    };
-
-    const filteredTodayTodoList = todayTodoList
-        ? hideCompleted
-            ? todayTodoList.filter((todo) => !todo.isCompleted)
-            : todayTodoList
-        : [];
-
-    const renderCategoryBadge = (categoryId: number | string) => {
-        const categoryName = getCategoryNameById(categoryId);
-
-        if (!categoryName) {
-            return null;
-        }
-
-        return (
-            <div className="inline-flex px-3 py-[3.5px] bg-blue-2 text-gray-scale-900 rounded-full mb-2 self-start">
-                {categoryName}
-            </div>
-        );
-    };
-
-    const renderDate = (dueDate: string | null | undefined) => {
-        return (
-            <div className="flex items-center gap-2">
-                <Calendar size={24} className='text-[#525463]'/>
-                <p className="text-[14px] text-[#525463]">
-                    {formatDateToEnglish(dueDate || null)}
-                </p>
-            </div>
-        );
-    };
+    if (!categoryName) {
+      return null;
+    }
 
     return (
-        <div className="space-y-4">
-            {yesterdayTodoList &&
-                yesterdayTodoList.map((todo) => (
-                    <div
-                        key={todo.id}
-                        className="relative flex flex-col gap-4 py-5 rounded-[16px] bg-gray-scale-200"
-                    >
-                        <div className="absolute top-5 right-5">
-                            <img src={CheckIcon} className="w-6 h-6 cursor-pointer"/>
-                        </div>
-
-                        <div className="px-6 pr-20 flex flex-col items-start w-full gap-2">
-                            {renderCategoryBadge(todo.category_id)}
-                            <p className="text-[20px] text-[#525463] font-semibold w-full line-clamp-2 overflow-hidden">
-                                {todo.title}
-                            </p>
-                            <p className="text-[14px] text-[#858899] w-full line-clamp-2 overflow-hidden">
-                                {todo.memo}
-                            </p>
-                            {renderDate(todo.dueDate)}
-                        </div>
-
-                        <div className="flex justify-end px-6">
-                            <button
-                                className="px-4 py-2 rounded-full bg-white text-blue font-semibold cursor-pointer"
-                                onClick={() => handleMoveToToday(todo.id)}
-                                disabled={isPending}
-                            >
-                                오늘 일정에 추가하기
-                            </button>
-                        </div>
-                    </div>
-                ))}
-
-            {filteredTodayTodoList.map((todo) => (
-                <div
-                    key={todo.id}
-                    className="relative flex flex-col gap-4 py-5 rounded-[16px] bg-white border border-blue"
-                >
-                    <div className="absolute top-5 right-5 flex items-center gap-4">
-                        <Trash2
-                            className="cursor-pointer text-gray-400 "
-                            size={24}
-                            onClick={() => handleDeleteTask(todo.id, todo.title)}
-                            color="#7098ff"
-                        />
-                        <img
-                            src={todo.isCompleted ? CheckFillIcon : CheckIcon}
-                            className="w-6 h-6 cursor-pointer"
-                            onClick={() =>
-                                handleCompleteTask(todo.id, todo.isCompleted, todo.title)
-                            }
-                        />
-                    </div>
-
-                    <div className="px-6 pr-20 flex flex-col items-start w-full gap-2">
-                        {renderCategoryBadge(todo.category_id)}
-                        <p className="text-[20px] text-[#525463] font-semibold w-full line-clamp-2 overflow-hidden">
-                            {todo.title}
-                        </p>
-                        <p className="text-[14px] text-[#858899] w-full line-clamp-2 overflow-hidden">
-                            {todo.memo}
-                        </p>
-                        {renderDate(todo.dueDate)}
-                    </div>
-
-
-                    <div className="flex justify-end px-6">
-                        <button
-                            className={cn(
-                                'px-4 py-[6px] rounded-full text-white font-semibold cursor-pointer',
-                                todo.isCompleted
-                                    ? 'bg-gray-scale-400 text-gray-scale-200'
-                                    : 'bg-blue text-white',
-                            )}
-                            onClick={() => {
-                                handleDelete(todo.id, todo.title);
-                            }}
-                        >
-                            뽀모도로 시작하기
-                        </button>
-                    </div>
-                </div>
-            ))}
-            {filteredTodayTodoList.length === 0 && (
-                <div
-                    className="bg-[#F0F0F5] px-4 py-8 rounded-md flex flex-col items-center justify-center min-h-[200px]">
-                    <p className="font-semibold">
-                        {hideCompleted && todayTodoList && todayTodoList.length > 0
-                            ? '완료되지 않은 일이 없어요'
-                            : '아직 오늘의 할 일이 없어요'}
-                    </p>
-                    <p
-                        className="text-[14px] text-[#525463] mt-2 cursor-pointer hover:text-blue"
-                        onClick={handleRouteToEisenhower}
-                    >
-                        오늘의 할 일 추가하기 {'>'}
-                    </p>
-                </div>
-            )}
-        </div>
+      <div className="inline-flex px-3 py-[3.5px] bg-blue-2 text-gray-scale-900 rounded-full mb-2 self-start">
+        {categoryName}
+      </div>
     );
+  };
+
+  const renderDate = (dueDate: string | null | undefined) => {
+    return (
+      <div className="flex items-center gap-2">
+        <Calendar size={24} className="text-[#525463]" />
+        <p className="text-[14px] text-[#525463]">
+          {formatDateToEnglish(dueDate || null)}
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {yesterdayTodoList &&
+        yesterdayTodoList.map((todo) => (
+          <div
+            key={todo.id}
+            className="relative flex flex-col gap-4 py-5 rounded-[16px] bg-gray-scale-200"
+          >
+            <div className="absolute top-5 right-5">
+              <img src={CheckIcon} className="w-6 h-6 cursor-pointer" />
+            </div>
+
+            <div className="px-6 pr-20 flex flex-col items-start w-full gap-2">
+              {renderCategoryBadge(todo.category_id)}
+              <p className="text-[20px] text-[#525463] font-semibold w-full line-clamp-1 overflow-hidden">
+                {todo.title}
+              </p>
+              <p className="text-[14px] text-[#858899] w-full line-clamp-1 overflow-hidden">
+                {todo.memo}
+              </p>
+              {renderDate(todo.dueDate)}
+            </div>
+
+            <div className="flex justify-end px-6">
+              <button
+                className="px-4 py-2 rounded-full bg-white text-blue font-semibold cursor-pointer"
+                onClick={() => handleMoveToToday(todo.id)}
+                disabled={isPending}
+              >
+                오늘 일정에 추가하기
+              </button>
+            </div>
+          </div>
+        ))}
+
+      {filteredTodayTodoList.map((todo) => (
+        <div
+          key={todo.id}
+          className="relative flex flex-col gap-4 py-5 rounded-[16px] bg-white border border-blue"
+        >
+          <div className="absolute top-5 right-5 flex items-center gap-4">
+            <Trash2
+              className="cursor-pointer text-gray-400 "
+              size={24}
+              onClick={() => handleDeleteTask(todo.id, todo.title)}
+              color="#7098ff"
+            />
+            <img
+              src={todo.isCompleted ? CheckFillIcon : CheckIcon}
+              className="w-6 h-6 cursor-pointer"
+              onClick={() =>
+                handleCompleteTask(todo.id, todo.isCompleted, todo.title)
+              }
+            />
+          </div>
+
+          <div className="px-6 pr-20 flex flex-col items-start w-full gap-2">
+            {renderCategoryBadge(todo.category_id)}
+            <p className="text-[20px] text-[#525463] font-semibold w-full line-clamp-1 overflow-hidden">
+              {todo.title}
+            </p>
+            <p className="text-[14px] text-[#858899] w-full line-clamp-1 overflow-hidden">
+              {todo.memo}
+            </p>
+            {renderDate(todo.dueDate)}
+          </div>
+
+          <div className="flex justify-end px-6">
+            <button
+              className={cn(
+                'px-4 py-[6px] rounded-full text-white font-semibold cursor-pointer',
+                todo.isCompleted
+                  ? 'bg-gray-scale-400 text-gray-scale-200'
+                  : 'bg-blue text-white',
+              )}
+              onClick={() => {
+                handleDelete(todo.id, todo.title);
+              }}
+            >
+              뽀모도로 시작하기
+            </button>
+          </div>
+        </div>
+      ))}
+      {filteredTodayTodoList.length === 0 && (
+        <div className="bg-[#F0F0F5] px-4 py-8 rounded-md flex flex-col items-center justify-center min-h-[200px]">
+          <p className="font-semibold">
+            {hideCompleted && todayTodoList && todayTodoList.length > 0
+              ? '완료되지 않은 일이 없어요'
+              : '아직 오늘의 할 일이 없어요'}
+          </p>
+          <p
+            className="text-[14px] text-[#525463] mt-2 cursor-pointer hover:text-blue"
+            onClick={handleRouteToEisenhower}
+          >
+            오늘의 할 일 추가하기 {'>'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -46,7 +46,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
   const { todayTodoList } = useGetTodayTodoList();
   const { yesterdayTodoList } = useGetYesterdayTodoList();
 
-  const { getCategoryNameById } = useGetCategoryList();
+  const { getCategoryNameById, getCategoryColorById } = useGetCategoryList();
   const { moveTodayMutation, isPending } = useMoveToday();
   const { patchPomodoroMutation } = usePatchPomodoro();
   const { updateStatusMutation } = useUpdateStatusTodo();
@@ -123,13 +123,19 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
 
   const renderCategoryBadge = (categoryId: number | string) => {
     const categoryName = getCategoryNameById(categoryId);
+    const categoryColor = getCategoryColorById(categoryId);
 
     if (!categoryName) {
       return null;
     }
 
+    console.log(categoryName, categoryColor);
+
     return (
-      <div className="inline-flex px-3 py-[3.5px] bg-blue-2 text-gray-scale-900 rounded-full mb-2 self-start">
+      <div
+        className="inline-flex px-3 py-[3.5px] text-gray-scale-900 rounded-full mb-2 self-start"
+        style={{ backgroundColor: categoryColor || '#E9F0FF' }}
+      >
         {categoryName}
       </div>
     );

--- a/frontend/src/components/today/TodayList.tsx
+++ b/frontend/src/components/today/TodayList.tsx
@@ -234,7 +234,7 @@ export default function TodayList({ hideCompleted = false }: TodayListProps) {
         <div className="bg-[#F0F0F5] px-4 py-8 rounded-md flex flex-col items-center justify-center min-h-[200px]">
           <p className="font-semibold">
             {hideCompleted && todayTodoList && todayTodoList.length > 0
-              ? '완료되지 않은 일이 없어요'
+              ? '오늘의 할 일을 모두 완료했어요!'
               : '아직 오늘의 할 일이 없어요'}
           </p>
           <p

--- a/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
+++ b/frontend/src/components/ui/brainstorming/MoveToInventoryModal.tsx
@@ -10,9 +10,8 @@ import {
 } from '@/components/ui/Dialog';
 import { Button } from '@/components/ui/button';
 import useGetInventoryFolderList from '@/hooks/queries/inventory/folder/useGetInventoryFolderList';
-import { toast } from 'sonner';
 import useCreateInventoryItem from '@/hooks/queries/inventory/item/useCreateInventoryItem';
-import {showToast} from "@/components/common/Toast.tsx";
+import { showToast } from '@/components/common/Toast.tsx';
 
 type MoveToInventoryModalProps = {
   isOpen: boolean;
@@ -56,8 +55,10 @@ export default function MoveToInventoryModal({
         onSuccess: () => {
           onOpenChange(false);
           setSelectedFolderId(null);
-          showToast('success',`"${item.title}" 항목이 성공적으로 이동되었습니다.`)
-          // toast.success(`"${item.title}" 항목이 성공적으로 이동되었습니다.`);
+          showToast(
+            'success',
+            `"${item.title}" 항목이 성공적으로 이동되었습니다.`,
+          );
           if (onSuccess) onSuccess();
         },
       },

--- a/frontend/src/hooks/queries/inventory/item/useCreateInventoryItem.ts
+++ b/frontend/src/hooks/queries/inventory/item/useCreateInventoryItem.ts
@@ -10,6 +10,7 @@ const useCreateInventoryItem = () => {
       inventoryItemService.createItem(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bubbleList'] });
+      queryClient.invalidateQueries({ queryKey: ['inventoryFolderList'] });
     },
   });
 

--- a/frontend/src/hooks/queries/inventory/item/useMoveInventoryItem.ts
+++ b/frontend/src/hooks/queries/inventory/item/useMoveInventoryItem.ts
@@ -12,6 +12,9 @@ const useMoveInventoryItem = (folderId: number) => {
       queryClient.invalidateQueries({
         queryKey: ['inventoryItemList', folderId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['inventoryFolderList'],
+      });
     },
   });
 

--- a/frontend/src/hooks/queries/today/useMoveToday.ts
+++ b/frontend/src/hooks/queries/today/useMoveToday.ts
@@ -9,6 +9,8 @@ const useMoveToday = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todayTodoList'] });
       queryClient.invalidateQueries({ queryKey: ['yesterdayTodoList'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCount'] });
+      queryClient.invalidateQueries({ queryKey: ['todayTodoCompletedCount'] });
     },
   });
 

--- a/frontend/src/pages/matrix.tsx
+++ b/frontend/src/pages/matrix.tsx
@@ -97,7 +97,7 @@ export default function MatrixPage() {
                     asChild
                     className="flex gap-5 cursor-pointer"
                   >
-                    <button className="text-[28px]  h-[42px]  shrink-0 text-[#525463] h-8 font-semibold inline-flex items-center gap-[5px] cursor-pointer">
+                    <button className="text-[28px]  h-[42px]  shrink-0 text-[#525463] font-semibold inline-flex items-center gap-[5px] cursor-pointer">
                       {activeTab === 'all' ? '미완료 일정' : '완료된 일정'}
                       <ChevronDown
                         className={cn(
@@ -129,7 +129,7 @@ export default function MatrixPage() {
                           : '',
                       )}
                     >
-                      <h1>미완료 일정</h1>
+                      <h1>완료 일정</h1>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/frontend/src/pages/today.tsx
+++ b/frontend/src/pages/today.tsx
@@ -19,7 +19,7 @@ export default function TodayListPage() {
   const randomQuote = QUOTES[randomIndex];
   return (
     <div className="w-full">
-      <h1 className="block lg:hidden text-[20px] text-[28px] text-[#525463] font-semibold mb-6">
+      <h1 className="block lg:hidden text-[20px] md:text-[28px] text-[#525463] font-semibold mb-6">
         오늘의 할 일
       </h1>
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #315

## 📝 작업 내용
- 아이젠하워에 달려있는 카테고리에 맞게 → 오늘의 할 일 카테고리도 달려 있어야함
- 리마인더 카드 메모 한 줄 까지만 보이게 (이거 제목도 같이 적용함)
- 폴더 항목 새로고침하면 안 바뀜. 폴더 이동 시에도 바로 항목 수 업데이트 안됨. 새로초김 해야지 됨
- 오늘의 할 일 subtitle ellipsis
- 오늘의 할 일 완료되지 않는 일이 없어요 워딩 바꾸기
    - 이거 “오늘의 할 일을 모두 완료했어요!” 로 바꿈
- 미완료/완료된 일정 토글에 같은 텍스트 반복
- 오늘의 할 일 추천에서 오늘의 할 일로 옮기면 도표 데이터 반영 안되는 문제 수정
- TaskCard 제목 길 때 레이아웃 문제 수정
