### PR TITLE
[BE] feat: 최초 로그인 / 재로그인 분기 처리

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
@@ -59,7 +59,7 @@ public class AuthController {
         response.addHeader("Set-Cookie", cookieValue);
 
         // AT는 body에 담아 응답
-        return ApiResponse.ok(new AccessTokenResponse(tokenResponse.accessToken()));
+        return ApiResponse.ok(new AccessTokenResponse(tokenResponse.accessToken(), tokenResponse.isFirstLogin()));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/capstone/backend/domain/auth/dto/response/AccessTokenResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,6 +1,15 @@
 package capstone.backend.domain.auth.dto.response;
 
 public record AccessTokenResponse(
-        String accessToken
+        String accessToken,
+        Boolean isRegistered
 ) {
+    public AccessTokenResponse(String accessToken) {
+        this(accessToken, null);
+    }
+
+    public AccessTokenResponse(String accessToken, Boolean isRegistered) {
+        this.accessToken = accessToken;
+        this.isRegistered = isRegistered;
+    }
 }

--- a/backend/src/main/java/capstone/backend/domain/auth/dto/response/TokenResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/dto/response/TokenResponse.java
@@ -2,5 +2,6 @@ package capstone.backend.domain.auth.dto.response;
 
 public record TokenResponse(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        boolean isFirstLogin
 ) {}

--- a/backend/src/main/java/capstone/backend/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import capstone.backend.domain.auth.repository.RefreshTokenRedisRepository;
 import capstone.backend.domain.auth.schema.BlacklistToken;
 import capstone.backend.domain.auth.schema.OauthCode;
 import capstone.backend.domain.auth.schema.RefreshToken;
+import capstone.backend.domain.member.service.MemberService;
 import capstone.backend.global.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class AuthService {
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
     private final BlacklistTokenRedisRepository blacklistTokenRedisRepository;
     private final JwtProvider jwtProvider;
+    private final MemberService memberService;
 
     public void saveRefreshToken(Long memberId, String token) {
         RefreshToken refreshToken = new RefreshToken(memberId, token, memberId, jwtProvider.getRefreshTokenExpiration());
@@ -69,7 +71,10 @@ public class AuthService {
 
         saveRefreshToken(memberId, refreshToken);  // Redis에 RT 저장
 
-        return new TokenResponse(accessToken, refreshToken);
+        // 핵심 로직: 최초 로그인 여부 판단
+        boolean isFirstLogin = memberService.isMemberRegistered(memberId);
+
+        return new TokenResponse(accessToken, refreshToken, isFirstLogin);
     }
 
     // 로그아웃 로직

--- a/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/capstone/backend/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +28,14 @@ public class MemberController {
             @AuthenticationPrincipal CustomOAuth2User user
     ) {
         return ApiResponse.ok(memberService.findMember(user.getMemberId()));
+    }
+
+    @PatchMapping("/me/registered")
+    @Operation(summary = "재로그인 처리 API", description = "튜토리얼 페이지 이후 최초 로그인 설정 해제")
+    public ApiResponse<Void> reLogin(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        memberService.updateLoginStatus(user.getMemberId());
+        return ApiResponse.ok();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/member/scheme/Member.java
+++ b/backend/src/main/java/capstone/backend/domain/member/scheme/Member.java
@@ -26,8 +26,10 @@ public class Member {
     @Column(nullable = false)
     private String provider; // OAuth2 로그인 제공자 (google, github, naver 등)
 
+    private Boolean isRegistered; // 최초 로그인, 재로그인 여부
+
     // private 생성자: 직접 객체 생성을 막고, 필수 필드 검증
-    private Member(String email, String username, Role role, String provider) {
+    private Member(String email, String username, Role role, String provider, boolean isRegistered) {
         if (email == null || email.isBlank()) throw new IllegalArgumentException("Email은 필수값입니다.");
         if (role == null) throw new IllegalArgumentException("Role은 필수값입니다.");
         if (provider == null || provider.isBlank()) throw new IllegalArgumentException("Provider는 필수값입니다.");
@@ -36,10 +38,15 @@ public class Member {
         this.username = username;
         this.role = role;
         this.provider = provider;
+        this.isRegistered = isRegistered;
     }
 
     // 정적 팩토리 메서드
-    public static Member create(String email, String username, Role role, String provider) {
-        return new Member(email, username, role, provider);
+    public static Member create(String email, String username, Role role, String provider, boolean isRegistered) {
+        return new Member(email, username, role, provider, isRegistered);
+    }
+
+    public void updateRegistered() {
+        this.isRegistered = true;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
@@ -4,7 +4,10 @@ import capstone.backend.domain.member.dto.response.UserDataDTO;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
+import capstone.backend.domain.member.scheme.Role;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final Logger log = LoggerFactory.getLogger(MemberService.class);
     private final MemberRepository memberRepository;
 
     public UserDataDTO findMember(Long memberId) {
@@ -28,5 +32,30 @@ public class MemberService {
     @Transactional
     public void deleteMember(Long memberId) {
         memberRepository.deleteById(memberId);
+    }
+
+    public boolean isMemberRegistered(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return member.getIsRegistered();  // true: 재 로그인
+    }
+
+    @Transactional
+    public Member updateLoginStatus(Member member) {
+        log.info("Updating login status for {}", member);
+        member.updateRegistered();
+        memberRepository.save(member);
+        return member;
+    }
+
+    @Transactional
+    public Member registerNewMember(String email, String username, String provider) {
+        Member newMember = Member.create(email, username, Role.USER, provider, false);
+        return memberRepository.save(newMember);
+    }
+
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(email).orElse(null);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/capstone/backend/domain/member/service/MemberService.java
@@ -4,10 +4,7 @@ import capstone.backend.domain.member.dto.response.UserDataDTO;
 import capstone.backend.domain.member.exception.MemberNotFoundException;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
-import capstone.backend.domain.member.scheme.Role;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private static final Logger log = LoggerFactory.getLogger(MemberService.class);
     private final MemberRepository memberRepository;
 
     public UserDataDTO findMember(Long memberId) {
@@ -42,20 +38,10 @@ public class MemberService {
     }
 
     @Transactional
-    public Member updateLoginStatus(Member member) {
-        log.info("Updating login status for {}", member);
+    public void updateLoginStatus(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
         member.updateRegistered();
-        memberRepository.save(member);
-        return member;
-    }
-
-    @Transactional
-    public Member registerNewMember(String email, String username, String provider) {
-        Member newMember = Member.create(email, username, Role.USER, provider, false);
-        return memberRepository.save(newMember);
-    }
-
-    public Member findByEmail(String email) {
-        return memberRepository.findByEmail(email).orElse(null);
     }
 }

--- a/backend/src/main/java/capstone/backend/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/capstone/backend/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -4,24 +4,23 @@ import capstone.backend.domain.inventory.service.InventoryFolderService;
 import capstone.backend.domain.member.repository.MemberRepository;
 import capstone.backend.domain.member.scheme.Member;
 import capstone.backend.domain.member.scheme.Role;
-import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
-import capstone.backend.global.security.oauth2.user.OAuth2UserInfoFactory;
-import capstone.backend.global.security.oauth2.user.OAuth2UserInfo;
 import capstone.backend.global.security.oauth2.exception.OAuth2AuthenticationProcessingException;
+import capstone.backend.global.security.oauth2.user.CustomOAuth2User;
+import capstone.backend.global.security.oauth2.user.OAuth2UserInfo;
+import capstone.backend.global.security.oauth2.user.OAuth2UserInfoFactory;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.stereotype.Service;
 
-
+@Service
 @Slf4j
 @RequiredArgsConstructor
-@Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
@@ -48,31 +47,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oAuth2User.getAttributes());
 
             // 필수 정보 검증
-            if (userInfo.getEmail() == null) {
-                log.error("[OAuth2] 사용자 정보 검증 실패 - 이메일이 없습니다.");
+            if (userInfo.getEmail() == null || userInfo.getProvider() == null) {
                 throw new OAuth2AuthenticationProcessingException("OAuth2 사용자 정보가 유효하지 않습니다.");
             }
 
-            if (userInfo.getProvider() == null) {
-                log.error("[OAuth2] 사용자 정보 검증 실패 - Provider 정보가 없습니다.");
-                throw new OAuth2AuthenticationProcessingException("OAuth2 제공자 정보가 유효하지 않습니다.");
-            }
-
-            Member member = memberRepository.findByEmail(userInfo.getEmail())
-                    .orElseGet(() -> {
-                        Member newMember = Member.create(
-                                userInfo.getEmail(),
-                                userInfo.getName(),
-                                Role.USER,
-                                provider);
-
-                        memberRepository.save(newMember);
-
-                        //기본 폴더 생성
-                        inventoryFolderService.createDefaultFolder(newMember);
-
-                        return newMember;
-                    });
+            Member member = findOrCreateMember(userInfo, provider);
 
             // 사용자 객체 반환
             return new CustomOAuth2User(member, userInfo);
@@ -83,5 +62,25 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             log.error("[OAuth2] 알 수 없는 예외 발생 - {}", ex.getMessage(), ex);
             throw new InternalAuthenticationServiceException("OAuth2 사용자 정보 처리 중 오류 발생", ex);
         }
+    }
+
+    private Member findOrCreateMember(OAuth2UserInfo userInfo, String provider) {
+        return memberRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() -> {
+                    log.info("[OAuth2] 최초 로그인 유저 - 신규 계정 생성 및 기본 폴더 설정");
+                    Member newMember = Member.create(
+                            userInfo.getEmail(),
+                            userInfo.getName(),
+                            Role.USER,
+                            provider,
+                            false);
+
+                    memberRepository.save(newMember);
+
+                    //기본 폴더 생성
+                    inventoryFolderService.createDefaultFolder(newMember);
+
+                    return newMember;
+                });
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #351 

## 📝 작업 내용

Member 엔티티 내부에 isRegistered 컬럼을 생성하여, 최초/재 로그인 판별을 위한 필드를 추가하였습니다.
이후 CustomOAuthUserService에서 첫 소셜 로그인 시도 시 false로 생성하게 하였고, 두 번째 소셜 로그인 시도 시 true로 변경하는 로직을 구축하였습니다.

이후 FE의 요청에 따라 JWT를 발급하는 과정에서 isRegistered 데이터를 같이 보내주는 것으로 처리하였습니다.

### 스크린샷 (선택)
<img width="908" alt="image" src="https://github.com/user-attachments/assets/3519e517-28de-440b-b3d7-7d750a39d2e1" />

## 💬 리뷰 요구사항(선택)

현재, 두 번째 소셜 로그인 시도 이후부터 isRegistered를 true로 설정하는 로직이 실행됩니다.
하지만 사용자가 튜토리얼 페이지를 거치지 않고 카카오 로그인을 순간적으로 두 번 요청해버리는 순간, isRegistered가 바로 true가 되지 않을까 하는 생각이 듭니다.
따라서, 튜토리얼 페이지를 거치는 경우에 BE에서 isRegistered를 true로 변경하는 API를 생성한 뒤, 이를 FE에서 호출하는 방식으로 가야할 지, 지금 구현된 방식으로 가야 할 지 고민입니다...
