### PR TITLE
프론트 추가 QA

### DIFF
--- a/frontend/src/components/eisenhower/filter/DateRangePicker.tsx
+++ b/frontend/src/components/eisenhower/filter/DateRangePicker.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/popover';
 import { Calendar as CalendarComponent } from '@/components/ui/calendar';
 import Calendar from '@/assets/eisenhower/calander_fill.svg';
+import { showToast } from '@/components/common/Toast.tsx';
 
 type DateRangePickerProps = {
   startDate: Date;
@@ -39,15 +40,23 @@ export function DateRangePicker({
   const formatDateRange = () => {
     if (!dateRange.from) return '날짜 선택';
 
-    if (!dateRange.to) {
-      return format(dateRange.from, 'yyyy년 MM월 dd일', { locale: ko });
+    const from = dateRange.from;
+    const to = dateRange.to ?? from;
+
+    const isSameDay = from.getTime() === to.getTime();
+    const isSameMonth =
+      format(from, 'yyyy-MM', { locale: ko }) ===
+      format(to, 'yyyy-MM', { locale: ko });
+
+    if (isSameDay) {
+      return format(from, 'yyyy년 MM월 dd일', { locale: ko });
     }
 
-    if (format(dateRange.from, 'yyyy-MM') === format(dateRange.to, 'yyyy-MM')) {
-      return `${format(dateRange.from, 'yyyy년 MM월 dd일', { locale: ko })} - ${format(dateRange.to, 'dd일', { locale: ko })}`;
+    if (isSameMonth) {
+      return `${format(from, 'yyyy년 MM월 dd일', { locale: ko })} - ${format(to, 'dd일', { locale: ko })}`;
     }
 
-    return `${format(dateRange.from, 'yyyy년 MM월 dd일', { locale: ko })} - ${format(dateRange.to, 'yyyy년 MM월 dd일', { locale: ko })}`;
+    return `${format(from, 'yyyy년 MM월 dd일', { locale: ko })} - ${format(to, 'yyyy년 MM월 dd일', { locale: ko })}`;
   };
 
   return (
@@ -76,8 +85,17 @@ export function DateRangePicker({
             }}
             onSelect={(range) => {
               if (range?.from && range?.to) {
-                setDateRange({ from: range.from, to: range.to });
-                setIsOpen(false);
+                const isSameDay = range.from.getTime() === range.to.getTime();
+
+                if (isSameDay) {
+                  setDateRange({ from: null as any, to: undefined });
+                  onDateChange(null, null);
+                  setIsOpen(false);
+                } else {
+                  setDateRange({ from: range.from, to: range.to });
+                  onDateChange(range.from, range.to);
+                  setIsOpen(false);
+                }
               } else if (range?.from) {
                 setDateRange({ from: range.from, to: undefined });
                 onDateChange(range.from, range.from);

--- a/frontend/src/components/inventory/InventoryItemCard.tsx
+++ b/frontend/src/components/inventory/InventoryItemCard.tsx
@@ -20,6 +20,8 @@ import {
 import { Button } from '@/components/ui/button';
 import useDeleteInventoryItem from '@/hooks/queries/inventory/item/useDeleteInventoryItem';
 import MoveToFolderModal from '@/components/inventory/modal/MoveToFolderModal';
+import { FileText, Folder, ChevronUp } from 'lucide-react';
+import { useResponsive } from '@/hooks/use-mobile'; // 이미 사용 중이라면 OK
 
 type InventoryItemCardProps = {
   item: {
@@ -127,7 +129,8 @@ export default function InventoryItemCard({
       <li className="px-6 py-4 bg-white rounded-xl">
         <Collapsible open={isOpen} onOpenChange={handleToggle}>
           <div className="flex items-center justify-between gap-6">
-            <div className="w-1/2 overflow-hidden flex flex-col gap-2">
+            <div className="overflow-hidden flex flex-col gap-2">
+              {/*<div className="w-1/2 overflow-hidden flex flex-col gap-2">*/}
               {isOpen ? (
                 <div>
                   {isEditable ? (
@@ -136,16 +139,16 @@ export default function InventoryItemCard({
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="제목을 입력하세요"
-                      className="!text-[20px] text-gray-700 font-semibold px-0 py-0 h-auto border-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+                      className="text-[16px] md:text-[20px] text-gray-700 font-semibold px-0 py-0 h-auto border-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
                     />
                   ) : (
-                    <h3 className="text-[20px] text-gray-700 font-semibold truncate">
+                    <h3 className="text-[16px] md:text-[20px] text-gray-700 font-semibold truncate">
                       {title}
                     </h3>
                   )}
                 </div>
               ) : (
-                <h3 className="text-[20px] text-gray-700 font-semibold truncate">
+                <h3 className="text-[16px] md:text-[20px] text-gray-700 font-semibold truncate">
                   {title}
                 </h3>
               )}
@@ -155,14 +158,30 @@ export default function InventoryItemCard({
             </div>
 
             <div className="flex items-center gap-2 flex-shrink-0">
+              {/* 모바일: 아이콘 버튼 */}
               <CollapsibleTrigger asChild>
-                <button className="px-4 py-2 bg-blue-2 text-blue text-[14px] sm:text-[16px] rounded-full font-semibold flex items-center gap-1 cursor-pointer">
+                <button className="md:hidden px-4 py-2 bg-blue-2 text-blue text-[14px] rounded-full font-semibold flex items-center gap-1 cursor-pointer">
+                  {isOpen ? <ChevronUp size={18} /> : <FileText size={18} />}
+                </button>
+              </CollapsibleTrigger>
+
+              <button
+                onClick={() => setIsMoveDialogOpen(true)}
+                className="md:hidden px-4 py-[7px] text-blue text-[14px] rounded-full font-semibold flex items-center gap-1 cursor-pointer border-blue border-[1px]"
+              >
+                <Folder size={18} />
+              </button>
+
+              {/* PC: 텍스트 버튼 */}
+              <CollapsibleTrigger asChild>
+                <button className="hidden md:flex px-4 py-2 bg-blue-2 text-blue text-[16px] rounded-full font-semibold items-center gap-1 cursor-pointer">
                   {buttonText}
                 </button>
               </CollapsibleTrigger>
+
               <button
                 onClick={() => setIsMoveDialogOpen(true)}
-                className="px-4 py-[7px] text-blue text-[14px] sm:text-[16px] rounded-full font-semibold flex items-center gap-1 cursor-pointer border-blue border-[1px]"
+                className="hidden md:flex px-4 py-[7px] text-blue text-[16px] rounded-full font-semibold items-center gap-1 cursor-pointer border-blue border-[1px]"
               >
                 폴더이동
               </button>

--- a/frontend/src/components/ui/Modal/EisenhowerAi.tsx
+++ b/frontend/src/components/ui/Modal/EisenhowerAi.tsx
@@ -26,6 +26,7 @@ import {
   DialogHeader,
   DialogContent,
 } from '@/components/ui/Dialog.tsx';
+import { SECTION_TITLES } from '@/constants/eisenhower.ts';
 
 interface Props {
   trigger: ReactNode;
@@ -142,8 +143,15 @@ export default function EisenhowerAi({
               ) : (
                 <>
                   <p>
-                    <strong>‘{recommendation?.recommendedQuadrant}’</strong>로
-                    추천되었어요! 이 일정은 {recommendation?.reason}
+                    <strong>
+                      ‘
+                      {recommendation?.recommendedQuadrant &&
+                        SECTION_TITLES[
+                          recommendation.recommendedQuadrant as Quadrant
+                        ]}
+                      ’
+                    </strong>
+                    로 추천되었어요! 이 일정은 {recommendation?.reason}
                   </p>
                 </>
               )}

--- a/frontend/src/components/ui/Modal/EisenhowerAi.tsx
+++ b/frontend/src/components/ui/Modal/EisenhowerAi.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 // import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/ui/button';
 import {
@@ -49,12 +49,22 @@ export default function EisenhowerAi({
     return new Date(dueDate).toISOString().split('T')[0];
   }, [dueDate]);
 
+  const [cachedRecommendation, setCachedRecommendation] = useState<
+    typeof recommendation | null
+  >(null);
+
   const { recommendation, isLoading } = useEisenhowerAiRecommendation({
     title,
     currentQuadrant: quadrant,
     dueDate: formattedDueDate,
-    isOpen,
+    isOpen: isOpen && !cachedRecommendation,
   });
+
+  useEffect(() => {
+    if (recommendation && !cachedRecommendation) {
+      setCachedRecommendation(recommendation);
+    }
+  }, [recommendation, cachedRecommendation]);
 
   const { categories } = useCategoryStore();
   const category = categoryId
@@ -151,7 +161,7 @@ export default function EisenhowerAi({
                         ]}
                       ’
                     </strong>
-                    로 추천되었어요! 이 일정은 {recommendation?.reason}
+                    로 추천되었어요! {recommendation?.reason}
                   </p>
                 </>
               )}

--- a/frontend/src/components/ui/Modal/NodeTaskModal.tsx
+++ b/frontend/src/components/ui/Modal/NodeTaskModal.tsx
@@ -37,8 +37,10 @@ type NodeToTaskModalProps = {
   taskData: {
     title: string;
     id: number | null;
+    bubbleId?: number | null;
   };
   task?: Task;
+  onSuccess?: (bubbleId: number) => void;
 };
 
 export function NodeToTaskModal({
@@ -46,6 +48,7 @@ export function NodeToTaskModal({
   onOpenChange,
   taskData,
   task,
+  onSuccess,
 }: NodeToTaskModalProps) {
   const [priority, setPriority] = useState<Quadrant>('Q1');
   const [title, setTitle] = useState(task?.title ?? taskData.title);
@@ -145,11 +148,17 @@ export function NodeToTaskModal({
       {
         onSuccess: () => {
           onOpenChange(false);
-          navigate('/matrix');
+          // navigate('/matrix');
+          showToast('success', '일정 생성을 완료하였습니다.');
+
+          if (taskData.bubbleId && onSuccess) {
+            onSuccess(taskData.bubbleId);
+          }
         },
         onError: (err) => {
           console.error('생성 실패:', err);
-          alert('일정 생성에 실패했습니다.');
+          // alert('일정 생성에 실패했습니다.');
+          showToast('error', '일정 생성에 실패했습니다.');
         },
       },
     );

--- a/frontend/src/pages/brainstorming.tsx
+++ b/frontend/src/pages/brainstorming.tsx
@@ -274,8 +274,17 @@ export default function Brainstorming() {
       bubbleId: bubble.bubbleId,
       title: bubble.title,
     });
-    setIsDialogOpen(true);
-    setOpenPopoverId(null);
+
+    setBubbles((prev) =>
+      prev.map((b) =>
+        b.bubbleId === bubble.bubbleId ? { ...b, isDeleting: true } : b,
+      ),
+    );
+
+    setTimeout(() => {
+      setIsDialogOpen(true);
+      setOpenPopoverId(null);
+    }, 250);
   };
 
   const handleSaveBubble = (bubble) => {
@@ -302,9 +311,15 @@ export default function Brainstorming() {
 
       // 애니메이션이 끝난 후 버블 제거
       setTimeout(() => {
-        setBubbles((prev) =>
-          prev.filter((bubble) => bubble.bubbleId !== toBeSavedBubbleId),
-        );
+        setBubbles((prev) => {
+          const updated = prev.filter(
+            (bubble) => bubble.bubbleId !== toBeSavedBubbleId,
+          );
+          if (updated.length === 0) {
+            setIsBubbleDialogOpen(true);
+          }
+          return updated;
+        });
         setToBeSavedBubbleId(null); // 상태 초기화
       }, 250);
     }

--- a/frontend/src/pages/brainstorming.tsx
+++ b/frontend/src/pages/brainstorming.tsx
@@ -310,6 +310,10 @@ export default function Brainstorming() {
     }
   };
 
+  const handleMatrixSuccess = (bubbleId: number) => {
+    setBubbles((prev) => prev.filter((bubble) => bubble.bubbleId !== bubbleId));
+  };
+
   return (
     <div ref={containerRef} className={clsx('w-full h-full ')}>
       <div
@@ -490,6 +494,7 @@ export default function Brainstorming() {
         isOpen={isDialogOpen}
         onOpenChange={setIsDialogOpen}
         taskData={taskData}
+        onSuccess={handleMatrixSuccess}
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #354

## 📝 작업 내용

- 브레인스토밍에서 아이젠으로 보내면 아이젠화면으로 리다이렉트 되는 것 막았습니다
- 날짜 필터링 현재 새로고침 해야만 없어지는데, 같은 날짜 두 번 선택하면 필터링 제거되도록 수정했습니다.
- 브레인스토밍에서 마지막 버블을 보관함에 보낼 경우 클린 메세지가 뜨게 수정했습니다.
- 아이젠하워 작업 우선순위 추천에서 한 항목에 대해서 재추천을 할시에 이전에 추천했던게 남아있는 상태에서 새걸로 바뀌는 문제 이미 전에 호출했던 결과가 있으면 유지하고 새 호출을 안 하도록 수정했습니다.
- 아이젠하워 우선순위 추천 모달에서 Q1 등으로 뜨는 거 텍스트로 수정했습니다.
- 모바일에서 보관함 볼 때 크기 조절 필요 - 제목이 다 안보이는 문제 -> 글씨 크기 작게 수정
