### PR TITLE
[BE] feat: 버블 병합 API 구현

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/bubble/controller/v2/BubbleController.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/controller/v2/BubbleController.java
@@ -2,6 +2,7 @@ package capstone.backend.domain.bubble.controller.v2;
 
 
 import capstone.backend.domain.bubble.dto.request.BubbleUpdateRequest;
+import capstone.backend.domain.bubble.dto.request.MergeBubbleRequest;
 import capstone.backend.domain.bubble.dto.request.PromptRequest;
 import capstone.backend.domain.bubble.dto.response.BubbleDTO;
 import capstone.backend.domain.bubble.service.BubbleService;
@@ -96,5 +97,15 @@ public class BubbleController {
     ) {
         bubbleService.deleteBubble(user.getMemberId(), id);
         return ApiResponse.ok();
+    }
+
+    @PostMapping("/merge")
+    @Operation(summary = "버블 병합", description = "버블을 병합합니다.")
+    public ApiResponse<BubbleDTO> mergeBubbles(
+        @AuthenticationPrincipal CustomOAuth2User user,
+        @Valid @RequestBody MergeBubbleRequest request
+    ){
+        BubbleDTO mergedBubble = bubbleService.mergeBubbles(user.getMemberId(), request);
+        return ApiResponse.ok(mergedBubble);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/request/MergeBubbleRequest.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/request/MergeBubbleRequest.java
@@ -1,0 +1,17 @@
+package capstone.backend.domain.bubble.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record MergeBubbleRequest(
+    @NotNull
+    @Schema(description = "병합할 버블 리스트", example = "[1, 2]")
+    List<Long> bubbleList,
+
+    @NotBlank
+    @Schema(description = "생성할 버블 텍스트", example = "점심에 밥 먹고 양치하기")
+    String mergedTitle
+) {
+}

--- a/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/repository/BubbleRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
     List<Bubble> findAllByMemberId(Long memberId);
     Optional<Bubble> findByMemberIdAndId(Long memberId, Long id);
+    List<Bubble> findAllByMemberIdAndIdIn(Long memberId, List<Long> ids);
 }

--- a/backend/src/main/java/capstone/backend/domain/bubble/service/BubbleService.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/service/BubbleService.java
@@ -2,6 +2,7 @@ package capstone.backend.domain.bubble.service;
 
 
 import capstone.backend.domain.bubble.dto.request.BubbleUpdateRequest;
+import capstone.backend.domain.bubble.dto.request.MergeBubbleRequest;
 import capstone.backend.domain.bubble.dto.response.BubbleDTO;
 import capstone.backend.domain.bubble.entity.Bubble;
 import capstone.backend.domain.bubble.exception.BubbleNotFoundException;
@@ -67,5 +68,23 @@ public class BubbleService {
         Bubble bubble = bubbleRepository.findByMemberIdAndId(memberId, id)
                 .orElseThrow(BubbleNotFoundException::new);
         bubble.update(request.title());
+    }
+
+    //버블 병합
+    @Transactional
+    public BubbleDTO mergeBubbles(Long memberId, MergeBubbleRequest request) {
+        //버블 삭제
+        List<Bubble> bubblesToDelete = bubbleRepository.findAllByMemberIdAndIdIn(memberId, request.bubbleList());
+
+        if (bubblesToDelete.size() != request.bubbleList().size()) {
+            throw new BubbleNotFoundException();
+        }
+
+        bubbleRepository.deleteAll(bubblesToDelete);
+
+        //버블 생성
+        Bubble newBubble = Bubble.create(request.mergedTitle(), bubblesToDelete.get(0).getMember());
+
+        return new BubbleDTO(bubbleRepository.save(newBubble));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #357 

## 📝 작업 내용

버블을 합치는 API를 만들었습니다.
req로 병합할 버블 list와 제목을 받으면, 해당 list의 버블들을 모두 삭제하고, 새로운 버블을 생성하도록 구현했습니다.

버블 생성 시 아래와 같이 코드를 작성하여 member에 대한 조회가 2번 일어나지 않도록 했습니다.
`Bubble newBubble = Bubble.create(request.mergedTitle(), bubblesToDelete.get(0).getMember());`