### PR TITLE
[BE] refactor: GPT Server 에서의 예외처리를 그대로 반환하도록 수정 작업

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/bubble/dto/response/GPTErrorResponse.java
+++ b/backend/src/main/java/capstone/backend/domain/bubble/dto/response/GPTErrorResponse.java
@@ -1,0 +1,8 @@
+package capstone.backend.domain.bubble.dto.response;
+
+public record GPTErrorResponse(
+        int code,
+        String message,
+        String detail
+) {
+}

--- a/backend/src/main/java/capstone/backend/global/api/exception/ApiExceptionHandler.java
+++ b/backend/src/main/java/capstone/backend/global/api/exception/ApiExceptionHandler.java
@@ -74,8 +74,7 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
     public ApiResponse<?> apiException(ApiException e) {
-
-        return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        return ApiResponse.error(e.getHttpStatus(), e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  Closes #359 

## 📝 작업 내용

- GPT 서버에서 반환하는 에러 응답(JSON)을 GPTErrorResponse record로 매핑하도록 변경
- WebClient에서 에러 응답 본문을 파싱해 detail 메시지를 ApiException에 포함시켜 반환
- ApiException 발생 시 해당 HTTP 상태 코드도 함께 반영되도록 수정
- Retry 설정에서 ApiException은 재시도 대상에서 제외되도록 조건 명시


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
