### PR TITLE
[BE] Hotfix: OAuth2 인증 필터 무한 로딩으로 인한 StackOverflow Error 해결

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "인증/인가", description = "JWT 관련 API")
@@ -69,9 +70,11 @@ public class AuthController {
     )
     public ApiResponse<Void> logout(
             @AuthenticationPrincipal CustomOAuth2User user,
-            @RequestBody @Valid AccessTokenRequest request
+            @RequestBody @Valid AccessTokenRequest request,
+            HttpServletResponse response
     ) {
-        authService.logout(user.getMemberId(), request.accessToken());
+        authService.logout(user.getMemberId(), request.accessToken(), response);
+        SecurityContextHolder.clearContext();
         return ApiResponse.ok();
     }
 
@@ -82,10 +85,13 @@ public class AuthController {
     )
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal CustomOAuth2User user,
-            @RequestBody @Valid AccessTokenRequest request
+            @RequestBody @Valid AccessTokenRequest request,
+            HttpServletResponse response
     ) {
-        authService.logout(user.getMemberId(), request.accessToken());
+        authService.logout(user.getMemberId(), request.accessToken(), response);
         memberService.deleteMember(user.getMemberId());
+
+        SecurityContextHolder.clearContext();
         return ApiResponse.ok();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/capstone/backend/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import capstone.backend.domain.auth.entity.OauthCode;
 import capstone.backend.domain.auth.entity.RefreshToken;
 import capstone.backend.domain.member.service.MemberService;
 import capstone.backend.global.security.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -78,7 +79,7 @@ public class AuthService {
     }
 
     // 로그아웃 로직
-    public void logout(Long memberId, String accessToken) {
+    public void logout(Long memberId, String accessToken, HttpServletResponse response) {
         // 1. RT 삭제
         refreshTokenRedisRepository.findById(memberId)
                 .ifPresent(refreshTokenRedisRepository::delete);
@@ -92,6 +93,8 @@ public class AuthService {
                     .build();
             blacklistTokenRedisRepository.save(blacklistToken);
         }
+
+        response.addHeader("Set-Cookie", "refreshToken=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None");
 
         log.info("로그아웃 처리 완료 - memberId={}, AT 블랙리스트 등록", memberId);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #370 

## 📝 작업 내용

현재 여전히 security 컨텍스트가 꼬이는 현상이 발생합니다...
우선은, 로그인을 여러 차례 동시적으로 반복하지 않아야 할 것 같습니다.

### 문제 상황

1. Security Context 내 인증 토큰 객체 문제
기존 코드 상에서 JwtAuthenticationFilter 클래스의 getAuthentication() 메서드에서 반환하는 인증 토큰 객체는 바로 OAuth2AuthenticationToken이다.

근데, Spring Security가 `OAuth2AuthenticationToken`을 처리하면서 무한 재귀 호출이 발생할 수 있음.

`OAuth2AuthenticationToken`은 Spring Security가 OAuth2 인증 중 자동 처리하는 객체이고, 일반적인 JWT 기반 인증에서는 사용하지 않아야 함.

그런데 지금 이 객체를 직접 생성해서 `SecurityContextHolder`에 주입하고 있기 때문에, Spring Security 필터 체인이 다시 OAuth2 인증을 시도하면서 무한 루프에 빠지고 `StackOverflow`가 발생할 수 있음.

2. AuthenticationManager.authenticate() 메서드의 재귀 호출 문제
기본적으로 Spring Security 단에서 AuthenticationManager를 빈으로 주입 받으면서, 기본적으로 생성하여 


### 시도
1. `OAuth2AuthenticationToken`을 `UsernamePasswordAuthenticationToken`으로 변경하여 Security 단에서 한 번 더 처리하지 않게 변경함.

2. logout, 회원 탈퇴 시 Authentication 삭제 로직 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


