### PR TITLE
[FE]: 튜토리얼 이미지 잘림 문제 수정

### DIFF
--- a/frontend/src/components/onboarding/OnboardingSlide.tsx
+++ b/frontend/src/components/onboarding/OnboardingSlide.tsx
@@ -31,6 +31,7 @@ const OnboardingSlide = ({
       <div
         className={cn(
           'w-[307px] h-[559px] md:w-[940px] md:h-[612px] rounded-t-3xl overflow-hidden mt-auto',
+          'md:max-w-[calc(100vw-500px)] md:max-h-[calc(100vh-280px)]',
           hideBorder
             ? 'overflow-visible w-[307px] h-[600px] md:w-[959px] md:h-[612px]'
             : 'border border-gray-scale-400 overflow-hidden',

--- a/frontend/src/components/onboarding/OnboardingSlide.tsx
+++ b/frontend/src/components/onboarding/OnboardingSlide.tsx
@@ -18,7 +18,7 @@ const OnboardingSlide = ({
   hideBorder = false,
 }: OnboardingSlideProps) => {
   return (
-    <div className="flex flex-col items-center w-full h-full px-[50px] md:px-[250px] pt-[100px] md:pt-[130px]">
+    <div className="flex flex-col items-center w-full h-full pt-[100px] md:pt-[130px]">
       <div className="flex flex-col items-center text-center gap-[10px] mb-10">
         <h2 className="text-[24px] md:text-[32px] text-gray-scale-700 font-semibold">
           {title}
@@ -32,6 +32,7 @@ const OnboardingSlide = ({
         className={cn(
           'w-[307px] h-[559px] md:w-[940px] md:h-[612px] rounded-t-3xl overflow-hidden mt-auto',
           'md:max-w-[calc(100vw-500px)] md:max-h-[calc(100vh-280px)]',
+          'aspect-[307/559] md:aspect-[940/612]',
           hideBorder
             ? 'overflow-visible w-[307px] h-[600px] md:w-[959px] md:h-[612px]'
             : 'border border-gray-scale-400 overflow-hidden',

--- a/frontend/src/components/inventory/InventoryItemCard.tsx
+++ b/frontend/src/components/inventory/InventoryItemCard.tsx
@@ -129,17 +129,16 @@ export default function InventoryItemCard({
       <li className="px-6 py-4 bg-white rounded-xl">
         <Collapsible open={isOpen} onOpenChange={handleToggle}>
           <div className="flex items-center justify-between gap-6">
-            <div className="overflow-hidden flex flex-col gap-2">
-              {/*<div className="w-1/2 overflow-hidden flex flex-col gap-2">*/}
+            <div className="overflow-hidden flex flex-col gap-2 flex-1 min-w-0">
               {isOpen ? (
-                <div>
+                <div className="w-full">
                   {isEditable ? (
-                    <Input
+                    <input
                       autoFocus
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                       placeholder="제목을 입력하세요"
-                      className="text-[16px] md:text-[20px] text-gray-700 font-semibold px-0 py-0 h-auto border-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+                      className="text-[16px] md:text-[20px] text-gray-700 font-semibold px-0 py-0 h-auto border-none bg-transparent focus:outline-none w-full"
                     />
                   ) : (
                     <h3 className="text-[16px] md:text-[20px] text-gray-700 font-semibold truncate">

--- a/frontend/src/pages/onboarding.tsx
+++ b/frontend/src/pages/onboarding.tsx
@@ -18,9 +18,9 @@ import slideImage3Mobile from '@/assets/onboarding/onboarding-mobile-3.png';
 import slideImage4Mobile from '@/assets/onboarding/onboarding-mobile-4.png';
 import slideImage5Mobile from '@/assets/onboarding/onboarding-mobile-5.png';
 
-import OnboardingSlide from '@/components/\bonboarding/OnboardingSlide';
 import { useResponsive } from '@/hooks/use-mobile';
 import usePatchRegister from '@/hooks/queries/auth/usePatchRegister';
+import OnboardingSlide from '@/components/\bonboarding/OnboardingSlide';
 
 const paginationStyle = {
   position: 'absolute',
@@ -33,6 +33,7 @@ const paginationStyle = {
   justifyContent: 'center',
   zIndex: 20,
 };
+
 const OnboardingPage = () => {
   const navigate = useNavigate();
   const [activeIndex, setActiveIndex] = useState(0);
@@ -112,6 +113,10 @@ const OnboardingPage = () => {
           clickable: true,
           el: '.swiper-custom-pagination',
         }}
+        navigation={{
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
+        }}
         onSlideChange={handleSlideChange}
         className="w-full h-full"
       >
@@ -129,6 +134,9 @@ const OnboardingPage = () => {
         ))}
 
         <div className="swiper-custom-pagination" style={paginationStyle}></div>
+
+        <div className="swiper-button-prev !text-gray-600 !w-10 !h-10 !mt-0 !top-1/2 !left-4 !bg-white !rounded-full !shadow-lg hover:!bg-gray-50 !z-10 after:!text-lg after:!font-bold"></div>
+        <div className="swiper-button-next !text-gray-600 !w-10 !h-10 !mt-0 !top-1/2 !right-4 !bg-white !rounded-full !shadow-lg hover:!bg-gray-50 !z-10 after:!text-lg after:!font-bold"></div>
       </Swiper>
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈
resolve #373

## 📝 작업 내용
튜토리얼 페이지에서 브라우저 크기 변경 시 이미지 및 레이아웃이 깨지는 문제를 수정했습니다.

**기존 문제**
- 이미지 잘림: 브라우저 높이/너비가 줄어들 때 온보딩 이미지가 잘려서 보임
- 고정 크기 충돌: 고정된 패딩(250px)과 이미지 크기로 인한 레이아웃 깨짐

✅ 해결 방안
- aspect-ratio를 기존 이미지의 비율(모바일: 307:559, 데스크톱: 940:612)로 맞춰 브라우저 크기가 줄어들 때 비율을 유지하면서 축소되도록 처리


++ 추가로 보관함 input 너비 잘리는 문제도 같이 수정했습니다.
