### PR TITLE
[BE] refactor: 아이젠하워 알림 배치 신뢰성/중복방지 및 재실행 안전화

### DIFF
--- a/backend/src/main/java/capstone/backend/domain/eisenhower/batch/step/DeleteOldNotificationsTasklet.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/batch/step/DeleteOldNotificationsTasklet.java
@@ -18,8 +18,10 @@ public class DeleteOldNotificationsTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(@NonNull StepContribution contribution, @NonNull ChunkContext chunkContext) {
-        LocalDate today = LocalDate.now();
-        eisenhowerNotificationRepository.deleteAllByDueDateBefore(today.minusDays(7));
+        String runDateStr = (String) chunkContext.getStepContext().getJobParameters().get("runDate");
+        LocalDate runDate = LocalDate.parse(runDateStr);
+
+        eisenhowerNotificationRepository.deleteAllByNotificationDateBefore(runDate.minusDays(7));
         return RepeatStatus.FINISHED;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/batch/step/GenerateNotificationTasklet.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/batch/step/GenerateNotificationTasklet.java
@@ -1,13 +1,14 @@
 package capstone.backend.domain.eisenhower.batch.step;
 
 import capstone.backend.domain.eisenhower.service.EisenhowerNotificationService;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -17,7 +18,9 @@ public class GenerateNotificationTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(@NonNull StepContribution contribution, @NonNull ChunkContext chunkContext) {
-        eisenhowerNotificationService.generateDailyNotifications();
+        String runDateStr = (String) chunkContext.getStepContext().getJobParameters().get("runDate");
+        LocalDate runDate = LocalDate.parse(runDateStr);
+        eisenhowerNotificationService.generateDailyNotifications(runDate);
         return RepeatStatus.FINISHED;
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerNotification.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/entity/EisenhowerNotification.java
@@ -6,6 +6,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,16 +20,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@Table(
+        name = "eisenhower_notification",
+        uniqueConstraints = @UniqueConstraint(
+                name = "ux_member_item_date",
+                columnNames = {"member_id","eisenhower_item_id","notification_date"}
+        )
+)
 public class EisenhowerNotification {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, name = "eisenhower_notification_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "member_id")
     private Long memberId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "eisenhower_item_id")
     private Long eisenhowerItemId;
 
     @Column(nullable = false)
@@ -36,12 +45,16 @@ public class EisenhowerNotification {
     @Column(nullable = false)
     private LocalDate dueDate;
 
-    public static EisenhowerNotification of(EisenhowerItem item) {
+    @Column(nullable = false, name = "notification_date")
+    private LocalDate notificationDate;
+
+    public static EisenhowerNotification of(EisenhowerItem item, LocalDate notificationDate) {
         return EisenhowerNotification.builder()
                 .memberId(item.getMember().getId())
                 .eisenhowerItemId(item.getId())
                 .title(item.getTitle())
                 .dueDate(item.getDueDate())
+                .notificationDate(notificationDate)
                 .build();
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerNotificationRepository.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/repository/EisenhowerNotificationRepository.java
@@ -6,7 +6,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EisenhowerNotificationRepository extends JpaRepository<EisenhowerNotification, Long> {
-    void deleteByEisenhowerItemId(Long eisenhowerItemId);
-    void deleteAllByDueDateBefore(LocalDate date);
     List<EisenhowerNotification> findAllByMemberIdOrderByDueDateDesc(Long memberId);
+
+    void deleteAllByNotificationDateBefore(LocalDate date);
+
+    boolean existsByMemberIdAndEisenhowerItemIdAndNotificationDate(Long id, Long id1, LocalDate runDate);
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/scheduler/EisenhowerNotificationScheduler.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/scheduler/EisenhowerNotificationScheduler.java
@@ -1,11 +1,14 @@
 package capstone.backend.domain.eisenhower.scheduler;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,14 +22,20 @@ public class EisenhowerNotificationScheduler {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void run() throws Exception {
+        String runDate = LocalDate.now(ZoneId.of("Asia/Seoul")).toString();
         // JobParameters 생성
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("timestamp", System.currentTimeMillis())
+                .addString("runDate", runDate)
                 .toJobParameters();
 
-        log.info("Eisenhower Notification Scheduler started");
+        log.info("Eisenhower Notification Scheduler started runDate={}", runDate);
         // Job 실행
-        jobLauncher.run(notificationJob, jobParameters);
-        log.info("Eisenhower Notification Scheduler finished");
+        try {
+            jobLauncher.run(notificationJob, jobParameters);
+        }catch (JobInstanceAlreadyCompleteException e){
+            log.info("Eisenhower Notification Scheduler already runDate={}", runDate);
+        }
+
+        log.info("Eisenhower Notification Scheduler finished runDate={}", runDate);
     }
 }

--- a/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerNotificationService.java
+++ b/backend/src/main/java/capstone/backend/domain/eisenhower/service/EisenhowerNotificationService.java
@@ -8,6 +8,7 @@ import capstone.backend.domain.eisenhower.repository.EisenhowerNotificationRepos
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,14 +28,25 @@ public class EisenhowerNotificationService {
     }
 
     @Transactional
-    public void generateDailyNotifications() {
-        LocalDate tomorrow = LocalDate.now().plusDays(1);
+    public void generateDailyNotifications(LocalDate runDate) {
+        LocalDate tomorrow = runDate.plusDays(1);
 
         List<EisenhowerItem> dueTodayItems = eisenhowerItemRepository.findAllByDueDateAndIsCompleted(tomorrow, false);
 
         for (EisenhowerItem item : dueTodayItems) {
-            eisenhowerNotificationRepository.deleteByEisenhowerItemId(item.getId());
-            eisenhowerNotificationRepository.save(EisenhowerNotification.of(item));
+            boolean exists = eisenhowerNotificationRepository.existsByMemberIdAndEisenhowerItemIdAndNotificationDate(
+                    item.getMember().getId(),
+                    item.getId(),
+                    runDate
+            );
+
+            if (!exists) {
+                try {
+                    eisenhowerNotificationRepository.save(EisenhowerNotification.of(item, runDate));
+                } catch (DataIntegrityViolationException ignore) {
+                    // 중복 알림이 이미 존재하는 경우 무시
+                }
+            }
         }
     }
 }

--- a/backend/src/main/java/capstone/backend/global/batch/service/MultiJobExecutionService.java
+++ b/backend/src/main/java/capstone/backend/global/batch/service/MultiJobExecutionService.java
@@ -1,5 +1,7 @@
 package capstone.backend.global.batch.service;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,22 +19,22 @@ public class MultiJobExecutionService {
     private final JobLauncher jobLauncher;
     private final Map<String, Job> jobMap;
 
-    public void execute(String jobName){
-        try{
+    public void execute(String jobName) {
+        try {
             Job job = jobMap.get(jobName);
-            if(job == null){
+            if (job == null) {
                 log.warn("Job {} not found", jobName);
                 return;
             }
-
+            String runDate = LocalDate.now(ZoneId.of("Asia/Seoul")).toString();
             JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("timestamp", System.currentTimeMillis())
-                .toJobParameters();
+                    .addString("runDate", runDate)
+                    .toJobParameters();
 
             JobExecution jobExecution = jobLauncher.run(job, jobParameters);
             log.info("Job {} started with status: {}", jobName, jobExecution.getStatus());
 
-        } catch (Exception e){
+        } catch (Exception e) {
             log.error("Job {} failed", jobName, e);
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Closes #375 
> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- EisenhowerNotification 엔티티 및 DB 스키마 리팩토링
  - notification_date 컬럼 추가 및 NOT NULL 제약
  - (member_id, eisenhower_item_id, notification_date) UNIQUE 제약 적용 → 같은 아이템·같은 날 알림 중복 방지
- 알림 서비스 로직 수정
  - 기존 delete → save 패턴 제거
  - existsBy... + save 방식으로 변경
- 배치(Tasklet) 수정
  - runDate 파라미터 기반으로 알림 생성 및 삭제 처리
  - DeleteOldNotificationsTasklet: notification_date < runDate-7일 기준으로 삭제
- 스케줄러 수정
  - JobParameters에 runDate 추가, 동일 runDate 중복 실행 차단
  - 이미 완료된 경우 JobInstanceAlreadyCompleteException을 INFO 로그로 처리

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
